### PR TITLE
Update Readme.md to remove the underline of <a/> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/lynx-family/lynx/blob/develop/LICENSE">
+  <a href="https://github.com/lynx-family/lynx/blob/develop/LICENSE" style="text-decoration:none">
     <img src="https://img.shields.io/badge/License-Apache--2.0-cyan?logo=apache" alt="Apache Licensed">
   </a>
-  <a href="https://github.com/lynx-family/lynx/releases">
+  <a href="https://github.com/lynx-family/lynx/releases" style="text-decoration:none">
     <img src="https://img.shields.io/github/v/release/lynx-family/lynx.svg" alt="Latest release version">
   </a>
-  <a href="https://github.com/lynx-family/lynx/actions">
+  <a href="https://github.com/lynx-family/lynx/actions" style="text-decoration:none">
     <img src="https://img.shields.io/github/actions/workflow/status/lynx-family/lynx/ci.yml" alt="CI status">
-  </a><a href="https://x.com/lynxjs_org">
+  </a><a href="https://x.com/lynxjs_org" style="text-decoration:none">
     <img src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Flynxjs_org&style=social&label=Lynx" alt="X (formerly Twitter) URL">
   </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <div align="center">
   <p>
 
-[![Apache Licensed](https://img.shields.io/badge/License-Apache--2.0-cyan?logo=apache)](https://github.com/lynx-family/lynx/blob/develop/LICENSE) [![Latest release version](https://img.shields.io/github/v/release/lynx-family/lynx.svg)](https://github.com/lynx-family/lynx/actions) [![CI status](https://img.shields.io/github/actions/workflow/status/lynx-family/lynx/ci.yml)](https://github.com/lynx-family/lynx/actions) [![X (formerly Twitter) URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Flynxjs_org&style=social&label=Lynx)](https://x.com/lynxjs_org)
+[![Apache Licensed](https://img.shields.io/badge/License-Apache--2.0-cyan?logo=apache)](https://github.com/lynx-family/lynx/blob/develop/LICENSE) [![Latest release version](https://img.shields.io/github/v/release/lynx-family/lynx.svg)](https://github.com/lynx-family/lynx/releases) [![CI status](https://img.shields.io/github/actions/workflow/status/lynx-family/lynx/ci.yml)](https://github.com/lynx-family/lynx/actions) [![X (formerly Twitter) URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Flynxjs_org&style=social&label=Lynx)](https://x.com/lynxjs_org)
 
   </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -4,25 +4,19 @@
   </a>
 </p>
 
-<p align="center">
-  <a href="https://github.com/lynx-family/lynx/blob/develop/LICENSE" style="text-decoration:none">
-    <img src="https://img.shields.io/badge/License-Apache--2.0-cyan?logo=apache" alt="Apache Licensed">
-  </a>
-  <a href="https://github.com/lynx-family/lynx/releases" style="text-decoration:none">
-    <img src="https://img.shields.io/github/v/release/lynx-family/lynx.svg" alt="Latest release version">
-  </a>
-  <a href="https://github.com/lynx-family/lynx/actions" style="text-decoration:none">
-    <img src="https://img.shields.io/github/actions/workflow/status/lynx-family/lynx/ci.yml" alt="CI status">
-  </a><a href="https://x.com/lynxjs_org" style="text-decoration:none">
-    <img src="https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Flynxjs_org&style=social&label=Lynx" alt="X (formerly Twitter) URL">
-  </a>
-</p>
+
+<div align="center">
+  <p>
+
+[![Apache Licensed](https://img.shields.io/badge/License-Apache--2.0-cyan?logo=apache)](https://github.com/lynx-family/lynx/blob/develop/LICENSE) [![Latest release version](https://img.shields.io/github/v/release/lynx-family/lynx.svg)](https://github.com/lynx-family/lynx/actions) [![CI status](https://img.shields.io/github/actions/workflow/status/lynx-family/lynx/ci.yml)](https://github.com/lynx-family/lynx/actions) [![X (formerly Twitter) URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Flynxjs_org&style=social&label=Lynx)](https://x.com/lynxjs_org)
+
+  </p>
+</div>
 
 
 <p align="center">
 Empower the web community and invite more to build across platforms
 </p>
-
 
 ## Content
 - [About Lynx](#About-Lynx)


### PR DESCRIPTION
<img width="904" alt="image" src="https://github.com/user-attachments/assets/b5f2f505-f214-4353-a3b9-9976697b5c79" />

There is a blue underline between two badges.

This pull request try to remove this underline by remove <a/> tag.