### PR TITLE
[BugFix] When executing FiberUpdateListCallbacks, call the set_tasm o…

### DIFF
--- a/core/runtime/bindings/lepus/renderer_functions.cc
+++ b/core/runtime/bindings/lepus/renderer_functions.cc
@@ -4144,6 +4144,7 @@ RENDERER_FUNCTION_CC(FiberUpdateListCallbacks) {
     component_at_indexes = *arg3;
   }
   auto list_element = fml::static_ref_ptr_cast<ListElement>(arg0->RefCounted());
+  list_element->set_tasm(GET_TASM_POINTER());
   list_element->UpdateCallbacks(*arg1, *arg2, component_at_indexes);
   RETURN_UNDEFINED();
 }


### PR DESCRIPTION
…f List Element to avoid null pointer access that could lead to a crash.

As described in the title. When the ListElement is created from the Element Template, tasm_ is null. The ListElement created from the Element Template will definitely call FiberUpdateListCallbacks, at which point set_tasm can be invoked to avoid subsequent null pointer access crashes.

issue:m-4676645619
AutoSubmit:True
AutoLand:release/3.1