### PR TITLE
[Optimize] Ensure the thread safety of RunOnTasmThread.

### DIFF
--- a/core/public/lynx_engine_proxy.h
+++ b/core/public/lynx_engine_proxy.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/include/closure.h"
 #include "core/public/list_data.h"
 #include "core/public/pub_value.h"
 
@@ -17,6 +18,8 @@ namespace shell {
 class LynxEngineProxy {
  public:
   virtual ~LynxEngineProxy() = default;
+
+  virtual void DispatchTaskToLynxEngine(base::closure task) = 0;
 
   // Event
   virtual bool SendTouchEvent(const std::string& name, int32_t tag, float x,

--- a/core/renderer/ui_wrapper/painting/ios/painting_context_darwin.mm
+++ b/core/renderer/ui_wrapper/painting/ios/painting_context_darwin.mm
@@ -22,6 +22,7 @@
 #include "core/value_wrapper/value_impl_lepus.h"
 
 #import "LynxCallStackUtil.h"
+#import "LynxContext.h"
 #import "LynxEnv+Internal.h"
 #import "LynxEnv.h"
 #import "LynxError.h"
@@ -580,15 +581,13 @@ void PaintingContextDarwin::Invoke(
       if (owner == nil) {
         return;
       }
-      const auto& raw_ptr = owner.uiContext.shellPtr;
-      if (raw_ptr == 0) {
-        return;
-      }
-      reinterpret_cast<shell::LynxShell*>(raw_ptr)->RunOnTasmThread([code, data, block]() {
+
+      [owner.uiContext.lynxContext runOnTasmThread:^{
         // exec the block on tasm thread.
         block(code, PubLepusValue(LynxConvertToLepusValue(data)));
-      });
+      }];
     };
+
     LynxUI* ui = [owner findUIBySign:(int)element_id];
     if (!ui) {
       NSString* msg =

--- a/core/shell/android/lynx_template_render_android.cc
+++ b/core/shell/android/lynx_template_render_android.cc
@@ -1115,25 +1115,6 @@ void UpdateI18nResource(JNIEnv* env, jclass jcaller, jlong ptr, jlong lifecycle,
   AtomicLifecycle::TryFree(lifecycle_ptr);
 }
 
-static void RunOnTasmThread(JNIEnv* env, jobject jcaller, jlong ptr,
-                            jlong lifecycle, jobject runnable) {
-  AtomicLifecycle* lifecycle_ptr =
-      reinterpret_cast<AtomicLifecycle*>(lifecycle);
-  if (!AtomicLifecycle::TryLock(lifecycle_ptr)) {
-    return;
-  }
-  auto* shell_ptr = reinterpret_cast<lynx::shell::LynxShell*>(ptr);
-  lynx::base::android::ScopedGlobalJavaRef<jobject> runnable_object(env,
-                                                                    runnable);
-  lynx::base::android::ScopedGlobalJavaRef<jobject> caller(env, jcaller);
-  shell_ptr->RunOnTasmThread([caller = std::move(caller),
-                              runnable = std::move(runnable_object)]() {
-    JNIEnv* env = lynx::base::android::AttachCurrentThread();
-    Java_LynxTemplateRender_executeRunnable(env, caller.Get(), runnable.Get());
-  });
-  AtomicLifecycle::TryFree(lifecycle_ptr);
-}
-
 void SetInitTiming(JNIEnv* env, jclass jcaller, jlong ptr, jlong lifecycle,
                    jlong initStart, jlong initEnd) {
   AtomicLifecycle* lifecycle_ptr =

--- a/core/shell/lynx_engine_proxy_impl.cc
+++ b/core/shell/lynx_engine_proxy_impl.cc
@@ -11,6 +11,18 @@
 namespace lynx {
 namespace shell {
 
+void LynxEngineProxyImpl::DispatchTaskToLynxEngine(base::closure task) {
+  if (engine_actor_ == nullptr) {
+    LOGE(
+        "LynxEngineProxy::DispatchTaskToLynxEngine failed since engine_actor_ "
+        "is nullptr");
+    return;
+  }
+
+  engine_actor_->Act(
+      [task = std::move(task)](auto& engine) mutable { task(); });
+}
+
 bool LynxEngineProxyImpl::SendTouchEvent(const std::string& name, int32_t tag,
                                          float x, float y, float client_x,
                                          float client_y, float page_x,

--- a/core/shell/lynx_engine_proxy_impl.h
+++ b/core/shell/lynx_engine_proxy_impl.h
@@ -22,6 +22,8 @@ class LynxEngineProxyImpl : public LynxEngineProxy {
       : engine_actor_(actor) {}
   ~LynxEngineProxyImpl() = default;
 
+  void DispatchTaskToLynxEngine(base::closure task) override;
+
   bool SendTouchEvent(const std::string& name, int32_t tag, float x, float y,
                       float client_x, float client_y, float page_x,
                       float page_y, int64_t timestamp = 0) override;

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -2624,10 +2624,12 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
   }
 
   public void runOnTasmThread(Runnable runnable) {
-    if (mNativePtr == 0) {
+    if (mEngineProxy == null) {
+      LLog.i(TAG, "runOnTasmThread failed, engine proxy is null.");
       return;
     }
-    nativeRunOnTasmThread(mNativePtr, mNativeLifecycle, runnable);
+
+    mEngineProxy.dispatchTaskToLynxEngine(runnable);
   }
 
   public void startLynxRuntime() {
@@ -3282,11 +3284,6 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
     return null;
   }
 
-  @CalledByNative
-  public void executeRunnable(Runnable runnable) {
-    runnable.run();
-  }
-
   public static class LogLynxViewClient extends LynxViewClient {
     private long mStartLoadTime = 0;
 
@@ -3464,8 +3461,6 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
 
   private static native void nativeUpdateI18nResource(
       long ptr, long lifecycle, String key, String bytes, int status);
-
-  private native void nativeRunOnTasmThread(long ptr, long lifecycle, Runnable runnable);
 
   private static native void nativeSetInitTiming(
       long ptr, long lifecycle, long initStart, long initEnd);

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/LynxEngineProxy.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/LynxEngineProxy.java
@@ -4,45 +4,49 @@
 
 package com.lynx.tasm.core;
 
-import android.os.Handler;
-import android.os.Looper;
+import com.lynx.tasm.base.CalledByNative;
 import com.lynx.tasm.base.LLog;
 import com.lynx.tasm.common.LepusBuffer;
 import com.lynx.tasm.event.LynxCustomEvent;
 import com.lynx.tasm.event.LynxTouchEvent;
+import com.lynx.tasm.utils.UIThreadUtils;
+import java.lang.Runnable;
 import java.nio.ByteBuffer;
 
 public final class LynxEngineProxy {
   private static final String TAG = "LynxEngineProxy";
   public long mNativePtr;
-  private Handler mHandler;
 
   public LynxEngineProxy(long nativeCreator) {
     mNativePtr = nativeCreate(nativeCreator);
-    mHandler = new Handler(Looper.getMainLooper());
   }
 
   public void destroy() {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         nativeDestroy(mNativePtr);
         mNativePtr = 0;
       }
-    };
-    run(runnable);
+    });
   }
 
-  private void run(Runnable runnable) {
-    if (Looper.myLooper() == Looper.getMainLooper()) {
-      runnable.run();
-    } else {
-      mHandler.post(runnable);
-    }
+  public void dispatchTaskToLynxEngine(Runnable runnable) {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
+      @Override
+      public void run() {
+        if (mNativePtr == 0) {
+          LLog.e(TAG, "DispatchTaskToLynxEngine failed since mNativePtr is null");
+          return;
+        }
+
+        nativeDispatchTaskToLynxEngine(mNativePtr, runnable);
+      }
+    });
   }
 
   public void sendTouchEvent(LynxTouchEvent event) {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         if (mNativePtr == 0) {
@@ -57,12 +61,11 @@ public final class LynxEngineProxy {
             clientPoint.getY(), pagePoint.getX(), pagePoint.getY(), viewPoint.getX(),
             viewPoint.getY(), event.getTimestamp());
       }
-    };
-    run(runnable);
+    });
   }
 
   public void sendMultiTouchEvent(LynxTouchEvent event) {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         if (mNativePtr == 0) {
@@ -75,12 +78,11 @@ public final class LynxEngineProxy {
         nativeSendMultiTouchEvent(
             mNativePtr, event.getName(), buffer, length, event.getTimestamp());
       }
-    };
-    run(runnable);
+    });
   }
 
   public void sendCustomEvent(LynxCustomEvent event) {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         if (mNativePtr == 0) {
@@ -94,8 +96,7 @@ public final class LynxEngineProxy {
         nativeSendCustomEvent(
             mNativePtr, event.getName(), event.getTag(), buffer, length, paramsName);
       }
-    };
-    run(runnable);
+    });
   }
 
   /**
@@ -110,7 +111,7 @@ public final class LynxEngineProxy {
   public void sendGestureEvent(
       final String name, final int tag, int gestureId, final ByteBuffer params, final int length) {
     // Create a Runnable to perform the gesture event sending.
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         // Check if the native pointer is valid.
@@ -122,14 +123,11 @@ public final class LynxEngineProxy {
         // Invoke the native method to send the gesture event.
         nativeSendGestureEvent(mNativePtr, name, tag, gestureId, params, length);
       }
-    };
-
-    // Execute the Runnable asynchronously.
-    run(runnable);
+    });
   }
 
   public void onPseudoStatusChanged(final int id, final int preStatus, final int currentStatus) {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         if (mNativePtr == 0) {
@@ -138,12 +136,11 @@ public final class LynxEngineProxy {
         }
         nativeOnPseudoStatusChanged(mNativePtr, id, preStatus, currentStatus);
       }
-    };
-    run(runnable);
+    });
   }
 
   public void invokeLepusApiCallback(int callbackID, String entryName, Object data) {
-    Runnable runnable = new Runnable() {
+    UIThreadUtils.runOnUiThreadImmediately(new Runnable() {
       @Override
       public void run() {
         if (mNativePtr == 0) {
@@ -152,25 +149,34 @@ public final class LynxEngineProxy {
         }
         nativeInvokeLepusApiCallback(mNativePtr, callbackID, entryName, data);
       }
-    };
-    run(runnable);
+    });
   }
 
-  private native long nativeCreate(long nativeCreator);
+  @CalledByNative
+  private static void executeRunnable(Runnable runnable) {
+    runnable.run();
+  }
+
+  private native long nativeCreate(long nativePtr);
+
   private native void nativeDestroy(long nativePtr);
 
-  private native void nativeSendTouchEvent(long ptr, String name, int tag, float clientX,
+  private native void nativeDispatchTaskToLynxEngine(long nativePtr, Runnable runnable);
+
+  private native void nativeSendTouchEvent(long nativePtr, String name, int tag, float clientX,
       float clientY, float pageX, float pageY, float viewX, float viewY, long timestamp);
+
   private native void nativeSendMultiTouchEvent(
-      long ptr, String name, ByteBuffer params, int length, long timestamp);
+      long nativePtr, String name, ByteBuffer params, int length, long timestamp);
+
   private native void nativeSendCustomEvent(
-      long ptr, String name, int tag, ByteBuffer params, int length, String paramsName);
+      long nativePtr, String name, int tag, ByteBuffer params, int length, String paramsName);
 
   private native void nativeSendGestureEvent(
-      long ptr, String name, int tag, int gestureId, ByteBuffer params, int length);
+      long nativePtr, String name, int tag, int gestureId, ByteBuffer params, int length);
 
   private native void nativeOnPseudoStatusChanged(
-      long ptr, int id, int preStatus, int currentStatus);
+      long nativePtr, int id, int preStatus, int currentStatus);
 
   private native void nativeInvokeLepusApiCallback(
       long nativePtr, int callbackID, String entryName, Object data);

--- a/platform/darwin/common/lynx/LynxEngineProxy.h
+++ b/platform/darwin/common/lynx/LynxEngineProxy.h
@@ -14,28 +14,39 @@ NS_ASSUME_NONNULL_BEGIN
 @class LynxCustomEvent;
 
 @interface LynxEngineProxy : NSObject
+
+/**
+ * Dispatch a given task to be executed on the LynxEngine's running thread.
+ * @param task The block to be dispatched
+ */
+- (void)dispatchTaskToLynxEngine:(dispatch_block_t)task;
+
 /**
  * Invoke lepus function
  *  @param data function params
  *  @param callbackID the key of invoke task
  */
 - (void)invokeLepusFunc:(NSDictionary *)data callbackID:(int32_t)callbackID;
+
 /**
  * Synchronously send touch event to runtime
  *  @param event touch param
  */
 - (void)sendSyncTouchEvent:(LynxTouchEvent *)event;
 - (void)sendSyncMultiTouchEvent:(LynxTouchEvent *)event;
+
 /**
  * Synchronously send gesture event to runtime
  * @param event custom event param
  */
 - (void)sendGestureEvent:(int)gestureId event:(LynxCustomEvent *)event;
+
 /**
  * Synchronously send custom event to runtime
  *  @param event custom event param
  */
 - (void)sendCustomEvent:(LynxCustomEvent *)event;
+
 /**
  * Notify css pseudo status change
  *  @param tag pseudo tag

--- a/platform/darwin/common/lynx/LynxEngineProxy.mm
+++ b/platform/darwin/common/lynx/LynxEngineProxy.mm
@@ -29,6 +29,12 @@
   native_engine_proxy_ = proxy;
 }
 
+- (void)dispatchTaskToLynxEngine:(dispatch_block_t)task {
+  if (native_engine_proxy_ && task) {
+    native_engine_proxy_->DispatchTaskToLynxEngine([task]() { task(); });
+  }
+}
+
 - (void)invokeLepusFunc:(NSDictionary *)data callbackID:(int32_t)callbackID {
   if (!native_engine_proxy_ || !data[@"entry_name"]) {
     return;

--- a/platform/darwin/ios/lynx/LynxTemplateRender.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRender.mm
@@ -1877,8 +1877,7 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
 }
 
 - (void)runOnTasmThread:(dispatch_block_t)task {
-  std::function<void(void)> native_task = [task]() { task(); };
-  shell_->RunOnTasmThread(std::move(native_task));
+  [_lynxEngineProxy dispatchTaskToLynxEngine:task];
 }
 
 - (LynxGestureArenaManager*)getGestureArenaManager {


### PR DESCRIPTION
## Summary

`LynxShell` is only allowed to be accessed from the main thread, as accessing it from a non-main thread may cause crashes. However, `RunOnTasmThread` directly calls `LynxShell`, and this method may be invoked from a background thread, leading to potential thread safety issues.

To address this, the call chain has been refactored to ensure that `LynxShell` is always accessed via `LynxEngineProxy`, which is a thread-safe class capable of accessing the thread where `LynxEngine` runs.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
