### PR TITLE
[Infra] suppress the explicit import error of the lang package

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -290,7 +290,7 @@ deps = {
     "./tools_shared": {
         "type": "solution",
         "url": "https://github.com/lynx-family/tools-shared.git",
-        "commit": "ce1f7cb14f36dfe8d122ac4c314f1f045735cc74",
+        "commit": "dab217fe0cd20adfaf0b6a95ac9cd92e2c56a2e6",
         'deps_file': 'dependencies/DEPS',
         "ignore_in_git": True,
     },


### PR DESCRIPTION
Checkstyle prohibits explicit imports of the 'lang' package, but when writing JNI-related logic, we need to import it explicitly, which causes conflicts. Therefore, here we add a hack operation to suppress the explicit import error of the 'lang' package.

issue:#100
Change-Id: I5e69da1ded3e9c3b8e0cfef15c498f7c29991027

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
