### PR TITLE
[Optimize] Let ByteArrayInputStream hold InputBuffer through shared_p…

### DIFF
--- a/core/runtime/vm/lepus/BUILD.gn
+++ b/core/runtime/vm/lepus/BUILD.gn
@@ -75,6 +75,8 @@ unittest_set("lepus_testset") {
     "//lynx/testing/lynx/tasm/databinding/databinding_test.cc",
     "//lynx/testing/lynx/tasm/databinding/element_dump_helper.cc",
     "//lynx/testing/lynx/tasm/databinding/mock_replayer_component_loader.cc",
+    "binary_input_stream_unittest.cc",
+    "binary_input_stream_unittest.h",
     "context_decoder_unittests.cc",
     "function_api_unittest.cc",
     "lepus_error_helper_unittest.cc",

--- a/core/runtime/vm/lepus/binary_input_stream_unittest.cc
+++ b/core/runtime/vm/lepus/binary_input_stream_unittest.cc
@@ -1,0 +1,201 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+#define private public
+#define protected public
+
+#include "core/runtime/vm/lepus/binary_input_stream_unittest.h"
+
+namespace lynx {
+namespace lepus {
+namespace test {
+
+TEST_F(ByteArrayInputStreamTest, TestCursor) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  EXPECT_EQ(*stream->cursor(), 't');
+}
+
+TEST_F(ByteArrayInputStreamTest, TestCheckSize0) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  EXPECT_TRUE(stream->CheckSize(str.size()));
+  EXPECT_FALSE(stream->CheckSize(str.size() + 1));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestCheckSize1) {
+  std::string str = "";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  EXPECT_FALSE(stream->CheckSize(str.size()));
+  EXPECT_FALSE(stream->CheckSize(str.size() + 1));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestSeek) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  EXPECT_EQ(stream->Seek(1), 1);
+  EXPECT_EQ(stream->offset(), 1);
+  EXPECT_EQ(stream->Seek(0), 0);
+  EXPECT_EQ(stream->offset(), 0);
+  EXPECT_EQ(stream->Seek(str.size()), str.size() - 1);
+  EXPECT_EQ(stream->offset(), str.size() - 1);
+  EXPECT_EQ(stream->Seek(0), 0);
+  EXPECT_EQ(stream->offset(), 0);
+  EXPECT_EQ(stream->Seek(str.size() + 1), str.size() - 1);
+  EXPECT_EQ(stream->offset(), str.size() - 1);
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadUx0) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  uint8_t result = 0;
+  stream->ReadUx<uint8_t>(&result);
+  EXPECT_EQ(result, static_cast<uint8_t>('t'));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadUx1) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  int32_t result = 0;
+  stream->ReadUx<int32_t>(&result);
+  EXPECT_EQ(result, static_cast<int32_t>('t') + static_cast<int32_t>('e' << 8) +
+                        static_cast<int32_t>('s' << 16) +
+                        static_cast<int32_t>('t' << 24));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadData) {}
+
+TEST_F(ByteArrayInputStreamTest, TestReadStringStd0) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  std::string target_str;
+  stream->ReadString(target_str, str.size());
+  EXPECT_EQ(str, target_str);
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadStringStd1) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  std::string target_str;
+  stream->ReadString(target_str, str.size() + 1);
+  EXPECT_EQ(target_str, "");
+
+  stream->ReadString(target_str, 2);
+  EXPECT_EQ(target_str, "te");
+
+  stream->ReadString(target_str, 2);
+  EXPECT_EQ(target_str, "st");
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadString0) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  base::String target_str;
+  stream->ReadString(target_str, str.size());
+  EXPECT_EQ(target_str, "test string");
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadString1) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  base::String target_str;
+  stream->ReadString(target_str, str.size() + 1);
+  EXPECT_EQ(target_str, "");
+
+  stream->ReadString(target_str, 2);
+  EXPECT_EQ(target_str, "te");
+
+  stream->ReadString(target_str, 2);
+  EXPECT_EQ(target_str, "st");
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadCompactU32) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  uint32_t result = 0;
+  stream->ReadCompactU32(&result);
+  EXPECT_EQ(result, static_cast<uint32_t>('t') +
+                        static_cast<uint32_t>('e' << 8) +
+                        static_cast<uint32_t>('s' << 16) +
+                        static_cast<uint32_t>('t' << 24));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadCompactS32) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  int32_t result = 0;
+  stream->ReadCompactS32(&result);
+  EXPECT_EQ(result, static_cast<int32_t>('t') + static_cast<int32_t>('e' << 8) +
+                        static_cast<int32_t>('s' << 16) +
+                        static_cast<int32_t>('t' << 24));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestReadCompactU64) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  uint64_t result = 0;
+  stream->ReadCompactU64(&result);
+  EXPECT_EQ(result, static_cast<uint64_t>('t') +
+                        static_cast<uint64_t>('e' << 8) +
+                        static_cast<uint64_t>('s' << 16) +
+                        static_cast<uint64_t>('t' << 24) +
+                        (static_cast<uint64_t>(' ') << 32) +
+                        (static_cast<uint64_t>('s') << 40) +
+                        (static_cast<uint64_t>('t') << 48) +
+                        (static_cast<uint64_t>('r') << 56));
+}
+
+TEST_F(ByteArrayInputStreamTest, TestDeriveInputStream) {
+  std::string str = "test string";
+
+  auto stream = std::make_unique<ByteArrayInputStream>(
+      reinterpret_cast<const uint8_t*>(str.data()), str.size());
+
+  auto new_stream = stream->DeriveInputStream();
+
+  EXPECT_EQ(static_cast<ByteArrayInputStream*>(new_stream.get())->buf_,
+            stream->buf_);
+}
+
+}  // namespace test
+}  // namespace lepus
+}  // namespace lynx

--- a/core/runtime/vm/lepus/binary_input_stream_unittest.h
+++ b/core/runtime/vm/lepus/binary_input_stream_unittest.h
@@ -1,0 +1,29 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef CORE_RUNTIME_VM_LEPUS_BINARY_INPUT_STREAM_UNITTEST_H_
+#define CORE_RUNTIME_VM_LEPUS_BINARY_INPUT_STREAM_UNITTEST_H_
+
+#include "core/runtime/vm/lepus/binary_input_stream.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace lynx {
+namespace lepus {
+namespace test {
+
+class ByteArrayInputStreamTest : public ::testing::Test {
+ public:
+  ByteArrayInputStreamTest() = default;
+  ~ByteArrayInputStreamTest() = default;
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+}  // namespace test
+}  // namespace lepus
+}  // namespace lynx
+
+#endif  // CORE_RUNTIME_VM_LEPUS_BINARY_INPUT_STREAM_UNITTEST_H_


### PR DESCRIPTION
…tr, and it can construct a new ByteArrayInputStream through DeriveInputStream.

As described in the prompt, the current ByteArrayInputStream holds the InputBuffer through unique_ptr and also keeps track of the current offset to record what position has been read in the InputBuffer.

In the future, we will consider supporting parallel parsing of the InputBuffer, which would require multi-threaded reading of the InputBuffer. The InputBuffer is an object that can be read in a multi-threaded manner. However, ByteArrayInputStream cannot be operated in a multi-threaded environment.

Therefore, we have modified ByteArrayInputStream to hold InputBuffer through shared_ptr, and it can construct a new ByteArrayInputStream through DeriveInputStream. This way, when multi-threaded reading of the InputBuffer is needed, a new ByteArrayInputStream can be efficiently created, allowing each thread to hold a different ByteArrayInputStream and ensuring thread safety.

issue:m-4676645619
AutoSubmit:True

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
