### PR TITLE
[BugFix] Update css-defines-publish.yml

### DIFF
--- a/.github/workflows/css-defines-publish.yml
+++ b/.github/workflows/css-defines-publish.yml
@@ -5,6 +5,9 @@ on: workflow_dispatch
 jobs:
   css-defines-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
## Summary
npm  Provenance publish needs authorize to id-token

Add the required access authorization to write id-token for NPM provenance.

https://docs.npmjs.com/generating-provenance-statements

Follows the NPM guidance: 

To update your GitHub Actions workflow to publish your packages with provenance, you must:

Give permission to mint an ID-token:
```yaml
permissions:
  id-token: write
```

