### PR TITLE
[Optimize] [PageConfig] Allow pipelineSchedulerConfig to be set from external json

### DIFF
--- a/core/renderer/page_config.cc
+++ b/core/renderer/page_config.cc
@@ -9,6 +9,16 @@
 namespace lynx {
 namespace tasm {
 
+/**
+ * @name: pipelineSchedulerConfig
+ * @description: Scheduler config for pipeline, including
+ * enableParallelElement/list-framework batch render and other scheduler config
+ * @platform: Both
+ * @supportVersion: 3.1
+ */
+static constexpr const char* const kPipelineSchedulerConfig =
+    "pipelineSchedulerConfig";
+
 const PageConfig::PageConfigMap<TernaryBool>& PageConfig::GetFuncBoolMap() {
   static const base::NoDestructor<const PageConfigMap<TernaryBool>>
       kPageConfigFuncBoolMap{
@@ -30,6 +40,14 @@ const PageConfig::PageConfigMap<TernaryBool>& PageConfig::GetFuncBoolMap() {
             {&PageConfig::SetEnableSignalAPI,
              &PageConfig::GetEnableSignalAPI}}}};
   return *kPageConfigFuncBoolMap;
+}
+
+const PageConfig::PageConfigMap<uint64_t>& PageConfig::GetFuncUint64Map() {
+  static const base::NoDestructor<const PageConfigMap<uint64_t>>
+      kPageConfigFuncUint64Map{{{kPipelineSchedulerConfig,
+                                 {&PageConfig::SetPipelineSchedulerConfig,
+                                  &PageConfig::GetPipelineSchedulerConfig}}}};
+  return *kPageConfigFuncUint64Map;
 }
 
 }  // namespace tasm

--- a/core/renderer/page_config.h
+++ b/core/renderer/page_config.h
@@ -122,6 +122,17 @@ class PageConfig final : public EntryConfig {
           }
         }
 
+        // if is a uint64
+        auto uint64_pair = GetFuncUint64Map().find(name);
+        if (uint64_pair != GetFuncUint64Map().end()) {
+          if (it->value.IsUint64()) {
+            const auto [setter, getter] = uint64_pair->second;
+            if ((this->*(getter))() == 0) {
+              (this->*(setter))(it->value.GetUint64());
+            }
+          }
+        }
+
         // TODO(nihao.royal) unify parameters of different types.
       }
     }
@@ -130,6 +141,14 @@ class PageConfig final : public EntryConfig {
   void ForEachBoolConfig(
       const base::MoveOnlyClosure<TernaryBool, const std::string&> func) {
     for (const auto& [name, pair] : GetFuncBoolMap()) {
+      const auto [setter, getter] = pair;
+      (this->*(setter))(func(name));
+    }
+  }
+
+  void ForEachUint64Config(
+      const base::MoveOnlyClosure<uint64_t, const std::string&> func) {
+    for (const auto& [name, pair] : GetFuncUint64Map()) {
       const auto [setter, getter] = pair;
       (this->*(setter))(func(name));
     }
@@ -1413,6 +1432,8 @@ class PageConfig final : public EntryConfig {
   using PageConfigMap = std::unordered_map<std::string, PageConfigPair<T>>;
 
   static const PageConfigMap<TernaryBool>& GetFuncBoolMap();
+
+  static const PageConfigMap<uint64_t>& GetFuncUint64Map();
 };
 }  // namespace tasm
 }  // namespace lynx

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
@@ -276,16 +276,6 @@ static constexpr const char* const kEnableQueryComponentSync =
     "enableQueryComponentSync";
 
 /**
- * @name: pipelineSchedulerConfig
- * @description: Scheduler config for pipeline, including
- * enableParallelElement/list-framework batch render and other scheduler config
- * @platform: Both
- * @supportVersion: 3.1
- */
-static constexpr const char* const kPipelineSchedulerConfig =
-    "pipelineSchedulerConfig";
-
-/**
  * @name: enableNativeList
  * @description: Indicates whether use c++ list.
  * @supportVersion: 3.2
@@ -1053,6 +1043,14 @@ bool LynxBinaryConfigDecoder::DecodePageConfig(
     return TernaryBool::UNDEFINE_VALUE;
   });
 
+  page_config->ForEachUint64Config([&doc](const std::string& name) {
+    const char* const key = name.c_str();
+    if (doc.HasMember(key) && doc[key].IsUint64()) {
+      return doc[key].GetUint64();
+    }
+    return static_cast<uint64_t>(0);
+  });
+
   page_config->SetEnableElementAPITypeCheckThrowWarning(
       lynx::tasm::Config::IsHigherOrEqual(target_sdk_version_,
                                           LYNX_VERSION_2_16));
@@ -1069,12 +1067,6 @@ bool LynxBinaryConfigDecoder::DecodePageConfig(
       doc[kEnableQueryComponentSync].IsBool()) {
     page_config->SetEnableQueryComponentSync(
         doc[kEnableQueryComponentSync].GetBool());
-  }
-
-  if (doc.HasMember(kPipelineSchedulerConfig) &&
-      doc[kPipelineSchedulerConfig].IsUint64()) {
-    page_config->SetPipelineSchedulerConfig(
-        doc[kPipelineSchedulerConfig].GetUint64());
   }
 
   // enableMicrotaskPromisePolyfill


### PR DESCRIPTION
## Summary

Previously, pipelineSchedulerConfig was only included as a static template page configuration. Due to this limitation, different templates had to be compiled to for performance verification, which was quite inconvenient.

This pull request allows pipelineSchedulerConfig to be configured from external json source.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
