### PR TITLE
[Infra][DEPS] Uses venv python when sync DEPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.profraw
 __pycache__
 /venv
+.venv
 *.log*
 npm-debug.log*
 yarn-debug.log*

--- a/DEPS
+++ b/DEPS
@@ -5,6 +5,8 @@ system = platform.system().lower()
 machine = platform.machine().lower()
 machine = "x86_64" if machine == "amd64" else machine
 
+venv_python = ".venv/bin/python3"
+venv_pip3 = ".venv/bin/pip3"
 
 deps = {
     'platform/android/gradle/wrapper/gradle-6.7.1-all.zip': {
@@ -257,27 +259,46 @@ deps = {
         ],
         "condition": system in ['linux', 'darwin', 'windows']
     },
+    ### pyenv setup
+    'py_env_setup': {
+        "type": "action",
+        "cwd": root_dir,
+        "commands": [
+            "[ -d .venv ] || python3 -m venv .venv" if system in ['linux', 'darwin'] else "if not exist .venv python -m venv .venv",
+            venv_pip3 + " install --upgrade pip",
+            venv_python + " -m pip install PyYAML",
+        ],
+    },
     ### AUTO GENERATED SCRIPT START
     'gen_feature_count': {
         "type": "action",
         "cwd": root_dir,
         "commands": [
-            "python3 tools/feature_count/generate_feature_count.py",
+            venv_python + " tools/feature_count/generate_feature_count.py",
+        ],
+        "require": [
+            "py_env_setup",
         ],
     },
     'gen_error_code': {
         "type": "action",
         "cwd": root_dir,
         "commands": [
-            "python3 tools/error_code/gen_error_code.py",
+            venv_python + " tools/error_code/gen_error_code.py",
+        ],
+        "require": [
+            "py_env_setup",
         ],
     },
     'gen_lynx_perfromance_entry': {
         "type": "action",
         "cwd": root_dir,
         "commands": [
-            "python3 tools/performance/performance_observer/generate_performance_entry.py",
-        ]
+            venv_python + " tools/performance/performance_observer/generate_performance_entry.py",
+        ],
+        "require": [
+            "py_env_setup",
+        ],
     },
     ### AUTO GENERATED SCRIPT END
     'explorer/darwin/ios/lynx_explorer/xctestrunner': {


### PR DESCRIPTION
## Summary

When I try to sync DEPS using hab, it fails because I don't install `yaml` package for python. I added a command which can install PyYAML and use venv python automatically when syncing DEPS.

```
2025-03-06 14:08:55 zhongwu-macbook.local root[5421] ERROR a command has failed recently, original output:
Traceback (most recent call last):
  File "/Users/zhongwu/Documents/workspace/lynx/src/lynx/tools/feature_count/generate_feature_count.py", line 7, in <module>
    import code_generator
  File "/Users/zhongwu/Documents/workspace/lynx/src/lynx/tools/feature_count/code_generator.py", line 6, in <module>
    import base
  File "/Users/zhongwu/Documents/workspace/lynx/src/lynx/tools/feature_count/base.py", line 7, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
