### PR TITLE
[Optimize] Improve Readability of Copied Errors from Lynx LogBox

### DIFF
--- a/devtool/lynx_devtool/resources/lynx-logbox/src/pages/content/displayError.tsx
+++ b/devtool/lynx_devtool/resources/lynx-logbox/src/pages/content/displayError.tsx
@@ -81,8 +81,10 @@ function createErrorItem(item: IErrorRecord, key: number, cachedErrors: string[]
           <CopyOutlined
             style={{ fontSize: '16px', color: 'white' }}
             onClick={() => {
-              copy(JSON.stringify(item.rawErrorText));
-              getBridge().toastMessage('The error message has been copied');
+              if (item.rawErrorText !== undefined) {
+                copy(item.rawErrorText);
+                getBridge().toastMessage('Error message copied');
+              }
             }}
           />
         </div>


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

This optimization addresses an issue in Lynx where errors copied from the LogBox were double-escaped, resulting in hard-to-read content.

Previously, `item.rawErrorText`, which is already a string, was processed with `JSON.stringify`. This unnecessarily wrapped the string in quotes and escaped internal quotes.

The update removes the `JSON.stringify` call. Now, the error text is copied directly and a toast is displayed only if the message is not undefined, enhancing the readability of the copied error messages.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ X ] Tests updated (or not required).
- [ X ] Documentation updated (or not required).
