### PR TITLE
[BugFix] Flush layout task queue in LayoutImmediatelyWithUpdatedViewp…

### DIFF
--- a/base/include/fml/message_loop_impl.h
+++ b/base/include/fml/message_loop_impl.h
@@ -71,7 +71,8 @@ class MessageLoopImpl : public Wakeable,
 
   void SetRestrictionDuration(fml::TimeDelta duration);
 
-  void Bind(const TaskQueueId& queue_id);
+  void Bind(const TaskQueueId& queue_id,
+            bool should_run_expired_tasks_immediately = false);
 
   void UnBind(const TaskQueueId& queue_id);
 

--- a/base/include/fml/task_runner.h
+++ b/base/include/fml/task_runner.h
@@ -87,7 +87,8 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
 
   void RemoveTaskObserver(intptr_t key);
 
-  void Bind(fml::RefPtr<MessageLoopImpl> target_loop);
+  void Bind(fml::RefPtr<MessageLoopImpl> target_loop,
+            bool should_run_expired_tasks_immediately = false);
 
   void UnBind();
 

--- a/base/src/BUILD.gn
+++ b/base/src/BUILD.gn
@@ -326,6 +326,7 @@ if (enable_unittests) {
       "fml/synchronization/semaphore_unittest.cc",
       "fml/synchronization/sync_switch_unittest.cc",
       "fml/synchronization/waitable_event_unittest.cc",
+      "fml/task_runner_unittests.cc",
       "fml/task_source_unittests.cc",
       "fml/thread_unittests.cc",
       "fml/time/chrono_timestamp_provider.cc",

--- a/base/src/fml/message_loop_impl.cc
+++ b/base/src/fml/message_loop_impl.cc
@@ -210,11 +210,38 @@ std::vector<TaskQueueId> MessageLoopImpl::GetTaskQueueIds() const {
   return queue_ids_;
 }
 
-void MessageLoopImpl::Bind(const TaskQueueId& queue_id) {
+void MessageLoopImpl::Bind(const TaskQueueId& queue_id,
+                           bool should_run_expired_tasks_immediately) {
+  TRACE_EVENT("lynx", "MessageLoopImpl::Bind");
+
   task_queue_->IsTaskQueueAlignedWithVSync(queue_id)
       ? vsync_aligned_task_queue_ids_.emplace_back(queue_id)
       : queue_ids_.emplace_back(queue_id);
   task_queue_->SetWakeable(queue_id, this);
+
+  if (should_run_expired_tasks_immediately) {
+    std::vector<TaskQueueId> queue_ids{queue_id};
+    const auto now = fml::TimePoint::Now();
+
+    while (1) {
+      auto next_task = task_queue_->GetNextTaskToRun(queue_ids, now);
+      if (!next_task) {
+        break;
+      }
+
+      auto invocation = std::move((*next_task).task);
+      if (!invocation) {
+        break;
+      }
+      invocation();
+
+      auto observers =
+          task_queue_->GetObserversToNotify(next_task->task_queue_id);
+      for (const auto& observer : observers) {
+        (*observer)();
+      }
+    }
+  }
 }
 
 void MessageLoopImpl::UnBind(const TaskQueueId& queue_id) {

--- a/base/src/fml/task_runner.cc
+++ b/base/src/fml/task_runner.cc
@@ -150,14 +150,19 @@ void TaskRunner::RunNowOrPostTask(
   }
 }
 
-void TaskRunner::Bind(fml::RefPtr<MessageLoopImpl> target_loop) {
+void TaskRunner::Bind(fml::RefPtr<MessageLoopImpl> target_loop,
+                      bool should_run_expired_tasks_immediately) {
   if (target_loop && target_loop != loop_) {
     LYNX_BASE_CHECK(target_loop->CanRunNow());
     UnBind();
-    target_loop->Bind(queue_id_);
+    target_loop->Bind(queue_id_, should_run_expired_tasks_immediately);
     loop_ = std::move(target_loop);
-    // Try to wake up the loop when there are tasks in the queue.
-    MessageLoopTaskQueues::GetInstance()->WakeUp(loop_->GetTaskQueueIds());
+
+    if (!should_run_expired_tasks_immediately) {
+      // If expired tasks should not be run immediately,
+      // attempt to wake up the loop when there are tasks in the queue.
+      MessageLoopTaskQueues::GetInstance()->WakeUp(loop_->GetTaskQueueIds());
+    }
   }
 }
 

--- a/base/src/fml/task_runner_unittests.cc
+++ b/base/src/fml/task_runner_unittests.cc
@@ -1,0 +1,158 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "base/include/fml/synchronization/waitable_event.h"
+#include "base/include/fml/task_runner.h"
+#include "base/include/fml/thread.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace lynx {
+namespace fml {
+namespace testing {
+
+class TaskRunnerTest : public ::testing::Test {
+ protected:
+  TaskRunnerTest() = default;
+  ~TaskRunnerTest() override = default;
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+};
+
+TEST_F(TaskRunnerTest, Bind) {
+  fml::Thread original_thread("original_thread");
+  fml::Thread target_thread("target_thread");
+
+  auto original_loop = original_thread.GetLoop();
+  auto target_loop = target_thread.GetLoop();
+
+  auto task_runner = fml::MakeRefCounted<fml::TaskRunner>(original_loop);
+  int32_t result = 0;
+  constexpr int32_t expected = 10;
+
+  for (int32_t i = 0; i < expected; ++i) {
+    task_runner->PostTask([&result, original_loop, target_loop]() {
+      ++result;
+      ASSERT_EQ(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                original_loop.get());
+      ASSERT_NE(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                target_loop.get());
+    });
+  }
+
+  fml::AutoResetWaitableEvent arwe;
+  original_thread.GetTaskRunner()->PostTask([&arwe]() { arwe.Signal(); });
+
+  arwe.Wait();
+  ASSERT_EQ(result, expected);
+
+  arwe.Reset();
+  target_thread.GetTaskRunner()->PostTask([&arwe, task_runner, target_loop]() {
+    task_runner->Bind(target_loop);
+    arwe.Signal();
+  });
+
+  arwe.Wait();
+  result = 0;
+
+  for (int32_t i = 0; i < expected; ++i) {
+    task_runner->PostTask([&result, original_loop, target_loop]() {
+      ++result;
+      ASSERT_EQ(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                target_loop.get());
+      ASSERT_NE(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                original_loop.get());
+    });
+  }
+
+  arwe.Reset();
+  target_thread.GetTaskRunner()->PostTask([&arwe]() { arwe.Signal(); });
+
+  arwe.Wait();
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(TaskRunnerTest, BindWithShouldRunExpiredTasksImmediately) {
+  fml::Thread original_thread("original_thread");
+  fml::Thread target_thread("target_thread");
+
+  auto original_loop = original_thread.GetLoop();
+  auto target_loop = target_thread.GetLoop();
+
+  auto task_runner = fml::MakeRefCounted<fml::TaskRunner>(original_loop);
+  int32_t result = 0;
+  static constexpr int32_t expected = 10;
+
+  fml::AutoResetWaitableEvent arwe;
+  original_thread.GetTaskRunner()->PostTask([&arwe, &result, &target_thread,
+                                             task_runner, original_loop,
+                                             target_loop]() {
+    for (int32_t i = 0; i < expected; ++i) {
+      task_runner->PostTask([&result, original_loop, target_loop]() {
+        ++result;
+        ASSERT_EQ(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                  target_loop.get());
+        ASSERT_NE(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                  original_loop.get());
+      });
+    }
+
+    task_runner->UnBind();
+
+    target_thread.GetTaskRunner()->PostTask(
+        [&arwe, &result, task_runner, target_loop]() {
+          task_runner->Bind(target_loop);
+          ASSERT_EQ(result, 0);
+          arwe.Signal();
+        });
+  });
+
+  arwe.Wait();
+  arwe.Reset();
+
+  task_runner->PostTask([&arwe]() { arwe.Signal(); });
+  arwe.Wait();
+
+  ASSERT_EQ(result, expected);
+
+  original_thread.GetTaskRunner()->PostTask(
+      [task_runner, original_loop]() { task_runner->Bind(original_loop); });
+
+  result = 0;
+  original_thread.GetTaskRunner()->PostTask([&arwe, &result, &target_thread,
+                                             task_runner, original_loop,
+                                             target_loop]() {
+    for (int32_t i = 0; i < expected; ++i) {
+      task_runner->PostTask([&result, original_loop, target_loop]() {
+        ++result;
+        ASSERT_EQ(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                  target_loop.get());
+        ASSERT_NE(MessageLoop::GetCurrent().GetLoopImpl().get(),
+                  original_loop.get());
+      });
+    }
+
+    task_runner->UnBind();
+
+    target_thread.GetTaskRunner()->PostTask(
+        [&arwe, &result, task_runner, target_loop]() {
+          task_runner->Bind(target_loop, true);
+          ASSERT_EQ(result, expected);
+          arwe.Signal();
+        });
+  });
+
+  arwe.Wait();
+  arwe.Reset();
+
+  task_runner->PostTask([&arwe]() { arwe.Signal(); });
+  arwe.Wait();
+
+  ASSERT_EQ(result, expected);
+}
+
+}  // namespace testing
+}  // namespace fml
+}  // namespace lynx

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -648,6 +648,8 @@ void LynxShell::SyncFetchLayoutResult() {
   engine_actor_->Act([](auto& engine) { engine->SyncFetchLayoutResult(); });
 }
 
+// TODO(klaxxi): There may currently be two layout passes.
+// Optimization will be done later to skip the layout triggered in Bind.
 void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
                                                      int32_t width_mode,
                                                      float height,
@@ -662,7 +664,7 @@ void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
   auto ui_loop = runners_.GetUITaskRunner()->GetLoop();
 
   // TODO(heshan): Merge with the similar logic of EngineThreadSwitch
-  layout_runner->Bind(ui_loop);
+  layout_runner->Bind(ui_loop, true);
   tasm_operation_queue_->SetAppendPendingTaskNeededDuringFlush(true);
 
   UpdateViewport(width, width_mode, height, height_mode);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

When calling `LayoutImmediatelyWithUpdatedViewport`, if the layout thread has not yet processed previous tasks, this invocation may effectively preempt the layout thread queue. If certain tasks have not been executed in time, such as the creation of a layout node, this could lead to a synchronous access to the node and cause a crash.

To prevent task preemption and resolve this issue, we now execute pending tasks in the layout thread queue synchronously during `Bind`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
