### PR TITLE
[BugFix] Refactor isNotchScreen method for improved clarity and support for Android 9 and 10

### DIFF
--- a/devtool/lynx_devtool/resources/lynx-logbox/src/pages/content/displayError.tsx
+++ b/devtool/lynx_devtool/resources/lynx-logbox/src/pages/content/displayError.tsx
@@ -81,8 +81,10 @@ function createErrorItem(item: IErrorRecord, key: number, cachedErrors: string[]
           <CopyOutlined
             style={{ fontSize: '16px', color: 'white' }}
             onClick={() => {
-              copy(JSON.stringify(item.rawErrorText));
-              getBridge().toastMessage('The error message has been copied');
+              if (item.rawErrorText !== undefined) {
+                copy(item.rawErrorText);
+                getBridge().toastMessage('Error message copied');
+              }
             }}
           />
         </div>

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -18,6 +18,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.view.WindowInsets;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 import androidx.appcompat.app.AppCompatActivity;
@@ -47,8 +48,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
   public static final String URL_KEY = "url";
   private static final String URL_PREFIX = "file://lynx?local://";
   private static final String TAG = "LynxViewShellActivity";
-  private static final String HOME_PAGE_URL =
-      "file://lynx?local://homepage.lynx.bundle?fullscreen=true";
+  private static final String HOME_PAGE_URL = "file://lynx?local://homepage.lynx.bundle?fullscreen=true";
   private static final String DEFAULT_TOP_BAR_COLOR = "#F0F2F5";
   private static final String DEFAULT_TOP_BAR_TITLE_COLOR = "#000000";
   private static final String DEFAULT_TOP_BAR_BACK_BUTTON_STYLE = "light";
@@ -114,7 +114,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
 
   private void setWindowColor(Toolbar toolbar, QueryMapUtils queryMap) {
     String color = queryMap.contains("bar_color") ? "#" + queryMap.getString("bar_color")
-                                                  : DEFAULT_TOP_BAR_COLOR;
+        : DEFAULT_TOP_BAR_COLOR;
 
     toolbar.setBackgroundColor(Color.parseColor(color));
     getWindow().setStatusBarColor(Color.parseColor(color));
@@ -142,7 +142,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
     TextView tv = toolbar.findViewById(R.id.toolbar_title);
     String title = queryMap.contains("title") ? queryMap.getString("title") : null;
     String titleColor = queryMap.contains("title_color") ? "#" + queryMap.getString("title_color")
-                                                         : DEFAULT_TOP_BAR_TITLE_COLOR;
+        : DEFAULT_TOP_BAR_TITLE_COLOR;
 
     if (tv != null) {
       tv.setText(title);
@@ -160,10 +160,24 @@ public class LynxViewShellActivity extends AppCompatActivity {
   }
 
   public boolean isNotchScreen() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      // For Android 9 (P) and below, use a safer method to detect notch
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        WindowManager windowManager = getSystemService(WindowManager.class);
+        if (windowManager == null) {
+          return false;
+        }
+        WindowInsets windowInsets = getWindow().getDecorView().getRootWindowInsets();
+        if (windowInsets == null) {
+          return false;
+        }
+        DisplayCutout displayCutout = windowInsets.getDisplayCutout();
+        return displayCutout != null;
+      }
       return false;
     }
 
+    // For Android 10 (Q) and above, use Display.getCutout()
     WindowManager windowManager = getSystemService(WindowManager.class);
     if (windowManager == null) {
       return false;
@@ -181,15 +195,14 @@ public class LynxViewShellActivity extends AppCompatActivity {
 
     if (isNotchScreen()) {
       WindowManager.LayoutParams params = getWindow().getAttributes();
-      params.layoutInDisplayCutoutMode =
-          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+      params.layoutInDisplayCutoutMode = WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
       getWindow().setAttributes(params);
       getWindow().getDecorView().setSystemUiVisibility(
           View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
     }
 
-    WindowInsetsControllerCompat windowInsetsController =
-        WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+    WindowInsetsControllerCompat windowInsetsController = WindowCompat.getInsetsController(getWindow(),
+        getWindow().getDecorView());
 
     windowInsetsController.setSystemBarsBehavior(
         WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
@@ -213,7 +226,8 @@ public class LynxViewShellActivity extends AppCompatActivity {
     builder.setGenericResourceFetcher(new DemoGenericResourceFetcher());
     builder.setTemplateResourceFetcher(new DemoTemplateResourceFetcher(this));
     builder.setMediaResourceFetcher(new DemoMediaResourceFetcher());
-    // Parse the URL parameters and specify the LynxView width, height, and density according to the
+    // Parse the URL parameters and specify the LynxView width, height, and density
+    // according to the
     // parameters.
     QueryMapUtils queryMap = new QueryMapUtils();
     queryMap.parse(url);
@@ -278,8 +292,8 @@ public class LynxViewShellActivity extends AppCompatActivity {
     globalProps.put("screenHeight", displayMetrics.heightPixels / displayMetrics.density);
 
     String theme = "Light";
-    if ((context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)
-        == Configuration.UI_MODE_NIGHT_YES) {
+    if ((context.getResources().getConfiguration().uiMode
+        & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES) {
       theme = "Dark";
     }
     globalProps.put("theme", theme);


### PR DESCRIPTION
#127  
# Summary:
Lynx Explorer is crashing due to a NoSuchMethodError when calling getCutout() on android.view.Display
The getCutout() method on Display wasn't added until API level 29 (Android 10)

issue: Lynx Explorer is crashing due to a NoSuchMethodError when calling getCutout() on android.view.Display.
fix: The changes properly handles different Android versions by using version-specific API calls to detect if a device has a display cutout.