### PR TITLE
[Optimize] fix the inverted qrcode can not be scanned

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
@@ -13,6 +13,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.ResultPoint;
+import com.google.zxing.client.android.Intents;
 import com.journeyapps.barcodescanner.BarcodeCallback;
 import com.journeyapps.barcodescanner.BarcodeResult;
 import com.journeyapps.barcodescanner.DecoratedBarcodeView;
@@ -51,7 +52,7 @@ public class QRScanActivity extends Activity {
 
     mBarcodeView = findViewById(R.id.barcode_scanner);
     Collection<BarcodeFormat> formats = Arrays.asList(BarcodeFormat.QR_CODE);
-    mBarcodeView.getBarcodeView().setDecoderFactory(new DefaultDecoderFactory(formats));
+    mBarcodeView.getBarcodeView().setDecoderFactory(new DefaultDecoderFactory(formats,null,null, Intents.Scan.MIXED_SCAN));
     mBarcodeView.initializeFromIntent(getIntent());
     mBarcodeView.decodeSingle(callback);
   }

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
@@ -13,6 +13,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.ResultPoint;
+import com.google.zxing.client.android.Intents;
 import com.journeyapps.barcodescanner.BarcodeCallback;
 import com.journeyapps.barcodescanner.BarcodeResult;
 import com.journeyapps.barcodescanner.DecoratedBarcodeView;
@@ -51,7 +52,8 @@ public class QRScanActivity extends Activity {
 
     mBarcodeView = findViewById(R.id.barcode_scanner);
     Collection<BarcodeFormat> formats = Arrays.asList(BarcodeFormat.QR_CODE);
-    mBarcodeView.getBarcodeView().setDecoderFactory(new DefaultDecoderFactory(formats));
+    mBarcodeView.getBarcodeView().setDecoderFactory(
+        new DefaultDecoderFactory(formats, null, null, Intents.Scan.MIXED_SCAN));
     mBarcodeView.initializeFromIntent(getIntent());
     mBarcodeView.decodeSingle(callback);
   }

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/scan/QRScanActivity.java
@@ -52,7 +52,8 @@ public class QRScanActivity extends Activity {
 
     mBarcodeView = findViewById(R.id.barcode_scanner);
     Collection<BarcodeFormat> formats = Arrays.asList(BarcodeFormat.QR_CODE);
-    mBarcodeView.getBarcodeView().setDecoderFactory(new DefaultDecoderFactory(formats,null,null, Intents.Scan.MIXED_SCAN));
+    mBarcodeView.getBarcodeView().setDecoderFactory(
+        new DefaultDecoderFactory(formats, null, null, Intents.Scan.MIXED_SCAN));
     mBarcodeView.initializeFromIntent(getIntent());
     mBarcodeView.decodeSingle(callback);
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

fix the scan issue that an inverted qrcode can not be scanned
also fix https://github.com/lynx-family/lynx/issues/239


