### PR TITLE
[Feature] Add iOS-specific environment setup script and update README

### DIFF
--- a/explorer/darwin/ios/README.md
+++ b/explorer/darwin/ios/README.md
@@ -52,7 +52,7 @@ Run the following commands from the root of the repository to install the depend
 ```
 cd src/lynx
 tools/hab sync .
-source tools/envsetup.sh
+source tools/ios-only-envsetup.sh
 ```
 
 ## Build iOS App

--- a/tools/ios-only-envsetup.sh
+++ b/tools/ios-only-envsetup.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+# using posix standard commands to acquire realpath of file
+posix_absolute_path() {
+  if [[ ! $# -eq 1 ]];then
+    echo "illegal parameters $@"
+    exit 1
+  fi
+  cd $(dirname $1) 1>/dev/null || exit 1
+  local ABSOLUTE_PATH_OF_FILE="$(pwd -P)/$(basename $1)"
+  cd - 1>/dev/null || exit 1
+  echo $ABSOLUTE_PATH_OF_FILE
+}
+
+
+lynx_envsetup() {
+  local SCRIPT_ABSOLUTE_PATH="$(posix_absolute_path $1)"
+  local TOOLS_ABSOLUTE_PATH="$(dirname $SCRIPT_ABSOLUTE_PATH)"
+  export LYNX_DIR="$(dirname $TOOLS_ABSOLUTE_PATH)"
+  export LYNX_ROOT_DIR="$(dirname $LYNX_DIR)"
+  export BUILDTOOLS_DIR="${LYNX_ROOT_DIR}/buildtools"
+  export PATH="${BUILDTOOLS_DIR}/llvm/bin:${BUILDTOOLS_DIR}/ninja:${TOOLS_ABSOLUTE_PATH}/gn_tools:$PATH"
+  # setup node version
+  export PATH=${BUILDTOOLS_DIR}/node/bin:$PATH
+  # setup corepack
+  export COREPACK_HOME="${BUILDTOOLS_DIR}/corepack"
+
+  export PATH="${LYNX_DIR}/tools_shared:$PATH"
+}
+
+lynx_envsetup "${BASH_SOURCE:-$0}"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Add a envsetup script for iOS only developer, so that Android env is not required to build the explorer.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
