### PR TITLE
[BugFix][Android] Remove unexpected include in Lynx Trace Module

### DIFF
--- a/base/trace/native/trace_event_utils_systrace.h
+++ b/base/trace/native/trace_event_utils_systrace.h
@@ -9,7 +9,6 @@
 
 #include <string>
 
-#include "base/include/log/logging.h"
 #include "base/trace/native/internal_trace_category.h"
 #include "base/trace/native/trace_export.h"
 #include "base/trace/native/track_event_wrapper.h"


### PR DESCRIPTION
This MR removes an unexpected #include of "base/include/log/logging.h" from "trace_event_utils_systrace.h". The inclusion was problematic as it caused Lynx trace macros to leak into any file including "trace_event_utils_systrace.h", leading to macro symbol collisions due to the lack of a namespace for macros. For instance, if a file that already defines a `DCHECK` macro includes "trace_event_utils_systrace.h", it would encounter duplicate macro definitions, since DCHECK is also defined in "base/include/log/logging.h", resulting in compilation errors.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ X ] Tests updated (or not required).
- [ X ] Documentation updated (or not required).
