### PR TITLE
[Infra] Support x86_64 achitecture when build lynx and explorer on An…

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
           source tools/envsetup.sh
           pushd explorer/android
           if [ "${{ inputs.dry_run }}" = "false" ]; then
-            ./gradlew :LynxExplorer:assembleNoasanRelease -Penable_trace=none -Plynx-local-build -no-daemon
+            ./gradlew :LynxExplorer:assembleNoasanRelease -Penable_trace=none -PabiList=armeabi-v7a,x86,x86_64,arm64-v8a -no-daemon
           else
             ./gradlew :LynxExplorer:assembleNoasanRelease -Penable_trace=none -no-daemon
           fi
@@ -140,7 +140,7 @@ jobs:
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
           pushd platform/android
-          ./gradlew assembleAllModulesRelease -Penable_trace=none -no-daemon
+          ./gradlew assembleAllModulesRelease -Penable_trace=none -PabiList=armeabi-v7a,x86,x86_64,arm64-v8a -no-daemon
           popd
       - name: Package maven artifacts
         if: ${{ inputs.dry_run == false }}

--- a/.rtf/android-ut-lynx.template
+++ b/.rtf/android-ut-lynx.template
@@ -6,7 +6,7 @@ builder({
             "--parallel",
             "--configure-on-demand",
             "-x lint",
-            "-Pbuild_for_emu",
+            "-PabiList=x86",
             "-Penable_lynx_android_test=true",
             "-Penable_coverage=true",
         ],

--- a/devtool/base_devtool/android/base_devtool/build.gradle
+++ b/devtool/base_devtool/android/base_devtool/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     compileOnly 'androidx.annotation:annotation:1.0.0'
-    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.2'
+    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.3'
 }
 
 // Configure the compilation parameters in gn to generate the corresponding CMakeLists.txt files.

--- a/explorer/android/build.gradle
+++ b/explorer/android/build.gradle
@@ -17,13 +17,8 @@ buildscript {
             buildLynxDebugSo = false
         }
 
-        if (project.hasProperty("lynx-local-build")) {
-            abiList=['armeabi-v7a', 'arm64-v8a', 'x86']
-        } else if (project.hasProperty("build_for_emu")) {
-            abiList=['armeabi-v7a', 'x86']
-        } else {
-            abiList=['arm64-v8a']
-        }
+        value = project.properties["abiList"]
+        abiList = value? value.toString().split(",") : ["arm64-v8a"]
 
         if (project.hasProperty("IntegrationTest")) {
             buildIntegrationDemo = true

--- a/explorer/android/gradle.properties
+++ b/explorer/android/gradle.properties
@@ -57,3 +57,7 @@ enable_coverage=false
 build_showcase=true
 
 VERSION=0.0.1
+
+# Used to specify the architecture types for building native code. The optional values are: armeabi-v7a, x86, x86_64, arm64-v8a.
+# When setting this value, please use commas to separate different architecture types. For example: abiList=armeabi-v7a,x86
+abiList=arm64-v8a

--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.4.0'
     implementation 'com.squareup.retrofit2:retrofit:2.7.0'
-    implementation 'org.lynxsdk.lynx:v8so:0.0.1'
+    implementation 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
     implementation project(':LynxAndroid')
     implementation project(':LynxTestBench')

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -16,13 +16,8 @@ buildscript {
         }else{
             buildLynxDebugSo = false
         }
-        if (project.hasProperty("lynx-local-build")) {
-            abiList=['armeabi-v7a', 'arm64-v8a', 'x86']
-        } else if (project.hasProperty("build_for_emu")){
-            abiList=['armeabi-v7a', 'x86']
-        } else {
-            abiList=['arm64-v8a']
-        }
+        value = project.properties["abiList"]
+        abiList = value? value.toString().split(",") : ["arm64-v8a"]
         enable_coverage_bool = (enable_coverage == 'true')
     }
     repositories {

--- a/platform/android/gradle.properties
+++ b/platform/android/gradle.properties
@@ -54,3 +54,7 @@ enable_lynx_android_test=false
 enable_coverage=false
 
 VERSION = 0.0.1
+
+# Used to specify the architecture types for building native code. The optional values are: armeabi-v7a, x86, x86_64, arm64-v8a.
+# When setting this value, please use commas to separate different architecture types. For example: abiList=armeabi-v7a,x86
+abiList=arm64-v8a

--- a/platform/android/lynx_android/build.gradle
+++ b/platform/android/lynx_android/build.gradle
@@ -309,9 +309,9 @@ dependencies {
     androidTestImplementation "com.google.auto.service:auto-service-annotations:1.0-rc5"
     androidTestAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
-    implementation 'org.lynxsdk.lynx:primjs:2.11.1-rc.1'
-    extractJNI 'org.lynxsdk.lynx:primjs:2.11.1-rc.1'
-    extractJNI 'org.lynxsdk.lynx:v8so:0.0.1'
+    implementation 'org.lynxsdk.lynx:primjs:2.11.1-rc.2'
+    extractJNI 'org.lynxsdk.lynx:primjs:2.11.1-rc.2'
+    extractJNI 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
     api project(':LynxJSSDK')
 }

--- a/platform/android/lynx_devtool/build.gradle
+++ b/platform/android/lynx_devtool/build.gradle
@@ -256,8 +256,8 @@ dependencies {
 
     api project(':LynxJSSDK')
 
-    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.2'
-    implementation 'org.lynxsdk.lynx:v8so:0.0.1'
+    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.3'
+    implementation 'org.lynxsdk.lynx:v8so:11.1.277.3'
     
     compileOnly("com.squareup.okhttp3:okhttp:3.10.0")
     androidTestImplementation("com.squareup.okhttp3:mockwebserver:3.10.0")

--- a/platform/android/lynx_service/lynx_service_devtool/build.gradle
+++ b/platform/android/lynx_service/lynx_service_devtool/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.2'
+    implementation 'org.lynxsdk.lynx:debug-router:0.0.1-alpha.3'
     compileOnly "androidx.annotation:annotation:1.0.0"
     compileOnly project(':LynxAndroid')
     compileOnly project(':LynxDevtool')

--- a/tools/android_tools/generate_cmake_scripts_by_gn.py
+++ b/tools/android_tools/generate_cmake_scripts_by_gn.py
@@ -20,14 +20,14 @@ ANDROID_GN_ARGS_FILE_NAME = "gn_args.json"
 
 def android_target_cpu(variant_type):
   target_cpu = ''
-  if 'x86' in variant_type:
-    target_cpu = 'x86'
+  if 'x86_64' in variant_type:
+    target_cpu = 'x64'
   elif 'armeabi-v7a' in variant_type or 'armeabi' in variant_type:
     target_cpu = 'arm'
   elif 'mips' in variant_type:
     target_cpu = 'mipsel'
-  elif 'x86_64' in variant_type:
-    target_cpu = 'x64'
+  elif 'x86' in variant_type:
+    target_cpu = 'x86'
   elif 'arm64-v8a' in variant_type:
     target_cpu = 'arm64'
   elif 'mips64' in variant_type:

--- a/tools/rtf/core/template/android_ut_template.py
+++ b/tools/rtf/core/template/android_ut_template.py
@@ -8,7 +8,7 @@ builder = {
             "--parallel",
             "--configure-on-demand",
             "-x lint",
-            "-Pbuild_for_emu",
+            "-PabiList=x86",
             "-Penable_lynx_android_test=true",
             "-Penable_coverage=true",
         ],


### PR DESCRIPTION
…droid platform

1. Update primjs, debugrouter, v8so version with x86_64 achitecture.

2. Modify the methods for setting the native build architecture in Lynx and Explorer, and add a Gradle parameter named abiList.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
