### PR TITLE
[BugFix] Fix crash in SplitStringByCharsOrderly when input string con…

### DIFF
--- a/base/src/string/string_utils.cc
+++ b/base/src/string/string_utils.cc
@@ -390,7 +390,7 @@ base::InlineVector<std::string, 32> SplitStringByCharsOrderly(
       if (word_count && word_start >= 0 &&
           static_cast<size_t>(word_start) + static_cast<size_t>(word_count) <=
               size) {
-        grouper.emplace_back(byte_array, static_cast<size_t>(word_start),
+        grouper.emplace_back(str, static_cast<size_t>(word_start),
                              static_cast<size_t>(word_count));
       } else {
         grouper.emplace_back();

--- a/base/src/string/string_utils_unittest.cc
+++ b/base/src/string/string_utils_unittest.cc
@@ -178,6 +178,18 @@ TEST(SplitStringByCharsOrderlyTest, SplitStringByCharsOrderly) {
   ASSERT_EQ(result, expected);
 }
 
+TEST(SplitStringByCharsOrderlyTest,
+     SplitStringByCharsOrderlyWithNullCharacter) {
+  std::string input("background-\0image: {x:\0xx}", 26);
+  ;
+  base::Vector<std::string> expected;
+
+  auto result = SplitStringByCharsOrderly<':', ';'>(input);
+  expected = {std::string("background-\0image", 17),
+              std::string(" {x:\0xx}", 8)};
+  ASSERT_EQ(result, expected);
+}
+
 TEST(U8StringToU16Test, U8StringToU16) {
   std::vector<std::string> input;
   std::vector<std::u16string> expected;


### PR DESCRIPTION
## Summary

Here is a crash on Android.

> backtrace: 
    00 abort+164 
    01  std::__ndk1::__throw_out_of_range(char const*) at stdexcept:265 
            (inlined by) std::__ndk1::__basic_string_common<true>::__throw_out_of_range() const at string:616 
            (inlined by) std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >::basic_string(std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > const&, unsigned long, unsigned long, std::__ndk1::allocator<char> const&) at string:1952 
    02 std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >& lynx::base::Vector<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> > >::emplace_back<char const*&, unsigned long, unsigned long>(char const*&, unsigned long&&, unsigned long&&) at vector.h:616 
 (inlined by) lynx::base::SplitStringByCharsOrderly(std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >, char*, unsigned long) at string_utils.cc:393 
            (inlined by) auto lynx::base::SplitStringByCharsOrderly<(char)58, (char)59>(std::__ndk1::basic_string_view<char, std::__ndk1::char_traits<char> >) at string_utils.h:146 
    03 lynx::tasm::RendererFunctions::SetDynamicStyleTo(lynx::lepus::Context*, lynx::lepus::Value*, int) at renderer_functions.cc

```cpp
base::InlineVector<std::string, 32> SplitStringByCharsOrderly(
    std::string_view str, char cs[], size_t char_count) {
    const char* byte_array = str.data();
    const size_t size = str.size();
    ...
    grouper.emplace_back(byte_array, static_cast<size_t>(word_start), static_cast<size_t>(word_count));
}
```
The constructor that will be called in `emplace_back` here is `std::string(const std::string&, size_t, size_t)`.

If the input `str` contained a `\0` character, the implicit construction of `std::string` from `byte_array` would truncate at `\0`. 

If `word_start` is located after `\0`, an `out_of_range` exception will be thrown.

This fix ensures `std::string_view` is used instead, preserving the entire input and preventing unintended truncation.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
