### PR TITLE
[Infra] fix the issue of hab sync DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -74,7 +74,7 @@ deps = {
         'type': 'git',
         'url': 'https://github.com/iqiyi/xHook.git',
         'commit': 'e59285034feadfdd4ba9b65e1eea1d381da83ed3',
-        "patches": os.path.join(root_dir, 'dependencies', 'patches', 'xhook', '0001-Infra-Add-BUILD.gn-file-of-xhook.patch'),        
+        "patches": os.path.join(root_dir, 'patches', 'xhook', '0001-Infra-Add-BUILD.gn-file-of-xhook.patch'),        
         "ignore_in_git": True,
     },    
     'copy_root_gn_config': {
@@ -189,7 +189,7 @@ deps = {
         'type': 'git',
         'url': 'https://chromium.googlesource.com/chromium/src/third_party/zlib',
         'commit': 'f5fd0ad2663e239a31184ad4c9919991dda16f46',
-        "patches": os.path.join(root_dir, 'dependencies', 'patches', 'zlib', '0001-Adapt-zlib-to-the-Lynx-project.patch'),         
+        "patches": os.path.join(root_dir, 'patches', 'zlib', '0001-Adapt-zlib-to-the-Lynx-project.patch'),         
         "ignore_in_git": True,
     },
     'third_party/NativeScript/include': {


### PR DESCRIPTION
During hab sync, incorrect paths were used when applying xhook and zlib patches. Now fix it.

issue:m-5927693108

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
