### PR TITLE
[Optimize] Add whiteboard instance for lynxEngine if LynxGroup not set.

### DIFF
--- a/core/shell/lynx_shell_builder.cc
+++ b/core/shell/lynx_shell_builder.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "core/services/event_report/event_tracker_platform_impl.h"
+#include "core/shared_data/lynx_white_board.h"
 
 namespace lynx {
 namespace shell {
@@ -328,9 +329,10 @@ std::unique_ptr<lynx::shell::LynxEngine> LynxShellBuilder::CreateLynxEngine(
     tasm->SetLazyBundleLoader(this->loader_);
   }
 
-  if (this->white_board_ != nullptr) {
-    tasm->SetWhiteBoard(this->white_board_);
+  if (this->white_board_ == nullptr) {
+    this->white_board_ = std::make_shared<tasm::WhiteBoard>();
   }
+  tasm->SetWhiteBoard(this->white_board_);
 
   if (!this->locale_.empty()) {
     tasm->SetLocale(this->locale_);


### PR DESCRIPTION
`WhiteBoard` is a concept that used to communicate between multiple lynxViews, but in some cases users may just need to communicate between lepus/js/client in single LynxEngine instance. so we need to dispatch a single whiteboard instance even if lynxgroup is not set.

- create a new whiteboard instance if lynx_shell_builder is init with nullptr whiteboard.

AutoSubmit: true
issue: f-2923478

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
