### PR TITLE
[BugFix][Explorer][Android]: Fixes ViewShell back button, to handle navigating back

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -87,6 +87,15 @@ public class LynxViewShellActivity extends AppCompatActivity {
     super.onDestroy();
   }
 
+  @Override
+  public boolean onOptionsItemSelected(MenuItem item) {
+    if (item.getItemId() == android.R.id.home) {
+      finish();
+      return true;
+    }
+    return super.onOptionsItemSelected(item);
+  }
+
   private String getStorageItem(String key) {
     SharedPreferences p = this.getSharedPreferences(PREFERENCES, Context.MODE_PRIVATE);
     String value = p.getString(key, null);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary
Back button in the explorer app works on iOS but not on Android. 
Though physical back button works, but not the UI one `<` 


https://github.com/user-attachments/assets/44ae73bb-b9da-4862-a7a3-ff3fa235061e


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required). - NA
- [x] Documentation updated (or not required). - NA
