### PR TITLE
[BugFix][Explorer][iOS]: Fixes the input's placeholder's text color

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/input/LynxExplorerInput.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/input/LynxExplorerInput.m
@@ -61,7 +61,18 @@ LYNX_PROP_SETTER("value", setValue, NSString *) { self.view.text = value; }
 LYNX_PROP_SETTER("placeholder", setPlaceholder, NSString *) { self.view.placeholder = value; }
 
 LYNX_PROP_SETTER("text-color", setTextColor, NSString *) {
-  self.view.textColor = [UIHelper colorWithHexString:value];
+  UIColor *textColor = [UIHelper colorWithHexString:value];
+  self.view.textColor = textColor;
+
+  UIColor *placeholderColor = [textColor colorWithAlphaComponent:0.4];
+  if (@available(iOS 13.0, *)) {
+    NSAttributedString *attributedPlaceholder = [[NSAttributedString alloc]
+        initWithString:self.view.placeholder ?: @""
+            attributes:@{NSForegroundColorAttributeName : placeholderColor}];
+    self.view.attributedPlaceholder = attributedPlaceholder;
+  } else {
+    [self.view setValue:placeholderColor forKeyPath:@"_placeholderLabel.textColor"];
+  }
 }
 
 - (void)textFieldDidChange:(NSNotification *)notification {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary
Fixes https://github.com/lynx-family/lynx/issues/361

Before 
<img width="300" alt="Screenshot 2025-03-16 at 00 26 41" src="https://github.com/user-attachments/assets/8e7e0541-6cd7-4bab-a219-5b6e8fde830a" />

After this fix
<img width="300" alt="Screenshot 2025-03-16 at 01 05 57" src="https://github.com/user-attachments/assets/4186b795-f843-4136-87e4-d4e8e2830d93" />


We do update the placeholder text color on Android, but not on iOS
Here's the logic on Android - https://github.com/lynx-family/lynx/blob/develop/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/input/LynxExplorerInput.java#L111-L112

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
