### PR TITLE
[Infra][Optimize] create or reuse venv if no yaml installed in current python env

### DIFF
--- a/tools/build_jni/generate_jni.sh
+++ b/tools/build_jni/generate_jni.sh
@@ -15,13 +15,21 @@ python3 -c "import yaml"
 if [ $? -eq 0 ]; then
     echo "PyYAML installed"
 else
-    echo "PyYAML is not installed"
-    pip3 install PyYAML
-    python3 -c "import yaml"
-    if [ $? -eq 0 ]; then
-        echo "PyYAML installed successfully"
+    echo "PyYAML is not installed, try to use venv"
+    VENV_PATH=$CURRENT_PATH/../../.venv
+    if [ -d $VENV_PATH ]; then
+        echo "venv already exists, reuse it"
     else
-        echo "PyYAML installation failed"
+        echo "venv not exists, create it"
+        python3 -m venv $VENV_PATH
+    fi
+    source $VENV_PATH/bin/activate
+    pip3 install PyYAML
+    if [ $? -eq 0 ]; then
+        echo "PyYAML in venv installed successfully"
+    else
+        echo "PyYAML in venv installation failed, please install it manually."
+        exit 1
     fi
 fi
 for index in $(seq 0 $(($ANDROID_NAME_LENGTH - 1)))


### PR DESCRIPTION
The jni generation process depends on the `PyYAML` module, the script will try to install the module when it is not found in the current env, but it leads some issues:

1. pollute the global python env
2. may face failure due to PEP-668
3. although the documentation mentions that users need venv, when running directly through Android Studio, it cannot inherit it.

This patch fixes this create venv if it is not present in the current python env, and will check & reuse the previous venv.
