### PR TITLE
[BugFix] using `strong` for contextDict

### DIFF
--- a/platform/darwin/common/lynx/LynxConfig.mm
+++ b/platform/darwin/common/lynx/LynxConfig.mm
@@ -44,7 +44,9 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)init)
   }
   [_contextDict addEntriesFromDictionary:ctxDict];
   _moduleFactoryPtr->registerExtraInfo(ctxDict);
-  _moduleFactoryPtr->registerMethodSession(sessionInfo);
+  if (sessionInfo) {
+    _moduleFactoryPtr->registerMethodSession(sessionInfo);
+  }
 }
 
 - (std::shared_ptr<lynx::piper::ModuleFactoryDarwin>)moduleFactoryPtr {

--- a/platform/darwin/common/lynx/public/LynxConfig.h
+++ b/platform/darwin/common/lynx/public/LynxConfig.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, readonly) id<LynxTemplateProvider> templateProvider;
 @property(nonatomic) LynxComponentScopeRegistry *componentRegistry;
-@property(nonatomic, copy, nullable) NSMutableDictionary *contextDict;
+@property(nonatomic, strong, nullable) NSMutableDictionary *contextDict;
 
 /*! Set a global (default) config which will provide a convenient way
  for creating LynxView without LynxConfig. */

--- a/platform/darwin/ios/lynx/utils/LynxConfigProcessorUnitTest.m
+++ b/platform/darwin/ios/lynx/utils/LynxConfigProcessorUnitTest.m
@@ -118,4 +118,13 @@
   XCTAssertEqual(builder.bytecodeUrl, @"foo");
 }
 
+- (void)testRegisterContext {
+  LynxConfig *config = [[LynxConfig alloc] initWithProvider:nil];
+  config.contextDict = [[NSMutableDictionary alloc] init];
+
+  NSDictionary *dict = @{@"key" : @"value"};
+  [config registerContext:dict sessionInfo:nil];
+  XCTAssertEqual(config.contextDict[@"key"], @"value");
+}
+
 @end


### PR DESCRIPTION
`contextDict` in LynxConfig is of type `NSMutableDictionary`, using copy may caused the type to be a `NSDictionary` type. is's not a expected behaviour, since we will modify contextDict somewhere else.

issue: f-238576566
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
