### PR TITLE
[Optimize] Reducing Redundant Layout Calls in Synchronous Fetch Layout Result

### DIFF
--- a/core/renderer/ui_wrapper/layout/layout_context.h
+++ b/core/renderer/ui_wrapper/layout/layout_context.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "base/include/closure.h"
 #include "core/public/layout_ctx_platform_impl.h"
@@ -193,6 +194,10 @@ class LayoutContext : public std::enable_shared_from_this<LayoutContext>,
   void SetRecordId(int64_t record_id) { record_id_ = record_id; }
 #endif
 
+  void PauseLayout();
+
+  void ResumeLayout();
+
  private:
   class CircularLayoutDependencyDetector {
    public:
@@ -290,6 +295,12 @@ class LayoutContext : public std::enable_shared_from_this<LayoutContext>,
 
   LayoutContext(const LayoutContext&) = delete;
   LayoutContext& operator=(const LayoutContext&) = delete;
+
+  bool layout_paused_{false};
+
+  // Stores the pipeline options of all paused layouts,
+  // which will be used for layout upon resumption.
+  std::vector<PipelineOptions> pipeline_options_for_paused_layouts_{};
 };
 }  // namespace tasm
 }  // namespace lynx

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -661,9 +661,24 @@ void LynxShell::SyncFetchLayoutResult() {
 
   auto ui_loop = runners_.GetUITaskRunner()->GetLoop();
 
-  layout_runner->Bind(ui_loop, true);
+  // First, consume all potentially pending onLayoutAfter tasks,
+  // as ResumeLayout does not necessarily retrigger the layout afterward,
+  // also ensuring proper sequencing.
   layout_result_manager_->RunOnLayoutAfterTasks();
 
+  // Second, pause the layout to prevent multiple layout triggers
+  // while consuming pending tasks in the layout queue.
+  layout_actor_->Impl()->PauseLayout();
+
+  // Third, bind the layout queue to the current thread and
+  // clear all pending tasks in the layout queue.
+  layout_runner->Bind(ui_loop, true);
+
+  // Fourth, resume the layout.
+  // If there is a pending layout, it will be retriggered here.
+  layout_actor_->Impl()->ResumeLayout();
+
+  // Fifth, rebind the layout queue to the background thread.
   layout_runner->UnBind();
 
   layout_loop->PostTask(
@@ -671,8 +686,6 @@ void LynxShell::SyncFetchLayoutResult() {
       fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
 }
 
-// TODO(klaxxi): There may currently be two layout passes.
-// Optimization will be done later to skip the layout triggered in Bind.
 void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
                                                      int32_t width_mode,
                                                      float height,
@@ -687,29 +700,53 @@ void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
   auto ui_loop = runners_.GetUITaskRunner()->GetLoop();
 
   if (layout_result_manager_ == nullptr) {
+    // TODO(klaxxi): Remove the logic in this branch after
+    // passing the platform-level ForceLayoutOnBackgroundThread switch to
+    // LynxShell.
+    layout_actor_->Impl()->PauseLayout();
+
     layout_runner->Bind(ui_loop, true);
+
     tasm_operation_queue_->SetAppendPendingTaskNeededDuringFlush(true);
 
     UpdateViewport(width, width_mode, height, height_mode);
 
-    TriggerLayout();
+    layout_actor_->Impl()->ResumeLayout();
 
     layout_runner->UnBind();
     tasm_operation_queue_->SetAppendPendingTaskNeededDuringFlush(false);
+
+    layout_loop->PostTask(
+        [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
+        fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
   } else {
-    layout_runner->Bind(ui_loop, true);
+    // First, consume all potentially pending onLayoutAfter tasks,
+    // as ResumeLayout does not necessarily retrigger the layout afterward,
+    // also ensuring proper sequencing.
     layout_result_manager_->RunOnLayoutAfterTasks();
 
+    // Second, pause the layout, as a layout must always be retriggered
+    // after updateViewport, making any layout triggered while consuming
+    // pending tasks in the layout queue redundant.
+    layout_actor_->Impl()->PauseLayout();
+
+    // Third, bind the layout queue to the current thread and
+    // clear all pending tasks in the layout queue.
+    layout_runner->Bind(ui_loop, true);
+
+    // Fourth, update the viewport and resume the layout,
+    // which will retrigger the layout here.
     UpdateViewport(width, width_mode, height, height_mode);
 
-    TriggerLayout();
+    layout_actor_->Impl()->ResumeLayout();
 
+    // Fifth, rebind the layout queue to the background thread.
     layout_runner->UnBind();
-  }
 
-  layout_loop->PostTask(
-      [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
-      fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
+    layout_loop->PostTask(
+        [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
+        fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
+  }
 }
 
 void LynxShell::SendCustomEvent(const std::string& name, int32_t tag,


### PR DESCRIPTION
    During the synchronous retrieval of layout results, multiple layout executions might occur.
    
    This optimization pauses the layout process at the beginning and triggers a single layout execution
    at the end, ensuring that only one layout operation is performed during synchronous retrieval.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
