### PR TITLE
[BugFix] Fix the issue where dependent parties inject the log functio…

### DIFF
--- a/core/base/android/logging_android.cc
+++ b/core/base/android/logging_android.cc
@@ -57,8 +57,6 @@ void PrintLogMessageByLogDelegate(LogMessage* msg, const char* tag) {
 
 bool RegisterJNI(JNIEnv* env) { return RegisterNativesImpl(env); }
 
-long GetALogPtr(JNIEnv* env) { return Java_LLog_getALogPtr(env); }
-
 void InitLynxLog() {
   InitLynxLogging(InitAlog, PrintLogMessageByLogDelegate,
                   tasm::LynxEnv::GetInstance().IsDevToolEnabled());

--- a/core/base/android/logging_android.h
+++ b/core/base/android/logging_android.h
@@ -16,8 +16,6 @@ namespace logging {
 
 BASE_EXPORT_FOR_DEVTOOL bool RegisterJNI(JNIEnv* env);
 
-BASE_EXPORT_FOR_DEVTOOL long GetALogPtr(JNIEnv* env);
-
 BASE_EXPORT_FOR_DEVTOOL void InitLynxLog();
 
 }  // namespace logging

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/base/LLog.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/base/LLog.java
@@ -34,7 +34,6 @@ public class LLog {
 
   private static AbsLogDelegate sDebugLoggingDelegate;
   private static int sALogMinLogLevel = BuildConfig.DEBUG ? DEBUG : INFO;
-  private static long alogNativePtr = 0;
 
   private static boolean sIsNativeLibLoad = false;
   private static final int sDefaultRuntimeId = -1;
@@ -276,7 +275,7 @@ public class LLog {
       address = service.getDefaultWriteFunction();
     }
     if (address != 0) {
-      initALog(address);
+      nativeInitALogNative(address);
       Log.i(TAG, "LynxLog dependency load successfully. function native address is " + address);
       return;
     }
@@ -289,10 +288,8 @@ public class LLog {
     }
   }
 
-  public static void initALog(long addr) {
-    alogNativePtr = addr;
-    nativeInitALogNative(addr);
-  }
+  @Deprecated
+  public static void initALog(long addr) {}
 
   private static native void nativeSetNativeMinLogLevel(int level);
   private static native void nativeInitALogNative(long addr);
@@ -344,11 +341,6 @@ public class LLog {
   private static void logByte(int priority, String tag, byte[] msg, int source, long runtimeId,
       int channelType, int messageStart) {
     log(priority, tag, new String(msg), source, runtimeId, channelType, messageStart);
-  }
-
-  @CalledByNative
-  private static long getALogPtr() {
-    return alogNativePtr;
   }
 
   // deprecated functions


### PR DESCRIPTION
…n address through means other than LynxLogService.

1. Only allow LynxLogService to inject the log proxy function address, therefore mark the `initALog()` API as deprecated and remove its implementation.
2. Remove the unused `getALogPtr()` API and `alogNativePtr` variable.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
