### PR TITLE
[Optimize] Pass ForceLayoutOnBackgroundThread Flag to LynxShell

### DIFF
--- a/core/shell/android/lynx_template_render_android.cc
+++ b/core/shell/android/lynx_template_render_android.cc
@@ -190,7 +190,8 @@ jlong Create(JNIEnv* env, jclass jcaller, jlong timing_collector_android,
              jboolean enable_async_hydration, jboolean enable_js_group_thread,
              jstring js_group_thread_name, jobject tasm_platform_invoker,
              jlong white_board_ptr, jlong ui_delegate_ptr,
-             jboolean use_invoke_ui_method) {
+             jboolean use_invoke_ui_method,
+             jboolean force_layout_on_background_thread) {
   auto* ui_delegate =
       reinterpret_cast<lynx::tasm::UIDelegate*>(ui_delegate_ptr);
 
@@ -267,6 +268,7 @@ jlong Create(JNIEnv* env, jclass jcaller, jlong timing_collector_android,
               std::make_unique<lynx::shell::TasmPlatformInvokerAndroid>(
                   env, tasm_platform_invoker))
           .SetTimingCollectorPlatform(sp_timing_collector_android)
+          .SetForceLayoutOnBackgroundThread(force_layout_on_background_thread)
           .build());
 }
 

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -711,6 +711,8 @@ void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
                                                      int32_t width_mode,
                                                      float height,
                                                      int32_t height_mode) {
+  DCHECK(layout_result_manager_ != nullptr);
+
   DCHECK(runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   DCHECK(runners_.GetTASMTaskRunner()->RunsTasksOnCurrentThread());
   DCHECK(!runners_.GetLayoutTaskRunner()->RunsTasksOnCurrentThread());
@@ -720,54 +722,32 @@ void LynxShell::LayoutImmediatelyWithUpdatedViewport(float width,
 
   auto ui_loop = runners_.GetUITaskRunner()->GetLoop();
 
-  if (layout_result_manager_ == nullptr) {
-    // TODO(klaxxi): Remove the logic in this branch after
-    // passing the platform-level ForceLayoutOnBackgroundThread switch to
-    // LynxShell.
-    layout_actor_->Impl()->PauseLayout();
+  // First, consume all potentially pending onLayoutAfter tasks,
+  // as ResumeLayout does not necessarily retrigger the layout afterward,
+  // also ensuring proper sequencing.
+  layout_result_manager_->RunOnLayoutAfterTasks();
 
-    layout_runner->Bind(ui_loop, true);
+  // Second, pause the layout, as a layout must always be retriggered
+  // after updateViewport, making any layout triggered while consuming
+  // pending tasks in the layout queue redundant.
+  layout_actor_->Impl()->PauseLayout();
 
-    tasm_operation_queue_->SetAppendPendingTaskNeededDuringFlush(true);
+  // Third, bind the layout queue to the current thread and
+  // clear all pending tasks in the layout queue.
+  layout_runner->Bind(ui_loop, true);
 
-    UpdateViewport(width, width_mode, height, height_mode);
+  // Fourth, update the viewport and resume the layout,
+  // which will retrigger the layout here.
+  UpdateViewport(width, width_mode, height, height_mode);
 
-    layout_actor_->Impl()->ResumeLayout();
+  layout_actor_->Impl()->ResumeLayout();
 
-    layout_runner->UnBind();
-    tasm_operation_queue_->SetAppendPendingTaskNeededDuringFlush(false);
+  // Fifth, rebind the layout queue to the background thread.
+  layout_runner->UnBind();
 
-    layout_loop->PostTask(
-        [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
-        fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
-  } else {
-    // First, consume all potentially pending onLayoutAfter tasks,
-    // as ResumeLayout does not necessarily retrigger the layout afterward,
-    // also ensuring proper sequencing.
-    layout_result_manager_->RunOnLayoutAfterTasks();
-
-    // Second, pause the layout, as a layout must always be retriggered
-    // after updateViewport, making any layout triggered while consuming
-    // pending tasks in the layout queue redundant.
-    layout_actor_->Impl()->PauseLayout();
-
-    // Third, bind the layout queue to the current thread and
-    // clear all pending tasks in the layout queue.
-    layout_runner->Bind(ui_loop, true);
-
-    // Fourth, update the viewport and resume the layout,
-    // which will retrigger the layout here.
-    UpdateViewport(width, width_mode, height, height_mode);
-
-    layout_actor_->Impl()->ResumeLayout();
-
-    // Fifth, rebind the layout queue to the background thread.
-    layout_runner->UnBind();
-
-    layout_loop->PostTask(
-        [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
-        fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
-  }
+  layout_loop->PostTask(
+      [layout_runner, layout_loop]() { layout_runner->Bind(layout_loop); },
+      fml::TimePoint::Now(), fml::TaskSourceGrade::kEmergency);
 }
 
 void LynxShell::SendCustomEvent(const std::string& name, int32_t tag,

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnv.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnv.java
@@ -882,8 +882,8 @@ public class LynxEnv {
     return getBooleanFromExternalEnv(LynxEnvKey.ENABLE_VSYNC_ALIGNED_MESSAGE_LOOP_GLOBAL, false);
   }
 
-  public boolean enableLayoutOnBackgroundThread() {
-    return getBooleanFromExternalEnv(LynxEnvKey.ENABLE_LAYOUT_ON_BACKGROUND_THREAD, false);
+  public boolean shouldForceLayoutOnBackgroundThread() {
+    return getBooleanFromExternalEnv(LynxEnvKey.FORCE_LAYOUT_ON_BACKGROUND_THREAD, false);
   }
 
   public boolean isLayoutOnlyEnabled() {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnvKey.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnvKey.java
@@ -22,7 +22,7 @@ public enum LynxEnvKey {
   DEVTOOL_COMPONENT_ATTACH("devtool_component_attach"),
   ENABLE_GENERIC_LYNX_RESOURCE_FETCHER_FONT_KEY("enable_generic_lynx_resource_fetcher_font"),
   ENABLE_VSYNC_ALIGNED_MESSAGE_LOOP_GLOBAL("enable_vsync_aligned_message_loop_global"),
-  ENABLE_LAYOUT_ON_BACKGROUND_THREAD("enable_layout_on_background_thread"),
+  FORCE_LAYOUT_ON_BACKGROUND_THREAD("force_layout_on_background_thread"),
   ENABLE_REPORT_CREATE_ASYNC_TAG("enable_report_create_async_tag"),
   ENABLE_SVG_ASYNC("enable_svg_async"),
   ENABLE_IMAGE_EVENT_REPORT("enable_image_event_report"),

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -209,7 +209,8 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
 
   private boolean mEnableSyncFlush;
 
-  private boolean mEnableLayoutOnBackgroundThread = LynxEnv.inst().enableLayoutOnBackgroundThread();
+  private boolean mForceLayoutOnBackgroundThread =
+      LynxEnv.inst().shouldForceLayoutOnBackgroundThread();
 
   private boolean mEnableJSRuntime;
 
@@ -303,13 +304,13 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
     mAsyncRender = (mThreadStrategyForRendering == ThreadStrategyForRendering.MULTI_THREADS
         || mThreadStrategyForRendering == ThreadStrategyForRendering.MOST_ON_TASM);
 
-    // force disabling mEnableLayoutOnBackgroundThread when mAutoConcurrency is enabled.
+    // force disabling mForceLayoutOnBackgroundThread when mAutoConcurrency is enabled.
     if (mAutoConcurrency) {
-      mEnableLayoutOnBackgroundThread = false;
+      mForceLayoutOnBackgroundThread = false;
     }
 
-    // Force enabling layout thread when mEnableLayoutOnBackgroundThread is enabled.
-    if (mEnableLayoutOnBackgroundThread) {
+    // Force enabling layout thread when mForceLayoutOnBackgroundThread is enabled.
+    if (mForceLayoutOnBackgroundThread) {
       mThreadStrategyForRendering = mAsyncRender ? ThreadStrategyForRendering.MULTI_THREADS
                                                  : ThreadStrategyForRendering.PART_ON_LAYOUT;
     }
@@ -403,7 +404,7 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
     // use screen width as width measure spec by default
     // in order to avoid relayout when onMeasure in the maximum extent.
     // TODO(heshan): consider use screen width by default to avoid relayout
-    if ((mAutoConcurrency || mEnableLayoutOnBackgroundThread) && widthMeasureSpec == 0
+    if ((mAutoConcurrency || mForceLayoutOnBackgroundThread) && widthMeasureSpec == 0
         && heightMeasureSpec == 0) {
       widthMeasureSpec = View.MeasureSpec.makeMeasureSpec(
           mLynxContext.getResources().getDisplayMetrics().widthPixels, View.MeasureSpec.EXACTLY);
@@ -688,7 +689,8 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
             || LynxEnv.inst().enableVSyncAlignedMessageLoopGlobal(),
         mLynxViewBuilder.enableAsyncHydration, mGroup != null && mGroup.enableJSGroupThread(),
         getJSGroupThreadNameIfNeed(), new TasmPlatformInvoker(mNativeFacade), whiteBoardPtr,
-        lynxUIRenderer.getUIDelegatePtr(), lynxUIRenderer.useInvokeUIMethod());
+        lynxUIRenderer.getUIDelegatePtr(), lynxUIRenderer.useInvokeUIMethod(),
+        mForceLayoutOnBackgroundThread);
     lynxUIRenderer.attachNativeFacade(mNativeFacade);
     mNativeLifecycle = nativeLifecycleCreate();
     mCleanupReference = new CleanupReference(this, new CleanupOnUiThread(mNativeLifecycle), true);
@@ -1644,7 +1646,7 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
     }
     onTraceEventBegin(eventName);
 
-    if (mEnableLayoutOnBackgroundThread && !mAsyncRender) {
+    if (mForceLayoutOnBackgroundThread && !mAsyncRender) {
       maybeSyncLayoutResultDuringLayoutOnBackgroundThread(widthMeasureSpec, heightMeasureSpec);
     } else {
       if (mEnableSyncFlush) {
@@ -3342,7 +3344,8 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
       boolean enablePreUpdateData, boolean enableAutoConcurrency,
       boolean enableVSyncAlignedMessageLoop, boolean enableAsyncHydration,
       boolean enableJSGroupThread, String jsGroupThreadName, Object tasmPlatformInvoker,
-      long whiteboard, long uiDelegate, boolean useInvokeUIMethod);
+      long whiteboard, long uiDelegate, boolean useInvokeUIMethod,
+      boolean forceLayoutOnBackgroundThread);
 
   private static native void nativeDestroy(long ptr);
 


### PR DESCRIPTION
The ForceLayoutOnBackgroundThread flag is now passed to LynxShell to ensure proper control over background thread layout execution.

Additionally, all related methods and variable names along the call chain have been standardized to ForceLayoutOnBackgroundThread for consistency.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
