### PR TITLE
[Optimize] enable primsjs runtime checker.

### DIFF
--- a/core/renderer/template_entry.cc
+++ b/core/renderer/template_entry.cc
@@ -85,6 +85,12 @@ bool TemplateEntry::ConstructContext(TemplateAssembler* assembler,
         lepus::Context::CreateContext(is_lepusng_binary, disable_tracing_gc);
   }
 
+  // TODO(nihao.royal): maybe add a platform interface to enable the checker
+  // later;
+  if (LynxEnv::GetInstance().IsDevToolEnabled()) {
+    vm_context_->EnableRuntimeLeakCheck(true);
+  }
+
   if (!vm_context_) {
     return false;
   }

--- a/core/runtime/vm/lepus/context.h
+++ b/core/runtime/vm/lepus/context.h
@@ -232,6 +232,8 @@ class Context {
 
   const std::string& GetDebugInfoURL() { return debug_info_url_; }
 
+  virtual void EnableRuntimeLeakCheck(bool enable){};
+
  protected:
   virtual Value CallArgs(const base::String& name, const Value* args[],
                          size_t args_count, bool pause_suppression_mode) = 0;

--- a/core/runtime/vm/lepus/quick_context.cc
+++ b/core/runtime/vm/lepus/quick_context.cc
@@ -995,6 +995,10 @@ lepus::Value QuickContext::GetCurrentThis(lepus::Value* argv, int32_t offset) {
   return lepus::Value(context(), current_this_);
 }
 
+void QuickContext::EnableRuntimeLeakCheck(bool enable) {
+  SetObjectCtxCheckStatus(context(), enable);
+}
+
 #if ENABLE_TRACE_PERFETTO
 void QuickContext::SetRuntimeProfiler(
     std::shared_ptr<profile::RuntimeProfiler> runtime_profile) {
@@ -1002,7 +1006,6 @@ void QuickContext::SetRuntimeProfiler(
   profile::RuntimeProfilerManager::GetInstance()->AddRuntimeProfiler(
       runtime_profiler_);
 }
-
 void QuickContext::RemoveRuntimeProfiler() {
   profile::RuntimeProfilerManager::GetInstance()->RemoveRuntimeProfiler(
       runtime_profiler_);

--- a/core/runtime/vm/lepus/quick_context.h
+++ b/core/runtime/vm/lepus/quick_context.h
@@ -168,6 +168,8 @@ class QuickContext : private LEPUSRuntimeData, public Context {
   void RemoveRuntimeProfiler();
 #endif
 
+  virtual void EnableRuntimeLeakCheck(bool enable) override;
+
  private:
   virtual Value CallArgs(const base::String& name, const Value* args[],
                          size_t args_count,

--- a/core/runtime/vm/lepus/vm_context.cc
+++ b/core/runtime/vm/lepus/vm_context.cc
@@ -1541,5 +1541,9 @@ lepus::Value VMContext::GetCurrentThis(lepus::Value* argv, int32_t offset) {
   return *(argv + offset);
 }
 
+void VMContext::EnableRuntimeLeakCheck(bool enable) {
+  // VMContext does not support `SetObjectCtxCheckStatus`;
+}
+
 }  // namespace lepus
 }  // namespace lynx

--- a/core/runtime/vm/lepus/vm_context.h
+++ b/core/runtime/vm/lepus/vm_context.h
@@ -153,6 +153,8 @@ class VMContext : public Context {
   virtual lepus::Value GetCurrentThis(lepus::Value* argv,
                                       int32_t offset) override;
 
+  virtual void EnableRuntimeLeakCheck(bool enable) override;
+
   class DebugDelegate {
    public:
     virtual ~DebugDelegate() = default;

--- a/explorer/darwin/ios/lynx_explorer/Podfile
+++ b/explorer/darwin/ios/lynx_explorer/Podfile
@@ -37,7 +37,7 @@ target 'LynxExplorer' do
     'Http',
   ]
 
-  pod 'PrimJS', '2.11.1-rc.1', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '2.11.1-rc.3', :subspecs => ['quickjs', 'napi']
 
   pod 'SDWebImage','5.15.5'
   pod 'SDWebImageWebPCoder', '0.11.0'

--- a/platform/android/lynx_android/build.gradle
+++ b/platform/android/lynx_android/build.gradle
@@ -310,8 +310,8 @@ dependencies {
     androidTestImplementation "com.google.auto.service:auto-service-annotations:1.0-rc5"
     androidTestAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
-    implementation 'org.lynxsdk.lynx:primjs:2.11.1-rc.2'
-    extractJNI 'org.lynxsdk.lynx:primjs:2.11.1-rc.2'
+    implementation 'org.lynxsdk.lynx:primjs:2.11.1-rc.4'
+    extractJNI 'org.lynxsdk.lynx:primjs:2.11.1-rc.4'
     extractJNI 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
     implementation project(':LynxJSSDK')


### PR DESCRIPTION
value passed across primjs runtime is not safe in lynx, it may cause many unexpected stability issues. in this commit, we upgrade primjs version to introduce runtime checker, it will detect the case value is passed across multiple runtimes.

the checker will be enable when devtool is enabled now, maybe we can add a platform interface for our users to enable the checker later.

issue: f-23957679047
AutoLand: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
