### PR TITLE
[BugFix] ensure WhiteBoard safety with uniqueLock

### DIFF
--- a/core/shared_data/lynx_white_board.cc
+++ b/core/shared_data/lynx_white_board.cc
@@ -77,7 +77,7 @@ void WhiteBoard::RegisterSharedDataListener(const WhiteBoardStorageType& type,
 void WhiteBoard::RemoveSharedDataListener(const WhiteBoardStorageType& type,
                                           const std::string& key,
                                           int32_t listener_id) {
-  fml::SharedLock lock(*listener_lock_[type]);
+  fml::UniqueLock lock(*listener_lock_[type]);
   auto& listener_map = listener_map_[type];
   auto listener_iter = listener_map.find(key);
   if (listener_iter != listener_map.end()) {


### PR DESCRIPTION
`unsubscribeSessionStorage` is a write operation that should be guaranteed by uniquelock.

AutoSubmit: true
issue: f-6167091971

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
