### PR TITLE
[BugFix] Fix LynxModule TestBench crash when InvokeMethod returns an error

### DIFF
--- a/core/runtime/bindings/jsi/modules/lynx_module_impl.cc
+++ b/core/runtime/bindings/jsi/modules/lynx_module_impl.cc
@@ -251,10 +251,12 @@ LynxModuleImpl::invokeMethod(const MethodMetadata& method, Runtime* rt,
   }
 
 #if ENABLE_TESTBENCH_RECORDER
-  tasm::recorder::NativeModuleRecorder::GetInstance().RecordFunctionCall(
-      name_.c_str(), method.name.c_str(), static_cast<uint32_t>(count), args,
-      callback_ids.data(), static_cast<uint32_t>(callback_ids.size()),
-      response.value(), rt, record_id_);
+  if (response.has_value()) {
+    tasm::recorder::NativeModuleRecorder::GetInstance().RecordFunctionCall(
+        name_.c_str(), method.name.c_str(), static_cast<uint32_t>(count), args,
+        callback_ids.data(), static_cast<uint32_t>(callback_ids.size()),
+        response.value(), rt, record_id_);
+  }
 #endif  // ENABLE_TESTBENCH_RECORDER
 
   timing_collector->EndPlatformMethodInvoke(invoke_facade_method_start);


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

Since calling the value method when base::excepted is unexcepted is undefined behavior, it will cause TestBench to crash.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
