### PR TITLE
[Feature] Add CSS properties for linear layouts.

### DIFF
--- a/js_libraries/types/types/common/csstype.d.ts
+++ b/js_libraries/types/types/common/csstype.d.ts
@@ -41,7 +41,9 @@ export type CSSProperties = Modify<
     animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
     borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
     transformOrigin?: 'left' | 'right' | 'top' | 'bottom' | 'center' | (string & {});
+    linearDirection?: 'column' | 'row' | 'column-reverse' | 'row-reverse';
     linearOrientation?: 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse';
+    linearWeight?: number;
     linearGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'space-between' | 'start' | 'end' | 'center';
     linearLayoutGravity?:
       | 'none'


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary
Consider the following code
```js
<view
	style={{
		display: "linear",
		linearDirection: "row",
		linearWeight: 1,
	}}
>
</view>
```
Before my change Typescript would complain that linearDirection and linearWeight aren't CSSProperties. Now not only does Typescript not complain but we get full intellisense support providing a superior developer experience!

doc: https://lynxjs.org/guide/ui/layout/linear-layout.html
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ x ] Tests updated (or not required).
- [ x ] Documentation updated (or not required).
