### PR TITLE
[BugFix] Fix the issue that lynx sourceMap cannot be obtained

### DIFF
--- a/js_libraries/lynx-core/src/modules/report/reporter.ts
+++ b/js_libraries/lynx-core/src/modules/report/reporter.ts
@@ -63,9 +63,10 @@ export class Reporter {
   getSourceMapRelease = (url: string): string => {
     let ret = this.getNativeApp().__GetSourceMapRelease(url);
     if (!ret) {
-      return this.getNativeApp().__GetSourceMapRelease(
+      ret = this.getNativeApp().__GetSourceMapRelease(
         BaseApp.kDefaultSourceMapURL
       );
     }
+    return ret;
   };
 }


### PR DESCRIPTION
LynxCore does not return after calling the engine layer to get sourceMap.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
