### PR TITLE
[Testing][Devtool] Add covergae checker for lynx devtool cpp unittests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,7 @@ jobs:
           set -e
           source tools/envsetup.sh
           tools/rtf/rtf native-ut run --names devtool
+          tools/rtf/rtf coverage-check --type cpp --inputs out/coverage/lcov/lcov_summary.txt --threshold=0.5
 
   ios-unittests-check:
     runs-on: lynx-darwin-14-medium

--- a/.rtf/config
+++ b/.rtf/config
@@ -1,1 +1,1 @@
-plugins = ["NativeUT", "AndroidUT"]
+plugins = ["NativeUT", "AndroidUT", "CoverageChecker"]


### PR DESCRIPTION
Use the following command to perform unit test coverage detection `tools/rtf/rtf coverage-check --type cpp --inputs out/coverage/lcov/lcov_summary.txt --threshold=0.5`

- type : cpp, ios or android
- inputs: lcov file or xml
- threshold: Detection threshold

Change-Id: I6af62d7c164b083f9f02059e09370fe5779231e5

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
