### PR TITLE
[BugFix] fix thread-issue for whiteBoardListener.

### DIFF
--- a/core/shared_data/lynx_white_board.cc
+++ b/core/shared_data/lynx_white_board.cc
@@ -13,7 +13,8 @@
 namespace lynx {
 namespace tasm {
 
-WhiteBoard::WhiteBoard() {
+WhiteBoard::WhiteBoard()
+    : listeners_{static_cast<uint8_t>(WhiteBoardStorageType::COUNT)} {
   data_center_lock_ =
       std::unique_ptr<fml::SharedMutex>(fml::SharedMutex::Create());
   listener_lock_.emplace(
@@ -53,7 +54,7 @@ void WhiteBoard::TriggerListener(const WhiteBoardStorageType& type,
                                  const std::string& key,
                                  const pub::Value& value) {
   fml::SharedLock lock(*listener_lock_[type]);
-  auto& listener_map = listener_map_[type];
+  auto& listener_map = listeners_.at(static_cast<uint8_t>(type));
   auto listener_iter = listener_map.find(key);
   if (listener_iter != listener_map.end()) {
     // iterator over listeners and trigger callbacks;
@@ -69,7 +70,7 @@ void WhiteBoard::RegisterSharedDataListener(const WhiteBoardStorageType& type,
                                             const std::string& key,
                                             WhiteBoardListener listener) {
   fml::UniqueLock lock(*listener_lock_[type]);
-  auto& listener_map = listener_map_[type];
+  auto& listener_map = listeners_.at(static_cast<uint8_t>(type));
   auto pair = listener_map.emplace(key, std::vector<WhiteBoardListener>());
   pair.first->second.emplace_back(std::move(listener));
 }
@@ -78,7 +79,7 @@ void WhiteBoard::RemoveSharedDataListener(const WhiteBoardStorageType& type,
                                           const std::string& key,
                                           int32_t listener_id) {
   fml::UniqueLock lock(*listener_lock_[type]);
-  auto& listener_map = listener_map_[type];
+  auto& listener_map = listeners_.at(static_cast<uint8_t>(type));
   auto listener_iter = listener_map.find(key);
   if (listener_iter != listener_map.end()) {
     auto& listeners = listener_iter->second;

--- a/core/shared_data/lynx_white_board.h
+++ b/core/shared_data/lynx_white_board.h
@@ -23,7 +23,14 @@ namespace tasm {
  `set` `get` `registerListener` to whiteboard for sharing data between multiple
  lynxViews.
  */
-enum class WhiteBoardStorageType : uint8_t { TYPE_LEPUS, TYPE_JS, TYPE_CLIENT };
+enum class WhiteBoardStorageType : uint8_t {
+  TYPE_LEPUS = 0,
+  TYPE_JS,
+  TYPE_CLIENT,
+
+  // ADDED_BEBORE!!
+  COUNT
+};
 
 struct WhiteBoardListener {
   double callback_id;
@@ -69,8 +76,7 @@ class WhiteBoard final {
   std::unique_ptr<fml::SharedMutex> data_center_lock_;
   std::unordered_map<WhiteBoardStorageType, std::unique_ptr<fml::SharedMutex>>
       listener_lock_;
-  std::unordered_map<WhiteBoardStorageType, WhiteBoardListenerMap>
-      listener_map_;
+  std::vector<WhiteBoardListenerMap> listeners_;
 };
 
 }  // namespace tasm


### PR DESCRIPTION
`listener_map` in `WhiteBoard` now is not thread-safe, we need to pre-construct the map to avoid multi-thread calling `operator[]` causing crash.

AutoSubmit: true
issue: f-6167091971

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
