### PR TITLE
[BugFix] nativeApp.setCard called twice on web platform

### DIFF
--- a/js_libraries/lynx-core/package.json
+++ b/js_libraries/lynx-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/lynx-core",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Lynx JS environment initialization section, LynxCore will be pre-loaded before appService loading.",
   "type": "module",
   "main": "./dist/index.js",

--- a/js_libraries/lynx-core/src/appManager.ts
+++ b/js_libraries/lynx-core/src/appManager.ts
@@ -45,30 +45,16 @@ export function loadCard(
       `load card native app load app-service.js params.bundleSupportLoadScript ${params.bundleSupportLoadScript}`
     );
     loadSuccess = true;
-    if (__WEB__) {
-      tt.lynx.requireModuleAsync(APP_SERVICE_NAME, (error, ret) => {
-        if (error) {
-          tt.handleUserError(error);
-        } else {
-          if (tt.lynx._switches['allowUndefinedInNativeDataTypeSet']) {
-            tt.dataTypeSet.add('undefined');
-          }
-        }
-        nativeApp.setCard(tt);
-      });
-    }
-    if (!__WEB__) {
-      try {
-        delete tt.lynx.requireModule.cache[APP_SERVICE_NAME];
-        delete BaseApp._$factoryCache[APP_SERVICE_NAME];
-        tt.lynx.requireModule(APP_SERVICE_NAME, DEFAULT_ENTRY);
-        if (tt.lynx._switches['allowUndefinedInNativeDataTypeSet']) {
-          tt.dataTypeSet.add('undefined');
-        }
-      } catch (e) {
-        loadSuccess = false;
-        tt.handleUserError(e, undefined, undefined, 'loadCard failed');
+    try {
+      delete tt.lynx.requireModule.cache[APP_SERVICE_NAME];
+      delete BaseApp._$factoryCache[APP_SERVICE_NAME];
+      tt.lynx.requireModule(APP_SERVICE_NAME, DEFAULT_ENTRY);
+      if (tt.lynx._switches['allowUndefinedInNativeDataTypeSet']) {
+        tt.dataTypeSet.add('undefined');
       }
+    } catch (e) {
+      loadSuccess = false;
+      tt.handleUserError(e, undefined, undefined, 'loadCard failed');
     }
     nativeApp.setCard(tt);
   } catch (e) {


### PR DESCRIPTION
Before this commit L73 and L57 invoke twice `setCard`

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
