### PR TITLE
[BugFix] Catch JS and Native errors when loading JSON and call back t…

### DIFF
--- a/js_libraries/lynx-core/src/app/app.ts
+++ b/js_libraries/lynx-core/src/app/app.ts
@@ -531,9 +531,13 @@ export abstract class BaseApp<
     }
     // cache miss
     if (path.split('?')[0].endsWith('.json')) {
-      const content = this.nativeApp.readScript(path);
-      const ret = this._$executeJSON<T>(content, { path });
-      callback(null, ret);
+      try {
+        const content = this.nativeApp.readScript(path);
+        const ret = this._$executeJSON<T>(content, { path });
+        callback(null, ret);
+      } catch (e) {
+        callback(e);
+      }
       return;
     }
 


### PR DESCRIPTION

When using requireModuleAsync to load Json, there is no callback when the URL is wrong。This modification catch errors that occur when loading Json and calls back through the callback param

AutoSubmit: true

issue: #616

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
