### PR TITLE
[BugFix] Fix missing updateViewport call when content appears unchanged

### DIFF
--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -1697,6 +1697,8 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
   private void maybeSyncLayoutResultDuringLayoutOnBackgroundThread(
       int widthMeasureSpec, int heightMeasureSpec) {
     if (!mWillContentSizeChange) {
+      updateViewport(widthMeasureSpec, heightMeasureSpec);
+
       if (getEnableVsyncAlignedFlush()) {
         nativeFlush(mNativePtr, mNativeLifecycle);
       }


### PR DESCRIPTION
Even when the content does not change, the viewport may still need to be updated.

This commit ensures updateViewport is called in such cases to prevent rendering inconsistencies.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
