### PR TITLE
[BugFix] Ensure GlobalProps thread safe in UpdateMetaData api.

### DIFF
--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -506,12 +506,12 @@ void LynxShell::UpdateMetaData(const std::shared_ptr<tasm::TemplateData>& data,
                   pipeline_options.pipeline_start_timestamp);
   ThreadModeAutoSwitch auto_switch(thread_mode_manager_);
   EnsureTemplateDataThreadSafe(data);
-  EnsureGlobalPropsThreadSafe(global_props);
+  auto global_props_safe = EnsureGlobalPropsThreadSafe(global_props);
   auto order = ui_operation_queue_->UpdateNativeUpdateDataOrder();
   engine_actor_->Act(
-      [data, global_props, order,
-       pipeline_options = std::move(pipeline_options)](auto& engine) {
-        engine->UpdateMetaData(data, global_props, order,
+      [data, global_props = std::move(global_props_safe), order,
+       pipeline_options = std::move(pipeline_options)](auto& engine) mutable {
+        engine->UpdateMetaData(data, std::move(global_props), order,
                                std::move(pipeline_options));
       });
 }
@@ -1070,7 +1070,6 @@ void LynxShell::EnsureTemplateDataThreadSafe(
     const std::shared_ptr<tasm::TemplateData>& template_data) {
   // need clone template data if consumed by tasm thread
   if (template_data != nullptr && !(engine_actor_->CanRunNow())) {
-    LOGI("EnsureTemplateDataThreadSafe CloneValue." << this);
     template_data->CloneValue();
   }
 }
@@ -1080,7 +1079,6 @@ lepus::Value LynxShell::EnsureGlobalPropsThreadSafe(
   // need clone global props if consumed by tasm thread
   TRACE_EVENT(LYNX_TRACE_CATEGORY, "LynxShell::EnsureGlobalPropsThreadSafe");
   if (!(engine_actor_->CanRunNow())) {
-    LOGI("EnsureGlobalPropsThreadSafe CloneValue." << this);
     return lynx::lepus::Value::Clone(global_props);
   } else {
     return global_props;


### PR DESCRIPTION
`EnsureGlobalPropsThreadSafe` does not make input global_props thread-safe, we should pass the returned value to engine thread.

issue: f-6524437074
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
