### PR TITLE
[Optimize] Split PrepareVM logic from binary reader module.

### DIFF
--- a/core/renderer/dom/android/lynx_template_bundle_android.cc
+++ b/core/renderer/dom/android/lynx_template_bundle_android.cc
@@ -25,6 +25,7 @@ jlong ParseTemplate(JNIEnv* env, jclass jcaller, jbyteArray j_binary,
     // decode success.
     lynx::tasm::LynxTemplateBundle* bundle =
         new lynx::tasm::LynxTemplateBundle(reader.GetTemplateBundle());
+    bundle->PrepareVMByConfigs();
     return reinterpret_cast<int64_t>(bundle);
   } else {
     // decode failed.

--- a/core/template_bundle/lynx_template_bundle.cc
+++ b/core/template_bundle/lynx_template_bundle.cc
@@ -43,6 +43,25 @@ lepus::Value LynxTemplateBundle::GetExtraInfo() {
   return lepus::Value();
 }
 
+void LynxTemplateBundle::PrepareVMByConfigs() {
+  // Contexts cannot be pre-created in two cases:
+  // 1. not lepusNG
+  // 2. will reuse context (dynamic component && no-diff)
+  if (!is_lepusng_binary() || ShouldReuseLepusContext()) {
+    return;
+  }
+
+  quick_context_pool_ = lepus::QuickContextPool::Create(context_bundle_);
+
+  // if FE disables it in card, do not pre-create contexts. However, we reserve
+  // the ability for the client to force pre-creation
+  if (page_configs_ && page_configs_->GetEnableUseContextPool() &&
+      !page_configs_->GetDisableQuickTracingGC()) {
+    constexpr int32_t kLocalQuickContextPoolSize = 1;
+    quick_context_pool_->FillPool(kLocalQuickContextPoolSize);
+  }
+}
+
 bool LynxTemplateBundle::PrepareLepusContext(int32_t count) {
   if (!quick_context_pool_ || count <= 0) {
     return false;

--- a/core/template_bundle/lynx_template_bundle.h
+++ b/core/template_bundle/lynx_template_bundle.h
@@ -110,6 +110,10 @@ class LynxTemplateBundle final {
   bool ShouldReuseLepusContext() const;
 
   lepus::Value GetExtraInfo();
+
+  // Calling to prepare lepusNg context by pageConfig or settings;
+  // It should be called after decode success;
+  void PrepareVMByConfigs();
   bool PrepareLepusContext(int32_t count);
 
   bool EnableUseContextPool() const { return use_context_pool_; }

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_reader.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_reader.cc
@@ -72,7 +72,6 @@ bool LynxBinaryReader::DidDecodeTemplate() {
   tb.dynamic_component_moulds_ = std::move(dynamic_component_moulds_);
   tb.dynamic_component_declarations_ =
       std::move(dynamic_component_declarations_);
-  PrepareContext();
   return true;
 }
 
@@ -176,26 +175,6 @@ bool LynxBinaryReader::DecodeContext() {
   ERROR_UNLESS(tb.context_bundle_);
   ERROR_UNLESS(DecodeContextBundle(tb.context_bundle_.get()));
   return true;
-}
-
-void LynxBinaryReader::PrepareContext() {
-  // Contexts cannot be pre-created in two cases:
-  // 1. not lepusNG
-  // 2. will reuse context (dynamic component && no-diff)
-  auto& tb = template_bundle();
-  if (!tb.is_lepusng_binary() || tb.ShouldReuseLepusContext()) {
-    return;
-  }
-
-  tb.quick_context_pool_ = lepus::QuickContextPool::Create(tb.context_bundle_);
-
-  // if FE disables it in card, do not pre-create contexts. However, we reserve
-  // the ability for the client to force pre-creation
-  if (tb.page_configs_ && tb.page_configs_->GetEnableUseContextPool() &&
-      !tb.page_configs_->GetDisableQuickTracingGC()) {
-    constexpr int32_t kLocalQuickContextPoolSize = 1;
-    tb.quick_context_pool_->FillPool(kLocalQuickContextPoolSize);
-  }
 }
 
 bool LynxBinaryReader::DecodeParsedStylesSection() {

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_reader.h
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_reader.h
@@ -47,8 +47,7 @@ class LynxBinaryReader : public LynxBinaryBaseTemplateReader {
 
   // decode lepus
   virtual bool DecodeContext() override;
-  // in predecoding, try to create a context pool in advance
-  virtual void PrepareContext();
+
   // decode lepus chunk
   bool DecodeLepusChunkRoute();
   virtual bool DecodeLepusChunk() override;

--- a/core/template_bundle/template_codec/binary_decoder/template_binary_reader.h
+++ b/core/template_bundle/template_codec/binary_decoder/template_binary_reader.h
@@ -87,9 +87,6 @@ class TemplateBinaryReader : public LynxBinaryReader,
   bool GetCSSLazyDecode();
   bool GetCSSAsyncDecode();
 
-  // At runtime decoding, no need to prepare context
-  void PrepareContext() override {}
-
   virtual bool DidDecodeTemplate() override;
 
   // parsed styles

--- a/platform/darwin/common/lynx/LynxTemplateBundle.mm
+++ b/platform/darwin/common/lynx/LynxTemplateBundle.mm
@@ -36,6 +36,7 @@
       // decode success.
       template_bundle_ =
           std::make_shared<lynx::tasm::LynxTemplateBundle>(decoder.GetTemplateBundle());
+      template_bundle_->PrepareVMByConfigs();
     } else {
       // decode failed.
       _error = [NSString stringWithUTF8String:decoder.error_message_.c_str()];


### PR DESCRIPTION
previously we have supported VM PreCreate after binary decoded, we need to make binary_reader module more standalone, there should not be VM Create Logic here.

In this commit, we just move the logic to template bundle module.

issue: f-239048757677
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
