### PR TITLE
[BugFix][Android]: Fixes createUI catch error; due to missing Prop Setter in the Explorer app's input

### DIFF
--- a/platform/android/lynx_android/build.gradle
+++ b/platform/android/lynx_android/build.gradle
@@ -314,5 +314,5 @@ dependencies {
     extractJNI 'org.lynxsdk.lynx:primjs:2.11.1-rc.2'
     extractJNI 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
-    implementation project(':LynxJSSDK')
+    api project(':LynxJSSDK')
 }

--- a/platform/android/lynx_devtool/build.gradle
+++ b/platform/android/lynx_devtool/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-inline:4.8.1'
 
-    implementation project(':LynxJSSDK')
+    api project(':LynxJSSDK')
 
     implementation 'org.lynxsdk.lynx:debug-router:0.0.14'
     implementation 'org.lynxsdk.lynx:v8so:11.1.277.3'


### PR DESCRIPTION
Fixes https://github.com/lynx-family/lynx/issues/758
This reverts commit 9381a2d532832dbf7c072d100463c82b33697c30.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
