### PR TITLE
[BugFix] GetPageData should return with non-jsValue.

### DIFF
--- a/core/renderer/template_assembler.cc
+++ b/core/renderer/template_assembler.cc
@@ -1515,7 +1515,7 @@ lepus::Value TemplateAssembler::GetPageDataByKey(
     }
     return lepus::Value();
   }
-  return page_proxy()->GetDataByKey(keys);
+  return lepus::Value::Clone(page_proxy()->GetDataByKey(keys));
 }
 
 void TemplateAssembler::UpdateComponentData(const runtime::UpdateDataTask& task,


### PR DESCRIPTION
GetPageData may be called on child thread, which leads jsvalue passed to child thread causing crash. fix this issue by casting to lepusValue instantly.

AutoSubmit: true
issue: f-6563001688

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
