### PR TITLE
[Testing] Detect adb install timeout

### DIFF
--- a/tools/rtf/core/container/android_ut_container.py
+++ b/tools/rtf/core/container/android_ut_container.py
@@ -11,6 +11,9 @@ from core.target.observer import LogObserver, OwnersObserver
 from core.target.target_factory import TargetFactory
 from core.utils.emu_env_setup import EmulatorEnv
 from core.utils.log import Log
+from core.utils.result import Result
+from core.utils.constants import Constants
+from time import sleep
 
 
 class AndroidUTContainer(Container):
@@ -66,10 +69,29 @@ class AndroidUTContainer(Container):
             ["adb", "logcat", "-v", "time"], stdout=log_file, stderr=subprocess.STDOUT
         )
         for target in self.targets:
-            target.run()
+            result = target.run()
+            if (
+                result is not None
+                and result.is_err()
+                and result.code == Constants.ANDROID_APK_INSTALL_ERR
+            ):
+                Log.warning(
+                    f"{target.name} install apk error, try to restart emulator!"
+                )
+                self.emulator.close()
+                # The reason for needing a 10-second delay here is that the emulator takes time to shut down.
+                # During the shutdown process, the adb service may still be in a usable state. If an attempt
+                # is made to establish an adb connection at this time, it may result in an exception.
+                sleep(10)
+                self.emulator.prepare_android_emulator(
+                    use_real_device=self.use_real_device
+                )
+                result = target.run()
             if target.has_error():
                 for observer in self.observers:
                     observer.update(target)
                 Log.fatal(f"{target.name} has error!")
+            elif result is not None and result.is_err():
+                Log.fatal(f"{target.name} has error: {result.msg}")
             else:
                 Log.success(f"{target.name} success!")

--- a/tools/rtf/core/target/android_ut_target.py
+++ b/tools/rtf/core/target/android_ut_target.py
@@ -8,6 +8,8 @@ import subprocess
 from core.env.env import RTFEnv
 from core.target.target import Target
 from core.utils.log import Log
+from core.utils.result import Err, Ok
+from core.utils.constants import Constants
 
 
 class AndroidTargetType(enum.Enum):
@@ -79,12 +81,17 @@ class AndroidUTTarget(Target):
             f"adb -s {self.global_info['device_name']} install -g {self.target_path}"
         )
         try:
-            subprocess.check_call(install_cmd, shell=True)
+            subprocess.check_call(install_cmd, shell=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            return Err(Constants.ANDROID_APK_INSTALL_ERR, "Apk Install timeout")
         except Exception as e:
             Log.fatal(f"adb install failed for {self.name} \n: {e}")
+        return Ok()
 
     def run(self):
-        self.install_apk()
+        result = self.install_apk()
+        if result.is_err():
+            return result
         run_command = (
             f"adb -s {self.global_info['device_name']} shell am instrument -w -e package "
             f"com -e debug false -e coverage true -e coverageFile /sdcard/coverage_{self.name}.ec "

--- a/tools/rtf/core/template/android_ut_template.py
+++ b/tools/rtf/core/template/android_ut_template.py
@@ -12,7 +12,7 @@ builder = {
             "-Penable_lynx_android_test=true",
             "-Penable_coverage=true",
         ],
-        "workspace": "platform/android", 
+        "workspace": "platform/android",
         "type": "gradle",
     }
 }

--- a/tools/rtf/core/utils/constants.py
+++ b/tools/rtf/core/utils/constants.py
@@ -1,0 +1,14 @@
+# Copyright 2025 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+from enum import Enum, auto
+
+
+class AutoEnum(Enum):
+    def _generate_next_value_(name, start, count, last_values):
+        return count
+
+
+class Constants(AutoEnum):
+    ANDROID_APK_INSTALL_ERR = auto()

--- a/tools/rtf/core/utils/emu_env_setup.py
+++ b/tools/rtf/core/utils/emu_env_setup.py
@@ -120,9 +120,7 @@ class EmulatorEnv:
         images = output.decode("utf-8").strip().split("\n")
         if len(images) == 0:
             Log.fatal("No simulator resources found!")
-        start_simulator_device_cmd = (
-            f"emulator -no-window -writable-system -avd {images[0]} -partition-size 4096"
-        )
+        start_simulator_device_cmd = f"emulator -no-window -writable-system -avd {images[0]} -partition-size 4096"
         log_file = open(self.device_backend_log, "w")
         self.device_process = subprocess.Popen(
             [start_simulator_device_cmd], shell=True, stdout=log_file

--- a/tools/rtf/core/utils/result.py
+++ b/tools/rtf/core/utils/result.py
@@ -1,0 +1,31 @@
+# Copyright 2025 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+
+class Result:
+    def __init__(self, code, msg):
+        self.code = code
+        self.msg = msg
+
+    def is_ok(self):
+        pass
+
+    def is_err(self):
+        return not self.is_ok()
+
+
+class Err(Result):
+    def __init__(self, code, msg):
+        super().__init__(code, msg)
+
+    def is_ok(self):
+        return False
+
+
+class Ok(Result):
+    def __init__(self):
+        super().__init__(None, None)
+
+    def is_ok(self):
+        return True


### PR DESCRIPTION
Detect adb install timeout, and restart the emulator in case of timeout to attempt recovery.

Change-Id: Ie36bf22ceead4775ebac869579e62a4bcb6eccb7

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
