### PR TITLE
[Optimize] separate wasm bindings from encoder

### DIFF
--- a/core/template_bundle/template_codec/binary_encoder/encoder.cc
+++ b/core/template_bundle/template_codec/binary_encoder/encoder.cc
@@ -32,11 +32,6 @@
 #include "third_party/rapidjson/document.h"
 #include "third_party/rapidjson/stringbuffer.h"
 #include "third_party/rapidjson/writer.h"
-#ifdef __EMSCRIPTEN__
-#include <emscripten/bind.h>
-
-#include "third_party/aes/aes.h"
-#endif
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -623,47 +618,3 @@ const char* lepusCheck(const char* sourceFile, char* targetSdkVersion,
   return strdup(res_str.c_str());
 }
 }
-#ifdef __EMSCRIPTEN__
-extern "C" {
-void leakCheck(const char* msg) {
-  // Uncomment when analyzing memory leaks
-  //__lsan_do_leak_check();
-}
-}
-#endif
-
-// wasm binding
-
-#if defined(__EMSCRIPTEN__)
-
-EMSCRIPTEN_BINDINGS(encode) {
-  emscripten::register_vector<uint8_t>("VectorUInt8");
-  emscripten::value_object<lynx::tasm::EncodeResult>("EncodeResult")
-      .field("status", &lynx::tasm::EncodeResult::status)
-      .field("error_msg", &lynx::tasm::EncodeResult::error_msg)
-      .field("buffer", &lynx::tasm::EncodeResult::buffer)
-      .field("lepus_code", &lynx::tasm::EncodeResult::lepus_code)
-      .field("lepus_debug", &lynx::tasm::EncodeResult::lepus_debug)
-      .field("section_size", &lynx::tasm::EncodeResult::section_size);
-  function("_encode", &lynx::tasm::encode, emscripten::allow_raw_pointers());
-  function("_quickjsCheck", &lynx::tasm::quickjsCheck,
-           emscripten::allow_raw_pointers());
-  function("_encode_ssr",
-           emscripten::optional_override(
-               [](intptr_t buf, size_t size, const std::string& data) {
-                 return lynx::tasm::encode_ssr(
-                     reinterpret_cast<const uint8_t*>(buf), size, data);
-               }),
-           emscripten::allow_raw_pointers());
-  function("_encrypt",
-           emscripten::optional_override([](const std::string& plain) {
-             return AES().EncryptECB(plain);
-           }),
-           emscripten::allow_raw_pointers());
-  function("_decrypt",
-           emscripten::optional_override([](const std::string& cipher) {
-             return AES().DecryptECB(cipher);
-           }),
-           emscripten::allow_raw_pointers());
-}
-#endif

--- a/core/template_bundle/template_codec/wasm_bind.cc
+++ b/core/template_bundle/template_codec/wasm_bind.cc
@@ -1,0 +1,40 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <emscripten/bind.h>
+
+#include "core/template_bundle/template_codec/binary_encoder/encoder.h"
+#include "core/template_bundle/template_codec/generator/base_struct.h"
+#include "third_party/aes/aes.h"
+
+EMSCRIPTEN_BINDINGS(encode) {
+  emscripten::register_vector<uint8_t>("VectorUInt8");
+  emscripten::value_object<lynx::tasm::EncodeResult>("EncodeResult")
+      .field("status", &lynx::tasm::EncodeResult::status)
+      .field("error_msg", &lynx::tasm::EncodeResult::error_msg)
+      .field("buffer", &lynx::tasm::EncodeResult::buffer)
+      .field("lepus_code", &lynx::tasm::EncodeResult::lepus_code)
+      .field("lepus_debug", &lynx::tasm::EncodeResult::lepus_debug)
+      .field("section_size", &lynx::tasm::EncodeResult::section_size);
+  function("_encode", &lynx::tasm::encode, emscripten::allow_raw_pointers());
+  function("_quickjsCheck", &lynx::tasm::quickjsCheck,
+           emscripten::allow_raw_pointers());
+  function("_encode_ssr",
+           emscripten::optional_override(
+               [](intptr_t buf, size_t size, const std::string& data) {
+                 return lynx::tasm::encode_ssr(
+                     reinterpret_cast<const uint8_t*>(buf), size, data);
+               }),
+           emscripten::allow_raw_pointers());
+  function("_encrypt",
+           emscripten::optional_override([](const std::string& plain) {
+             return AES().EncryptECB(plain);
+           }),
+           emscripten::allow_raw_pointers());
+  function("_decrypt",
+           emscripten::optional_override([](const std::string& cipher) {
+             return AES().DecryptECB(cipher);
+           }),
+           emscripten::allow_raw_pointers());
+}

--- a/oliver/lynx-tasm/BUILD.gn
+++ b/oliver/lynx-tasm/BUILD.gn
@@ -158,6 +158,10 @@ if (build_lynx_lepus_node) {
       sources += [ "//lynx/core/renderer/tasm/napi_bind.cc" ]
     }
 
+    if (is_wasm) {
+      sources += [ "//lynx/core/template_bundle/template_codec/wasm_bind.cc" ]
+    }
+
     # utils
     sources += lynx_renderer_utils_sources_path
     sources += lynx_env_shared_sources_path


### PR DESCRIPTION
separate wasm bindings to a separate file as `wasm_bind.cc`, so that `__EMSCRIPTEN__` macro can be removed now, and make encoder.cc's logic more clear, it should just care about the encoder things and should not be wrapped with wasm bindings.

issue: f-23904876677
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
