### PR TITLE
[BugFix][iOS][LynxEnv] Fix the compatibility issue of safe-area-inset-top

### DIFF
--- a/platform/darwin/common/lynx/LynxEnv.mm
+++ b/platform/darwin/common/lynx/LynxEnv.mm
@@ -404,6 +404,7 @@
   lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_LEFT_ = 0;
   lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_RIGHT_ = 0;
   if (@available(iOS 11.0, *)) {
+    lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_TOP_ = keyWindow.safeAreaInsets.top;
     lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_BOTTOM_ = keyWindow.safeAreaInsets.bottom;
     lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_LEFT_ = keyWindow.safeAreaInsets.left;
     lynx::starlight::ComputedCSSStyle::SAFE_AREA_INSET_RIGHT_ = keyWindow.safeAreaInsets.right;


### PR DESCRIPTION


On iOS 11 and above, keywindow.inset.top should be used instead of statusbar.height as the value of safe-area-inset-top.

issue: m-887

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
