### PR TITLE
[BugFix] Fix ffi install problem with Xcode 16.3.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gem "cocoapods", '1.11.3'
-gem "ffi", "1.16.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,6 @@ GEM
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -102,7 +101,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.11.3)
-  ffi (= 1.16.3)
 
 BUNDLED WITH
    2.4.20


### PR DESCRIPTION
Update ffi to fix its install problem with Xcode 16.3, and update ruby's requirement in LynxExplorer's README.md.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
