### PR TITLE
[Optimize] support decode_wasm for tasm module

### DIFF
--- a/core/template_bundle/template_codec/generator/base_struct.h
+++ b/core/template_bundle/template_codec/generator/base_struct.h
@@ -26,6 +26,11 @@ struct EncodeResult {
   std::string section_size;
 };
 
+struct DecodeResult {
+  int status;
+  std::string result;
+};
+
 // Options used in encode time, but not be used in run time.
 struct GeneratorOptions {
   std::string cli_version_{};

--- a/core/template_bundle/template_codec/wasm_bind.cc
+++ b/core/template_bundle/template_codec/wasm_bind.cc
@@ -4,9 +4,39 @@
 
 #include <emscripten/bind.h>
 
+#include "core/template_bundle/lynx_template_bundle.h"
+#include "core/template_bundle/lynx_template_bundle_converter.h"
+#include "core/template_bundle/template_codec/binary_decoder/lynx_binary_reader.h"
 #include "core/template_bundle/template_codec/binary_encoder/encoder.h"
 #include "core/template_bundle/template_codec/generator/base_struct.h"
 #include "third_party/aes/aes.h"
+
+extern "C" {
+// TODO(nihao.royal): it seems like a emcc issue that you must export a
+// function. update emcc to fix it later.
+void quickjsCheck(const char* source) {
+  lynx::tasm::quickjsCheck(std::string(source)).c_str();
+}
+}
+
+lynx::tasm::DecodeResult decode(uintptr_t binaryPtr, size_t length) {
+  uint8_t* binary = reinterpret_cast<uint8_t*>(binaryPtr);
+  std::vector<uint8_t> binaryVector(binary, binary + length);
+  auto reader =
+      lynx::tasm::LynxBinaryReader::CreateLynxBinaryReader(binaryVector);
+  bool result = reader.Decode();
+  if (result) {
+    // decode success.
+    std::string res = lynx::tasm::LynxTemplateBundleConverter::
+        ConvertTemplateBundleToSerializedString(reader.GetTemplateBundle());
+    return {.status = 0, .result = std::move(res)};
+  } else {
+    // decode failed.
+    std::cout << "ParseTemplate failed. error_msg is : "
+              << reader.error_message_ << std::endl;
+    return {.status = -1, .result = reader.error_message_};
+  }
+}
 
 EMSCRIPTEN_BINDINGS(encode) {
   emscripten::register_vector<uint8_t>("VectorUInt8");
@@ -17,7 +47,14 @@ EMSCRIPTEN_BINDINGS(encode) {
       .field("lepus_code", &lynx::tasm::EncodeResult::lepus_code)
       .field("lepus_debug", &lynx::tasm::EncodeResult::lepus_debug)
       .field("section_size", &lynx::tasm::EncodeResult::section_size);
-  function("_encode", &lynx::tasm::encode, emscripten::allow_raw_pointers());
+  emscripten::value_object<lynx::tasm::DecodeResult>("DecodeResult")
+      .field("status", &lynx::tasm::DecodeResult::status)
+      .field("result", &lynx::tasm::DecodeResult::result);
+  function("_encode",
+           emscripten::optional_override([](const std::string& options_str) {
+             return lynx::tasm::encode(options_str);
+           }),
+           emscripten::allow_raw_pointers());
   function("_quickjsCheck", &lynx::tasm::quickjsCheck,
            emscripten::allow_raw_pointers());
   function("_encode_ssr",
@@ -27,14 +64,11 @@ EMSCRIPTEN_BINDINGS(encode) {
                      reinterpret_cast<const uint8_t*>(buf), size, data);
                }),
            emscripten::allow_raw_pointers());
-  function("_encrypt",
-           emscripten::optional_override([](const std::string& plain) {
-             return AES().EncryptECB(plain);
-           }),
-           emscripten::allow_raw_pointers());
-  function("_decrypt",
-           emscripten::optional_override([](const std::string& cipher) {
-             return AES().DecryptECB(cipher);
-           }),
-           emscripten::allow_raw_pointers());
+
+  function(
+      "_decode",
+      emscripten::optional_override([](uintptr_t binaryPtr, size_t length) {
+        return decode(binaryPtr, length);
+      }),
+      emscripten::allow_raw_pointers());
 }

--- a/oliver/gen_wasm_js.py
+++ b/oliver/gen_wasm_js.py
@@ -65,7 +65,7 @@ def gen_js_file(emsdk_path, binary_path, output_name, flags):
   path = os.path.join(binary_path, "lib{}.a".format(output_name))
   name = os.path.join(binary_path, "{}.js".format(output_name))
 
-  command = "{emsdk_path}/upstream/emscripten/emcc {path} \
+  command = "{emsdk_path}/upstream/emscripten/emcc --bind {path} \
             -o {name} \
             -g \
             {flags}".format(emsdk_path=emsdk_path, path=path, name=name, flags=flags)

--- a/oliver/lynx-tasm/BUILD.gn
+++ b/oliver/lynx-tasm/BUILD.gn
@@ -68,6 +68,7 @@ if (build_lynx_lepus_node) {
             " ",
             [
               "-s WASM=1",
+              "-s ERROR_ON_UNDEFINED_SYMBOLS=0",
               "-s WASM_ASYNC_COMPILATION=0",
               "-s ASSERTIONS=1",
               "-s NODEJS_CATCH_EXIT=0",
@@ -78,7 +79,7 @@ if (build_lynx_lepus_node) {
               "-s ALLOW_MEMORY_GROWTH=1",
               "-s MODULARIZE=1",
               "-s EXTRA_EXPORTED_RUNTIME_METHODS=\"['cwrap','ccall', 'allocateUTF8','UTF8ToString']\"",
-              "-s EXPORTED_FUNCTIONS=\"['_reencode_template_debug', '_lepusCheck', '_createBufferPool', '_dropBufferPool', '_readBufferPool_data', '_readBufferPool_len']\"",
+              "-s EXPORTED_FUNCTIONS=\"['_quickjsCheck', '_reencode_template_debug', '_lepusCheck', '_createBufferPool', '_dropBufferPool', '_readBufferPool_data', '_readBufferPool_len']\"",
             ]),
       ]
 
@@ -186,6 +187,7 @@ if (build_lynx_lepus_node) {
       "//lynx/core/base:json_utils",
       "//lynx/core/base:observer",
       "//lynx/core/build:build",
+      "//lynx/core/renderer/events:events_tasm",
       "//lynx/core/runtime:js_common",
       "//lynx/core/runtime/common:reporter",
       "//lynx/core/template_bundle/template_codec:template_encoder",

--- a/oliver/lynx-tasm/ChangeLog.md
+++ b/oliver/lynx-tasm/ChangeLog.md
@@ -1,3 +1,6 @@
+# 0.0.7
+* support `decode_wasm` to resolve a tasm file.
+
 # 0.0.6
 * support `decode_napi` to resolve a tasm file.
 

--- a/oliver/lynx-tasm/index.d.ts
+++ b/oliver/lynx-tasm/index.d.ts
@@ -20,4 +20,5 @@ export function encrypt(token: string): string;
 export function decrypt(token: string): string;
 export function encrypt_wasm(token: string): string;
 export function decrypt_wasm(token: string): string;
-export function decode_napi(template: Uint8Array): string;
+export function decode_napi(template: Uint8Array): any;
+export function decode_wasm(template: Uint8Array): any;

--- a/oliver/lynx-tasm/index.js
+++ b/oliver/lynx-tasm/index.js
@@ -102,7 +102,28 @@ function decode_napi(templateJS) {
   if (res.status !== 0) {
     throw new Error(`decode error: ${res.error_msg}`);
   }
-  return res
+  return JSON.parse(res.result);
+}
+
+function decode_wasm(buffer) {
+  const Module = loadModule();
+  // console.log(templateJs);
+  // const uint8array = new Uint8Array(templateJs.size());
+  // const res = m._decode(uint8array);
+  const byteArray = new Uint8Array(buffer);
+  const byteArrayLength = byteArray.length;
+  // Allocate memory in the Emscripten heap
+  const byteArrayPtr = Module._malloc(byteArrayLength);
+  // Copy the data to the Emscripten heap
+  Module.HEAPU8.set(byteArray, byteArrayPtr);
+  // Call the C++ function
+  const res = Module._decode(byteArrayPtr, byteArrayLength);
+  // Free the allocated memory
+  Module._free(byteArrayPtr);
+  if (res.status !== 0) {
+    throw new Error(`decode error: ${res.result}`);
+  }
+  return JSON.parse(res.result);
 }
 
 let encode = encode_napi;
@@ -118,5 +139,6 @@ module.exports = {
   decrypt,
   encrypt_wasm,
   decrypt_wasm,
-  decode_napi
+  decode_napi,
+  decode_wasm
 };

--- a/oliver/lynx-tasm/package.json
+++ b/oliver/lynx-tasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lynx-js/tasm",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "description": "",
     "main": "index.js",
     "types": "index.d.ts",


### PR DESCRIPTION
in this commit wasm decoder is supported in `@lynx-js/tasm`, so that fe developers may quickjs decoding a tasm file and reading the meaningfull content inside, it may quickly speed up the problen resolving time.

AutoSubmit: true
issue: f-2937456756

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
