### PR TITLE
[BugFix] fix LynxTemplateDataUnitTest issues.

### DIFF
--- a/platform/darwin/common/lynx/LynxTemplateDataUnitTest.mm
+++ b/platform/darwin/common/lynx/LynxTemplateDataUnitTest.mm
@@ -23,28 +23,31 @@
   // class.
 }
 
-- (void)empty {
+- (void)testEmpty {
   LynxTemplateData* templateData = [[LynxTemplateData alloc] initWithJson:@""];
   auto* value = LynxGetLepusValueFromTemplateData(templateData);
-  XCTAssertTrue(value->IsEmpty());
+  XCTAssertTrue(value->IsTable());
+  XCTAssertTrue(value->Table()->size() == 0);
 }
 
-- (void)markReadOnly {
+- (void)testMarkReadOnly {
   LynxTemplateData* templateData = [[LynxTemplateData alloc] initWithJson:@""];
   XCTAssertFalse(templateData.isReadOnly);
   [templateData markReadOnly];
   XCTAssertTrue(templateData.isReadOnly);
 }
 
-- (void)fromMap {
-  NSDictionary* dict = @{@"a" : @"1"};
+- (void)testFromMap {
+  NSDictionary* dict = @{@"a" : @"1", @"b" : [NSNull null]};
   LynxTemplateData* templateData = [[LynxTemplateData alloc] initWithDictionary:dict];
   auto* value = LynxGetLepusValueFromTemplateData(templateData);
 
   XCTAssertFalse(value->IsEmpty());
   XCTAssertTrue(value->IsTable());
-  XCTAssertTrue(value->Contains("a"));
-  XCTAssertTrue([dict isEqual:[templateData dictionary]]);
+  XCTAssertEqual(value->GetProperty("a").String(), "1");
+  XCTAssertTrue(value->GetProperty("b").IsNil());
+
+  XCTAssertTrue([@{@"a" : @"1"} isEqual:[templateData dictionary]]);
 }
 
 - (void)testLong {


### PR DESCRIPTION
there are some issues for LynxTemplateDataUnitTest:
1. each test method should starts with `test` prefix, or UnitTest will ignore this method;
2. add test for `NsNull` cases, it should be considered as Nil for lepus::Value

issue: f-18475675667
AutoLand: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
