### PR TITLE
[BugFix] disable vm pool when enable runtime leak check.

### DIFF
--- a/core/renderer/template_entry.cc
+++ b/core/renderer/template_entry.cc
@@ -50,9 +50,13 @@ bool TemplateEntry::ConstructContext(TemplateAssembler* assembler,
                                      bool use_context_pool,
                                      bool disable_tracing_gc) {
   auto source_type = LepusContextSourceType::kFromRuntime;
-  if (((is_lepusng_binary && use_context_pool) ||
-       template_bundle().EnableUseContextPool()) &&
-      !disable_tracing_gc) {
+  bool enable_use_context_pool = (is_lepusng_binary && use_context_pool) ||
+                                 template_bundle().EnableUseContextPool();
+  // TODO(nihao.royal): maybe add a platform interface to enable the runtime
+  // leak checker later;
+  bool enable_runtime_leak_check = LynxEnv::GetInstance().IsDevToolEnabled();
+  if (enable_use_context_pool && !disable_tracing_gc &&
+      !enable_runtime_leak_check) {
     // 1. try to take context for local pool
     if (template_bundle().quick_context_pool_) {
       vm_context_ = template_bundle().quick_context_pool_->TakeContextSafely();
@@ -85,9 +89,7 @@ bool TemplateEntry::ConstructContext(TemplateAssembler* assembler,
         lepus::Context::CreateContext(is_lepusng_binary, disable_tracing_gc);
   }
 
-  // TODO(nihao.royal): maybe add a platform interface to enable the checker
-  // later;
-  if (LynxEnv::GetInstance().IsDevToolEnabled()) {
+  if (enable_runtime_leak_check) {
     vm_context_->EnableRuntimeLeakCheck(true);
   }
 

--- a/core/template_bundle/lynx_template_bundle.cc
+++ b/core/template_bundle/lynx_template_bundle.cc
@@ -71,7 +71,7 @@ bool LynxTemplateBundle::PrepareLepusContext(int32_t count) {
   constexpr int32_t kOnePatchMaxSize = 20;
   quick_context_pool_->FillPool(std::min(kOnePatchMaxSize, count));
 
-  use_context_pool_ = true;
+  force_use_context_pool_ = true;
   return true;
 }
 

--- a/core/template_bundle/lynx_template_bundle.h
+++ b/core/template_bundle/lynx_template_bundle.h
@@ -116,7 +116,7 @@ class LynxTemplateBundle final {
   void PrepareVMByConfigs();
   bool PrepareLepusContext(int32_t count);
 
-  bool EnableUseContextPool() const { return use_context_pool_; }
+  bool EnableUseContextPool() const { return force_use_context_pool_; }
 
   void SetEnableVMAutoGenerate(bool enable);
 
@@ -203,7 +203,7 @@ class LynxTemplateBundle final {
   ElementBundle element_bundle_;
 
   // force to use context pool in runtime
-  bool use_context_pool_{false};
+  bool force_use_context_pool_{false};
 
   lepus::Value custom_sections_{};
 


### PR DESCRIPTION
runtime leak checker will check the tid of jsvalue create & use, so we need to disable vm pool when runtime leak check enabled.

issue:f-23957679047
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
