### PR TITLE
[Infra] Use cache in mac runner to optimize ci stability

### DIFF
--- a/.github/actions/android-explorer-build/action.yml
+++ b/.github/actions/android-explorer-build/action.yml
@@ -20,6 +20,8 @@ runs:
         python-version: '3.13'
     - name: Install Common Dependencies
       uses: ./lynx/.github/actions/common-deps
+      with:
+        cache-backend: github
     - name: Build Explorer App
       env:
         BUILD_TYPE: ${{ inputs.build-type }}

--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -7,29 +7,46 @@ inputs:
     description: concurrency of requests
     default: '2'
     required: false
-  skip-cache:
-    description: whether to skip cache
-    default: 'false'
+  cache-backend:
+    description: cache backend for habitat
+    default: 'lynx-infra'
     required: false
 
 runs:
   using: composite
   steps:
     - name: setup cache action
+      if: ${{ inputs.cache-backend == 'lynx-infra' }}
       uses: lynx-infra/cache@main
-      if: ${{ inputs.skip-cache == 'false' }}
       with:
         path: ~/.habitat_cache
         key: ${{ runner.os }}-${{ hashFiles('lynx/.habitat', 'lynx/DEPS') }}
         restore-keys: |
           ${{ runner.os }}-
 
+    - name: setup cache action
+      if: ${{ inputs.cache-backend == 'github' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.habitat_cache
+        key: ${{ runner.os }}-${{ hashFiles('lynx/.habitat', 'lynx/DEPS') }}
+        restore-keys: |
+          ${{ runner.os }}-
+
+    - name: install Python dependencies
+      shell: bash
+      run: |
+        if [ "$RUNNER_OS" == "macOS" ]; then
+          python3 -m pip install PyYAML --break-system-packages
+          python3 -m pip install requests --break-system-packages
+        else
+          python3 -m pip install PyYAML
+          python3 -m pip install requests
+        fi
+
     - name: run habitat sync
       shell: bash
       working-directory: lynx
-      run: |
-        python3 -m pip install PyYAML
-        python3 -m pip install requests
-        tools/hab sync .
+      run: tools/hab sync .
       env:
         HABITAT_CONCURRENCY: ${{ inputs.concurrency }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,21 +58,13 @@ jobs:
         with:
           path: lynx
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m venv myenv
-            source myenv/bin/activate
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            tools/hab sync .
+        uses: ./lynx/.github/actions/common-deps
       - name: Run Unittests
         run: |
           set -e
-          source ../myenv/bin/activate
+          python3 -m venv myenv
+          source myenv/bin/activate
+          cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
           tools/rtf/rtf native-ut run --names lynx
 
@@ -122,17 +114,7 @@ jobs:
         with:
           path: lynx
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m venv myenv
-            source myenv/bin/activate
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            tools/hab sync .
+        uses: ./lynx/.github/actions/common-deps
       - name: Setup Ruby Cache
         uses: ./lynx/.github/actions/ios-common-deps
       - name: Install iOS Dependencies
@@ -142,6 +124,7 @@ jobs:
           max_attempts: 3
           command: |
             set -e
+            python3 -m venv myenv
             source myenv/bin/activate
             cd $GITHUB_WORKSPACE/lynx
             source tools/envsetup.sh
@@ -192,20 +175,13 @@ jobs:
         with:
           path: lynx
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m venv myenv
-            source myenv/bin/activate
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            tools/hab sync .
+        uses: ./lynx/.github/actions/common-deps
       - name: Build Darwin Tasm
         run: |
-          source ../myenv/bin/activate
+          set -e
+          python3 -m venv myenv
+          source myenv/bin/activate
+          cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
           tools/hab sync . -f
           pushd oliver/lynx-tasm
@@ -397,5 +373,5 @@ jobs:
   release-workflow:
     uses: ./.github/workflows/publish-release.yml
     with:
-      dry_run: true
+      dry-run: true
     secrets: inherit

--- a/.github/workflows/lynx-core-publish.yml
+++ b/.github/workflows/lynx-core-publish.yml
@@ -15,15 +15,9 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            tools/hab sync . -f
+          cache-backend: github
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/lynx-types-publish.yml
+++ b/.github/workflows/lynx-types-publish.yml
@@ -15,15 +15,9 @@ jobs:
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            tools/hab sync . -f
+          cache-backend: github
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,7 +2,7 @@ name: publish-release
 on:
   workflow_call:
     inputs:
-      dry_run:
+      dry-run:
         required: true
         type: boolean
       version:
@@ -11,7 +11,7 @@ on:
 
 jobs:
   android-explorer-build:
-    if: ${{ inputs.dry_run == false }}
+    if: ${{ inputs.dry-run == false }}
     runs-on: lynx-ubuntu-22.04-avd-large
     steps:
       - name: Download Source
@@ -41,17 +41,7 @@ jobs:
         with:
           path: lynx
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            python3 -m venv myenv
-            source myenv/bin/activate
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            rm -rf $GITHUB_WORKSPACE/third_party
-            tools/hab sync .
+        uses: ./lynx/.github/actions/common-deps
       - name: Setup Ruby Cache
         uses: ./lynx/.github/actions/ios-common-deps
       - name: Install iOS Dependencies
@@ -61,6 +51,7 @@ jobs:
           max_attempts: 3
           command: |-
             set -e
+            python3 -m venv myenv
             source myenv/bin/activate
             cd $GITHUB_WORKSPACE/lynx
             source tools/envsetup.sh
@@ -78,14 +69,15 @@ jobs:
           tar --strip-components 10 -czvf LynxExplorer-${{ matrix.arch }}.app.tar.gz explorer/darwin/ios/lynx_explorer/iOSCoreBuild/DerivedData/Build/Products/Debug-iphonesimulator/LynxExplorer.app
       - name: push explorer to release
         uses: ncipollo/release-action@v1
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry-run == false }}
         with:
           tag: ${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: '${{ github.workspace }}/lynx/LynxExplorer-${{ matrix.arch }}.app.tar.gz'
           allowUpdates: true
+
   android-sdk-release:
-    runs-on: ${{ inputs.dry_run == false && 'ubuntu-latest' || 'lynx-ubuntu-22.04-avd-large' }}
+    runs-on: ${{ inputs.dry-run == false && 'ubuntu-latest' || 'lynx-ubuntu-22.04-avd-large' }}
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -96,26 +88,12 @@ jobs:
         with:
           python-version: '3.13'
       - name: Setup Android enviroment
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry-run == false }}
         uses: ./lynx/.github/actions/setup-android-env
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-      - name: Install Common Dependencies With Cache
-        if: ${{ inputs.dry_run == true }}
         uses: ./lynx/.github/actions/common-deps
-      - name: Install Common Dependencies
-        if: ${{ inputs.dry_run == false }}
-        run: |-
-          cd $GITHUB_WORKSPACE/lynx
-          python3 -m pip install PyYAML -i https://pypi.org/simple
-          source tools/envsetup.sh
-          tools/hab sync . -f
+        with:
+          cache-backend: ${{ inputs.dry-run == false && 'github' || 'lynx-infra' }}
       - name: Build artifact
         run: |-
           cd $GITHUB_WORKSPACE/lynx
@@ -124,7 +102,7 @@ jobs:
           ./gradlew assembleAllModulesRelease -Penable_trace=none -PabiList=armeabi-v7a,x86,x86_64,arm64-v8a -no-daemon
           popd
       - name: Package maven artifacts
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry-run == false }}
         run: |-
           cd $GITHUB_WORKSPACE/lynx
           pushd platform/android
@@ -141,14 +119,15 @@ jobs:
           popd
         id: build_artifact
       - name: Publish artifact to maven
-        if: ${{ inputs.dry_run == false }}
+        if: ${{ inputs.dry-run == false }}
         uses: lynx-infra/maven-publish-action@c48e3067642c7ceccf807cd52e6644a257cd8ded
         with:
           portal_api_token: ${{ secrets.PORTAL_API_TOKEN }}
           artifact_path_list: ${{ steps.build_artifact.outputs.artifact_list }}
+
   ios-sdk-publish:
     runs-on: macos-13
-    if: ${{ inputs.dry_run == false }}
+    if: ${{ inputs.dry-run == false }}
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -157,22 +136,14 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: lynx
       - name: Install Common Dependencies
-        uses: nick-fields/retry@v2
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            python3 -m venv myenv
-            source myenv/bin/activate
-            cd $GITHUB_WORKSPACE/lynx
-            python3 -m pip install PyYAML -i https://pypi.org/simple
-            python3 -m pip install requests -i https://pypi.org/simple
-            source tools/envsetup.sh
-            tools/hab sync . -f
+          cache-backend: github
       - name: Setup Ruby Cache
         uses: ./lynx/.github/actions/ios-common-deps
       - name: Prepare cocoapods publish source
         run: |-
+          python3 -m venv myenv
           source myenv/bin/activate
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/publish-release.yml
     needs: get-version
     with:
-      dry_run: false
+      dry-run: false
       version: ${{ needs.get-version.outputs.version }}
     permissions:
       contents: write


### PR DESCRIPTION
Other changes:
1. refactor the common-deps action input to support cache backend selection.
2. rename workflow input from dry_run to dry-run.
3. use official cache action when using GitHub hosted runner.

AutoSubmit: true

ExternalPullRequestID: 977
ExternalGitURL: https://github.com/coolkiid/lynx.git

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
