### PR TITLE
[Infra] Adapt Android builds for Windows development

### DIFF
--- a/explorer/android/README.md
+++ b/explorer/android/README.md
@@ -1,6 +1,6 @@
 # Build Lynx Explorer
 
-This document will help you build LynxExplorer for Android on MacOS or Linux.
+This document will help you build LynxExplorer for Android on MacOS, Linux and Windows.
 
 ## System requirements
 
@@ -19,52 +19,83 @@ The following dependencies are needed:
 
 #### Install JDK11
 
-#### MacOS
-We recommend using Homebrew to install the OpenJDK distribution called Zulu, which is provided by Azul.
+- MacOS
 
-```
-brew install --cask zulu@11
-```
+    We recommend using Homebrew to install the OpenJDK distribution called Zulu, which is provided by Azul.
 
-You can use the following command to confirm whether the installation is successful
+    ```
+    brew install --cask zulu@11
+    ```
 
-```
-javac --version
-```
+    You can use the following command to confirm whether the installation is successful.
 
-If the installation is successful, the terminal will output javac version number 11
+    ```
+    javac --version
+    ```
 
-#### Linux
+    If the installation is successful, the terminal will output javac version number 11.
 
-On Ubuntu or Debian:
-```
-sudo apt install openjdk-11-jdk 
-```
+- Linux
 
-On RHEL or CentOS:
-```
-sudo yum install openjdk-11-jdk 
-```
+    On Ubuntu or Debian:
 
+    ```
+    sudo apt install openjdk-11-jdk 
+    ```
+
+    On RHEL or CentOS:
+
+    ```
+    sudo yum install openjdk-11-jdk 
+    ```
+
+- Windows
+
+    We recommend using winget to install the OpenJDK distribution.
+
+    ```
+    winget install -e --id ojdkbuild.openjdk.11.jdk
+    ```
+
+    You can use the following command to confirm whether the installation is successful.
+
+    ```
+    javac --version
+    ```
+
+    If the installation is successful, the terminal will output javac version number 11.x.xx.
 
 #### Update JAVA_HOME
 
 Confirm your JDK installation directory. If you follow the above steps, the JDK path is likely to be 
+
 - `/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home` on MacOS
-- `/usr/lib/jvm/java-11-openjdk-amd64` on Linux.  
+- `/usr/lib/jvm/java-11-openjdk-amd64` on Linux
+- `C:\Program Files\ojdkbuild\java-11-openjdk-11.0.15-1` on Windows.
 
 Add the following statement to your environment configuration file (it may be ~/.zshrc or ~/.bash_profile or ~/.bashrc, depending on your terminal environment):
 
 - MacOS
-```
-export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
-export PATH=$JAVA_HOME/bin:$PATH
-```
+
+    ```
+    export JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home
+    export PATH=$JAVA_HOME/bin:$PATH
+    ```
+
 - Linux 
-```
-export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
-export PATH=$JAVA_HOME/bin:$PATH
-```
+
+    ```
+    export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+    export PATH=$JAVA_HOME/bin:$PATH
+    ```
+
+- Windows
+
+    ```
+    $JDK_PATH='C:\Program Files\ojdkbuild\java-11-openjdk-11.0.15-1'
+    [Environment]::SetEnvironmentVariable('JAVA_HOME', $JDK_PATH, 'User')
+    [Environment]::SetEnvironmentVariable('PATH', "$JDK_PATH;$PATH", 'User')
+    ```
 
 ### Android development environment
 
@@ -72,42 +103,38 @@ Configuring the Android development environment required by Lynx includes the fo
 
 #### Configure ANDROID_HOME
 
-Add the ANDROID_HOME variable to your environment configuration file(maybe ~/.zshrc or ~/.bash_profile or ~/.bashrc,depending on your terminal environment).
+Add the ANDROID_HOME variable to your environment configuration file(maybe ~/.zshrc or ~/.bash_profile or ~/.bashrc or ,depending on your terminal environment).
 
-If you have installed the Android SDK before, please set ANDROID_HOME to the installation directory of the Android SDK.(If you have previously installed Android SDK by Android Studio, the installation path of the Android SDK is usually located at /Users/your-username/Library/Android/sdk)
+If you have installed the Android SDK before, please set ANDROID_HOME to the installation directory of the Android SDK.(If you have previously installed Android SDK by Android Studio, the installation path of the Android SDK is usually located at /Users/your-username/Library/Android/sdk on MacOS and Liunx or C:\Users\Admin\AppData\Local\Android\Sdk on Windows)
 
 If you have NOT installed the Android SDK before, you can set ANDROID_HOME to the path where you want the Android SDK to be installed. We have tools to help you install the Android SDK to ANDROID_HOME.
 
-```
-export ANDROID_HOME=<path-to-android-sdk>
-```
+- MacOS and Linux
+
+    ```
+    export ANDROID_HOME=<path-to-android-sdk>
+    ```
+
+- Windows
+
+    ```
+    [Environment]::SetEnvironmentVariable('ANDROID_HOME', $path-to-android-sdk, 'User')
+    ```
 
 
 ### Python library
 
-#### MacOS
-The yaml dependency needs to be installed to execute some auto-generation logic.
+We recommend using pyenv to manage python environment.
+To install pyenv: 
 
-```
-# use the virtual environment to manage python environment
-python3 -m venv venv
-source venv/bin/activate
-# install PyYAML package
-pip3 install pyyaml
-```
-#### Linux
+- [`https://github.com/pyenv/pyenv`](https://github.com/pyenv/pyenv) on MacOS and Linux.
+- [`https://github.com/pyenv-win/pyenv-win`](https://github.com/pyenv-win/pyenv-win) on Windows.
 
-We recommend using pyenv to manage python environment on Linux.
-
-To install pyenv: [`https://github.com/pyenv/pyenv`](https://github.com/pyenv/pyenv)
 Install python with version higher or equal to 3.9 using pyenv:  
+
 ```
 pyenv install 3.9 # or higher
 pyenv global 3.9 # or higher
-```
-Install pyyaml after python is setup:
-```
-pip3 install pyyaml
 ```
 
 ## Get the code
@@ -122,13 +149,23 @@ git clone https://github.com/lynx-family/lynx.git src/lynx
 
 ### Get the dependent files
 
-After getting the project repository, execute the following commands in the root directory of the project to get the project dependent files
+After getting the project repository, execute the following commands in the root directory of the project to get the project dependent files.
 
-```
-cd src/lynx
-source tools/envsetup.sh
-tools/hab sync .
-```
+- MacOS and Linux
+
+    ```
+    cd src/lynx
+    source tools/envsetup.sh
+    tools/hab sync .
+    ```
+
+- Windows
+
+    ```
+    cd src\lynx
+    tools\envsetup.ps1
+    tools\hab.ps1 sync .
+    ```
 
 ### Install the Android components
 
@@ -146,37 +183,38 @@ You can compile LynxExplorer through the command line terminal or Android Studio
 
 #### Open the project
 
-1.Use Android Studio to open the `/explorer/android` directory of the project
+1.Use Android Studio to open the `/explorer/android` directory of the project.
 
 2.Make sure that the JDK used by your Android Studio points to the JDK 11 installed in the above steps: 
 
-1. Open Settings > Build,Execution,Deployment > Build Tools > Gradle, modify the Default Gradle JDK
+1. Open Settings > Build,Execution,Deployment > Build Tools > Gradle, modify the Default Gradle JDK.
 2. Fill in the path of your JAVA_HOME. If you follow the JDK configuration steps above, it is likely to be
     - `/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home` on MacOS.
     - `/usr/lib/jvm/java-11-openjdk-amd64` on Linux.
-    
-3.Trigger Gradle sync    
+    - `C:\Program Files\ojdkbuild\java-11-openjdk-11.0.15-1` on Windows.
+
+3.Trigger Gradle sync.
 
 #### Compile and run
 
-Select the `LynxExplorer` module and click the `Run` button to experience LynxExplorer on your device
+Select the `LynxExplorer` module and click the `Run` button to experience LynxExplorer on your device.
 
 ### Method 2: Compile and run using the command line
 
 #### Compile
 
-Enter the `explorer/android` directory from the project root directory and execute the following command
+Enter the `explorer/android` directory from the project root directory and execute the following command.
 
 ```
 cd explorer/android
 ./gradlew :LynxExplorer:assembleNoAsanDebug --no-daemon
 ```
 
-This command will generate LynxExplorer-noasan-debug.apk in the `lynx_explorer/build/outputs/apk/noasan/debug/` folder
+This command will generate LynxExplorer-noasan-debug.apk in the `lynx_explorer/build/outputs/apk/noasan/debug/` folder.
 
 #### Install
 
-You can install the above .apk file on your device using the adb command
+You can install the above .apk file on your device using the adb command.
 
 ````
 adb install lynx_explorer/build/outputs/apk/noasan/debug/LynxExplorer-noasan-debug.apk
@@ -184,6 +222,16 @@ adb install lynx_explorer/build/outputs/apk/noasan/debug/LynxExplorer-noasan-deb
 
 If the adb command is not found, you can add the path to the adb command in the environment configuration file(~/.zshrc or ~/.bash_profile or ~/.bashrc):
 
-```
-export PATH=${PATH}:${ANDROID_HOME}/platform-tools
-```
+- MacOS and Linux
+
+    ```
+    export PATH=${PATH}:${ANDROID_HOME}/platform-tools
+    ```
+
+- Windows
+
+    After executing the following command, restart PowerShell to use the adb command.
+
+    ```
+    [Environment]::SetEnvironmentVariable('PATH', "$ANDROID_HOME/platform-tools;$PATH", 'User')
+    ```

--- a/explorer/android/build.gradle
+++ b/explorer/android/build.gradle
@@ -122,16 +122,6 @@ task generateAllGnCmakeTargets {
 }
 
 
-task generateJNIHeader {
-    description "Because generated files should not checkin this repo, so generate JNI headers before build."
-    exec {
-        workingDir "../../"
-        commandLine "bash", "tools/build_jni/prebuild.sh"
-        println commandLine
-    }
-}
-
-
 task buildHomePage {
     description "Build home page card."
     exec {

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -141,16 +141,6 @@ task generateAllGnCmakeTargets {
     }
 }
 
-
-task generateJNIHeader {
-    description "Because generated files should not checkin this repo, so generate JNI headers before build."
-    exec {
-        workingDir "../../"
-        commandLine "bash", "tools/build_jni/prebuild.sh"
-        println commandLine
-    }
-}
-
 task clean(type: Delete) {
     dependsOn generateAllGnCmakeTargets
     dependsOn subprojects*.tasks*.matching { it.name.contains('clean') }

--- a/tools/build_jni/generate_and_register_jni_files.py
+++ b/tools/build_jni/generate_and_register_jni_files.py
@@ -404,10 +404,10 @@ def generate_files(root_path, jni_configs_file, use_base_jni_utils_header):
     jni_register_header_name = java_base_name + '_register_jni.h'
     jni_register_source_name = java_base_name + '_register_jni.cc'
     # file path
-    jni_file_path = os.path.join(root_path, jni_output_path, jni_file_name)
-    jni_file_rel_path = os.path.relpath(jni_file_path, root_path)
-    jni_register_header_abs_path = os.path.join(root_path, jni_output_path, jni_register_header_name)
-    jni_register_header_rel_path = os.path.relpath(jni_register_header_abs_path, root_path)
+    jni_file_path = os.path.join(root_path, jni_output_path, jni_file_name).replace("\\", "/")
+    jni_file_rel_path = os.path.relpath(jni_file_path, root_path).replace("\\", "/")
+    jni_register_header_abs_path = os.path.join(root_path, jni_output_path, jni_register_header_name).replace("\\", "/")
+    jni_register_header_rel_path = os.path.relpath(jni_register_header_abs_path, root_path).replace("\\", "/")
 
     include_header = f'#include "{jni_register_header_rel_path}"'
     include_headers.append([include_header, macro])

--- a/tools/build_jni/jni_generator.py
+++ b/tools/build_jni/jni_generator.py
@@ -715,7 +715,7 @@ class JNIFromJavaSource(object):
 
   @staticmethod
   def CreateFromFile(java_file_name, options):
-    with open(java_file_name, 'r') as f:
+    with open(java_file_name, 'r', encoding='UTF-8') as f:
         contents = f.read()
     fully_qualified_class = ExtractFullyQualifiedJavaClassName(java_file_name,
                                                                contents)

--- a/tools/envsetup.ps1
+++ b/tools/envsetup.ps1
@@ -1,23 +1,27 @@
 # Copyright 2025 The Lynx Authors. All rights reserved.
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 $tools_path = Split-Path -Parent $MyInvocation.MyCommand.Path
 $lynx_dir_path = Split-Path -Parent $tools_path
 $lynx_root_dir_path = Split-Path -Parent $lynx_dir_path
 
 function Setup-Environment($environ_key, $environ_value) {
-  [Environment]::SetEnvironmentVariable($environ_key, $environ_value, "Process")
+  [Environment]::SetEnvironmentVariable($environ_key, $environ_value, "User")
 }
 
 function Get-Environment($environ_key) {
-  $environ_value = [Environment]::GetEnvironmentVariable($environ_key, "Process")
+  $environ_value = [Environment]::GetEnvironmentVariable($environ_key, "User")
   return $environ_value
 }
 
 function Add-Environ($key, $value) {
   $currentValue = Get-Environment $key
   if ($currentValue) {
+    if ($currentValue.Contains($value)) {
+      return
+    }
     $new_path = "$value;$currentValue"
   } else {
     $new_path = $value
@@ -51,7 +55,8 @@ function Run-cmdLists($cmdLists) {
 }
 
 function Android-Env-Setup {
-  $androidHome =[Environment]::GetEnvironmentVariable('ANDROID_HOME', "Machine")
+  $androidHome = Get-Environment 'ANDROID_HOME'
+  
   if ($androidHome) {
     $androidNdk = Join-Path $androidHome 'ndk/21.1.6352462'
     Setup-Environment 'ANDROID_NDK' $androidNdk


### PR DESCRIPTION
1. Update the README for the Windows build process guide.
2. Adapt the JNI generator script.
3. To enable Gradle to find tools like ninja and python3, elevate the environment variable settings to the User level in envsetup.sh.

AutoSubmit:true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
