### PR TITLE
[Testing] Support debugMode for LynxExplorer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ platform/android/lynx_android/.cxx/
 platform/android/lynx_processor/bin/
 platform/android/lynx_android/CMakeLists_impl/
 platform/android/lynx_android/libs/
+platform/android/lynx_devtool/src/main/jniLibs/
 explorer/android/lynx_explorer/build/
 explorer/android/.gradle/
 explorer/android/.idea/

--- a/devtool/lynx_devtool/resources/devtool-switch/src/App.tsx
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/App.tsx
@@ -8,7 +8,7 @@ import { LongPress } from './sections/LongPress';
 import { Header } from './sections/Header';
 import { HighlightTouch } from './sections/HighlightTouch';
 import { LogBox } from './sections/LogBox';
-import { PerformanceTool } from './sections/PerformanceTool';
+import { TestBench } from './sections/TestBench';
 import { PixelCopy } from './sections/PixelCopy';
 import { CurrentJSEngine } from './sections/CurrentJSEngine';
 
@@ -34,22 +34,12 @@ export function LynxDebug(props: Props) {
   if (!enableLynxDebug) {
     return null;
   }
-
-  if (props.experimental) {
-    return (
-      <>
-        <DevTool />
-        <LynxDevTool experimental={props.experimental} />
-        <LogBox />
-      </>
-    );
-  }
   return (
     <>
       <DevTool />
       <LynxDevTool experimental={props.experimental} />
       <LogBox />
-      <PerformanceTool />
+      <TestBench />
     </>
   );
 }

--- a/devtool/lynx_devtool/resources/devtool-switch/src/atoms/index.ts
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/atoms/index.ts
@@ -67,7 +67,7 @@ export const logBox = atomWithStorage('logbox', false, {
   removeItem() {},
 });
 
-export const performanceTool = atomWithStorage('performance-tool', false, {
+export const testBench = atomWithStorage('testbench', false, {
   getItem() {
     'background-only';
     return NativeModules.LynxDevToolSetModule.isDebugModeEnabled?.() ?? false;

--- a/devtool/lynx_devtool/resources/devtool-switch/src/locales/en.json
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/locales/en.json
@@ -18,7 +18,7 @@
   "LogBox desc": "Displays error prompts when errors occur.",
   "Highlight Touch": "Hightlight Touch",
   "Highlight Touch desc": "Highlights the touch area and logs event-related messages.",
-  "Performance Tool": "Performance Tool",
-  "Performance Tool desc": "Supports Trace, TestBench, and more. \nRequires an app restart after toggling.",
+  "TestBench": "TestBench",
+  "TestBench desc": "Lynx Page Recording Tool\nRequires an app restart after toggling.",
   "Current JS Engine": "Current JS engine"
 }

--- a/devtool/lynx_devtool/resources/devtool-switch/src/locales/zh.json
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/locales/zh.json
@@ -18,7 +18,7 @@
   "LogBox desc": "开启后运行出错时会弹出错误提示",
   "Highlight Touch": "高亮触摸",
   "Highlight Touch desc": "开启后触摸时高亮触摸区域,并且输出事件相关日志",
-  "Performance Tool": "性能工具",
-  "Performance Tool desc": "开启后支持 Trace、TestBench 等\n开关后需重启 app",
+  "TestBench": "TestBench",
+  "TestBench desc": "Lynx 页面录制工具\n开关后需重启",
   "Current JS Engine": "当前 JS 引擎"
 }

--- a/devtool/lynx_devtool/resources/devtool-switch/src/sections/TestBench.tsx
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/sections/TestBench.tsx
@@ -1,11 +1,11 @@
 import { useAtom, useAtomValue } from 'jotai';
 
-import { performanceTool, platform } from '../atoms';
+import { testBench, platform } from '../atoms';
 import { Switch } from '../components/Switch';
 import { i18n } from '../i18n';
 
-export function PerformanceTool() {
-  const [enable, setEnable] = useAtom(performanceTool);
+export function TestBench() {
+  const [enable, setEnable] = useAtom(testBench);
 
   const currentPlatform = useAtomValue(platform);
 
@@ -15,8 +15,8 @@ export function PerformanceTool() {
 
   return (
     <Switch
-      title={i18n.t('Performance Tool')}
-      description={i18n.t('Performance Tool desc')}
+      title={i18n.t('TestBench')}
+      description={i18n.t('TestBench desc')}
       on={enable}
       onChange={() => setEnable((prev) => !prev)}
     />

--- a/explorer/android/build.gradle
+++ b/explorer/android/build.gradle
@@ -98,9 +98,23 @@ ext.writeGnArgs = { String gnArgs ->
 if (buildLynxDebugSo) {
     // force Gradle to evaluate the child build.gradle files before the parent
     evaluationDependsOnChildren()
-
     Project lynxTrace = project(':LynxTrace')
     Project lynxAndroid = project(':LynxAndroid')
+    Project lynxDevtool = project(':LynxDevtool')
+    lynxDevtool.android.libraryVariants.each {
+        String flavorName = it.flavorName.capitalize()
+        String buildTypeName = it.buildType.name.capitalize()
+        Task jniLibFoldersTask = lynxDevtool.tasks["merge${flavorName.capitalize()}${buildTypeName}JniLibFolders"]
+        Task lynxTraceNativeBuild = lynxTrace.tasks["externalNativeBuildDebugMode${buildTypeName}"]
+        Task lynxAndroidNativeBuild = lynxAndroid.tasks["externalNativeBuildDebugMode${buildTypeName}"]
+        // lynx will use lynxtrace.so created by externalNativeBuildDebugMode
+        lynxAndroidNativeBuild.dependsOn(lynxTraceNativeBuild)
+        // devtool will use lynx.so created by externalNativeBuildDebugMode
+        jniLibFoldersTask.dependsOn(lynxAndroidNativeBuild)
+        // make sure always run generateJsonModel
+        Task generateJsonModelTask = lynxAndroid.tasks["generateJsonModelDebugMode${buildTypeName}"]
+        generateJsonModelTask.outputs.upToDateWhen { false }
+    }
 }
 
 


### PR DESCRIPTION
1. Add DebugTool switch to lynx-devtool-switch-card

2. Add support for LynxExplorer DebugMode builds, If you add -PbuildLynxDebugSo during the build phase, it will generate both lynx.so and lynx_debug.so as output binaries. The lynx_debug.so includes debugging tool logic.

Change-Id: I056711fa9cb4bd60185c4dc92d2738616d4c4fee

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
