### PR TITLE
[Optimize] merge kTemplateLazyBundle & kLazyBundle type.

### DIFF
--- a/core/public/lynx_resource_loader.h
+++ b/core/public/lynx_resource_loader.h
@@ -26,10 +26,6 @@ enum class LynxResourceType : int32_t {
   kLazyBundle = 7,  // LazyBundle from js
   kLynxCoreJs = 8,
   kExternalJs = 9,
-  // There are some differences between JSLazyBundle and
-  // TemplateLazyBundlein the old logic, so here is a new type to be
-  // compatible with the old logic.
-  kTemplateLazyBundle = 10,  // LazyBundle from template
   kAssets = 11,
   kI18nText = 12,
   kGraphics = 13,

--- a/core/resource/lazy_bundle/lazy_bundle_loader.cc
+++ b/core/resource/lazy_bundle/lazy_bundle_loader.cc
@@ -190,7 +190,7 @@ void LazyBundleLoader::RequireTemplate(RadonLazyComponent* lazy_bundle,
     return;
   }
   auto request =
-      pub::LynxResourceRequest{url, pub::LynxResourceType::kTemplateLazyBundle};
+      pub::LynxResourceRequest{url, pub::LynxResourceType::kLazyBundle};
   resource_loader_->LoadResource(
       request, true,
       [url, weak_self = weak_from_this(), lazy_bundle,
@@ -225,8 +225,8 @@ void LazyBundleLoader::PreloadTemplates(const std::vector<std::string>& urls) {
     return;
   }
   std::for_each(urls.begin(), urls.end(), [this](const auto& url) {
-    auto request = pub::LynxResourceRequest{
-        url, pub::LynxResourceType::kTemplateLazyBundle};
+    auto request =
+        pub::LynxResourceRequest{url, pub::LynxResourceType::kLazyBundle};
     resource_loader_->LoadResource(
         request, false,
         [url,

--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -247,17 +247,9 @@ bool LynxResourceLoaderDarwin::FetchTemplateByFetcherWrapper(const std::string& 
                                    .err_msg = [errMsg UTF8String]};
     callback(resp);
   };
-  if (request_in_current_thread) {
-    TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_TEMPLATE_BY_FETCHER_WRAPPER, "url", url);
-    [_fetcher_wrapper fetchResource:nsUrl withLoadedBlock:fetcherBlock];
-  } else {
-    // TODO(nihao.royal): it's only used in preloadTemplate by now, and need to be deleted later.
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
-      TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_TEMPLATE_BY_FETCHER_WRAPPER);
-      [_fetcher_wrapper fetchResource:nsUrl withLoadedBlock:fetcherBlock];
-    });
-  }
-  return true;
+  return [_fetcher_wrapper fetchResource:nsUrl
+                         withLoadedBlock:fetcherBlock
+                                    sync:request_in_current_thread];
 }
 
 void LynxResourceLoaderDarwin::LoadResource(
@@ -298,15 +290,20 @@ void LynxResourceLoaderDarwin::LoadResource(
     if (FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback)) {
       return;
     }
-    // 2. try to use LynxResourceProvider
-    if (FetchTemplateByProvider(request.url, copyable_wrapper_callback)) {
-      return;
-    }
-    // 3. try to use LynxExternalResourceFetcherWrapper
+
+    // 2. try to use LynxExternalResourceFetcherWrapper
     if (FetchTemplateByFetcherWrapper(request.url, copyable_wrapper_callback,
                                       request_in_current_thread)) {
       return;
     }
+    // 3. try to use LynxResourceProvider
+    if (FetchTemplateByProvider(request.url, copyable_wrapper_callback)) {
+      return;
+    }
+
+    // No available provider or fetcher
+    pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
+    copyable_wrapper_callback(resp);
     return;
   }
 
@@ -320,29 +317,12 @@ void LynxResourceLoaderDarwin::LoadResource(
         };
     auto copyable_wrapper_callback = fml::MakeCopyable(std::move(callback_wrapper));
     // 1. try to use LynxTemplateResourceFetcher
-    FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback);
-    return;
-  }
-
-  if (request.type == pub::LynxResourceType::kTemplateLazyBundle) {
-    auto copyable_callback = fml::MakeCopyable(std::move(callback));
-    std::string url_copy = request.url;
-    base::MoveOnlyClosure<void, pub::LynxResourceResponse&> callback_wrapper = ^(
-        pub::LynxResourceResponse& response) {
-      VerifyLynxTemplateResource(url_copy, response, pub::LynxResourceType::kTemplateLazyBundle);
-      copyable_callback(response);
-    };
-    auto copyable_wrapper_callback = fml::MakeCopyable(std::move(callback_wrapper));
-    // 1. try to use LynxTemplateResourceFetcher
     if (FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback)) {
       return;
     }
-
-    // 2. try to use LynxExternalResourceFetcherWrapper;
-    if (FetchTemplateByFetcherWrapper(request.url, copyable_wrapper_callback,
-                                      request_in_current_thread)) {
-      return;
-    }
+    // No available provider or fetcher
+    pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
+    copyable_wrapper_callback(resp);
     return;
   }
 

--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -4348,7 +4348,7 @@ public class abstract com::lynx::jsbridge::LynxExtensionModule :  {
 
 public class com::lynx::tasm::provider::LynxExternalResourceFetcherWrapper :  {
   public com.lynx.tasm.provider.LynxExternalResourceFetcherWrapper.LynxExternalResourceFetcherWrapper(DynamicComponentFetcher fetcher);
-  public void com.lynx.tasm.provider.LynxExternalResourceFetcherWrapper.fetchResourceWithHandler(String url, @NonNull LoadedHandler handler);
+  public boolean com.lynx.tasm.provider.LynxExternalResourceFetcherWrapper.fetchResourceWithDynamicComponentFetcher(final String url, @NonNull LoadedHandler handler);
 }
 
 public class com::lynx::tasm::featurecount::LynxFeatureCounter :  {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
@@ -51,7 +51,7 @@ public class LynxResourceLoader {
   static final String MSG_NULL_DATA = "get null data for provider.";
 
   private final LynxBackgroundRuntimeOptions mLynxRuntimeOptions;
-  private LynxExternalResourceFetcherWrapper mFetcherWrapper;
+  private final LynxExternalResourceFetcherWrapper mFetcherWrapper;
   private final TemplateLoaderHelper mTemplateLoaderHelper;
   private final LynxGenericResourceFetcher mGenericResourceFetcher;
 
@@ -108,24 +108,24 @@ public class LynxResourceLoader {
         if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
           break;
         }
+        // 3. try to use LynxExternalResourceFetcherWrapper
+        if (fetchTemplateByFetcherWrapper(responseHandler, url, type)) {
+          break;
+        }
         // 2. try to use LynxResourceProvider
         if (fetchTemplateByProvider(responseHandler, url, type)) {
           break;
         }
-        // 3. try to use LynxExternalResourceFetcherWrapper
-        fetchTemplateByFetcherWrapper(responseHandler, url, type);
-        break;
-      case LynxResourceType.LYNX_RESOURCE_TYPE_TEMPLATE_LAZY_BUNDLE:
-        // 1. try to use LynxTemplateResourceFetcher
-        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
-          break;
-        }
-        // 2. try to use LynxExternalResourceFetcherWrapper
-        fetchTemplateByFetcherWrapper(responseHandler, url, type);
+        InvokeNativeCallbackWithBytes(
+            responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
         break;
       case LynxResourceType.LYNX_RESOURCE_TYPE_FRAME:
         // 1. frame only support LynxTemplateResourceFetcher
-        fetchTemplateByGenericTemplateFetcher(responseHandler, url, type);
+        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
+          break;
+        }
+        InvokeNativeCallbackWithBytes(
+            responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
         break;
       default:
         InvokeNativeCallbackWithBytes(
@@ -292,8 +292,9 @@ public class LynxResourceLoader {
   /**
    * fetch lazy bundle template by LynxExternalResourceFetcherWrapper
    */
-  private void fetchTemplateByFetcherWrapper(long responseHandler, String url, int resourceType) {
-    mFetcherWrapper.fetchResourceWithHandler(
+  private boolean fetchTemplateByFetcherWrapper(
+      long responseHandler, String url, int resourceType) {
+    return mFetcherWrapper.fetchResourceWithDynamicComponentFetcher(
         url, new LynxExternalResourceFetcherWrapper.LoadedHandler() {
           private final TemplateResourceCallback mCallback =
               new TemplateResourceCallback(url, responseHandler, mReportHelper, resourceType);

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceType.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceType.java
@@ -21,11 +21,6 @@ class LynxResourceType {
   static final int LYNX_RESOURCE_TYPE_EXTERNAL_JS = 9;
 
   /**
-   * Load load bundle on MTS
-   */
-  static final int LYNX_RESOURCE_TYPE_TEMPLATE_LAZY_BUNDLE = 10;
-
-  /**
    * Load asset js source on BTS
    */
   static final int LYNX_RESOURCE_TYPE_ASSETS = 11;

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/provider/LynxExternalResourceFetcherWrapper.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/provider/LynxExternalResourceFetcherWrapper.java
@@ -36,12 +36,7 @@ public class LynxExternalResourceFetcherWrapper {
     mDynamicComponentFetcher = fetcher;
   }
 
-  // pass data and error
-  public void fetchResourceWithHandler(String url, @NonNull LoadedHandler handler) {
-    fetchResourceWithDynamicComponentFetcher(url, handler);
-  }
-
-  private void fetchResourceWithDynamicComponentFetcher(
+  public boolean fetchResourceWithDynamicComponentFetcher(
       final String url, @NonNull LoadedHandler handler) {
     if (mDynamicComponentFetcher != null) {
       TraceEvent.beginSection(TraceEventDef.FETCHER_WRAPPER_USE_LAZY_BUNDLE_FETCHER);
@@ -53,10 +48,8 @@ public class LynxExternalResourceFetcherWrapper {
             }
           });
       TraceEvent.endSection(TraceEventDef.FETCHER_WRAPPER_USE_LAZY_BUNDLE_FETCHER);
-      return;
+      return true;
     }
-
-    // No available provider or fetcher
-    handler.onLoaded(null, new Throwable("No available provider or fetcher"));
+    return false;
   }
 }

--- a/platform/darwin/common/lynx/base/LynxExternalResourceFetcherWrapper.mm
+++ b/platform/darwin/common/lynx/base/LynxExternalResourceFetcherWrapper.mm
@@ -23,17 +23,21 @@
   return self;
 }
 
-- (void)fetchResource:(NSString*)url withLoadedBlock:(LoadedBlock)callback {
-  if (_component_fetcher) {
-    TRACE_EVENT(LYNX_TRACE_CATEGORY, DYNAMIC_COMPONENT_FETCHER_LOAD_COMPONENT, "url",
-                [url UTF8String]);
-    [_component_fetcher loadDynamicComponent:url withLoadedBlock:callback];
-    return;
+- (BOOL)fetchResource:(NSString*)url withLoadedBlock:(LoadedBlock)callback sync:(BOOL)sync {
+  if (!_component_fetcher) {
+    // false if component fetcher not set;
+    return false;
   }
-
-  // No available provider or fetcher
-  callback(nil, [LynxError lynxErrorWithCode:ECLynxResourceExternalResourceRequestFailed
-                                 description:@"No available provider or fetcher"]);
+  TRACE_EVENT(LYNX_TRACE_CATEGORY, DYNAMIC_COMPONENT_FETCHER_LOAD_COMPONENT, "url",
+              [url UTF8String]);
+  if (sync) {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
+      [self->_component_fetcher loadDynamicComponent:url withLoadedBlock:callback];
+    });
+  } else {
+    [_component_fetcher loadDynamicComponent:url withLoadedBlock:callback];
+  }
+  return true;
 }
 
 @end

--- a/platform/darwin/common/lynx/public/base/LynxExternalResourceFetcherWrapper.h
+++ b/platform/darwin/common/lynx/public/base/LynxExternalResourceFetcherWrapper.h
@@ -20,7 +20,12 @@ typedef void (^LoadedBlock)(NSData* _Nullable data, NSError* _Nullable error);
 
 - (instancetype)initWithDynamicComponentFetcher:(id<LynxDynamicComponentFetcher>)fetcher;
 
-- (void)fetchResource:(NSString*)url withLoadedBlock:(LoadedBlock)block;
+/**
+ * url: uri to load fetch resource;
+ * block: callback for resource loading process;
+ * sync: need to call component_fetcher synchronously;
+ */
+- (BOOL)fetchResource:(NSString*)url withLoadedBlock:(LoadedBlock)block sync:(BOOL)sync;
 
 @end
 

--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -1451,7 +1451,7 @@ public protocol LynxExtensionModule-p : <NSObject> {
 
 public class LynxExternalResourceFetcherWrapper : NSObject {
   public instancetype LynxExternalResourceFetcherWrapper::initWithDynamicComponentFetcher:(id< LynxDynamicComponentFetcher > fetcher);
-  public void LynxExternalResourceFetcherWrapper::fetchResource:withLoadedBlock:(NSString *url,[withLoadedBlock] LoadedBlock block);
+  public BOOL LynxExternalResourceFetcherWrapper::fetchResource:withLoadedBlock:sync:(NSString *url,[withLoadedBlock] LoadedBlock block,[sync] BOOL sync);
 }
 
 public class LynxExtraTiming : NSObject {


### PR DESCRIPTION
`kTemplateLazyBundle` & `kLazyBundle` exist for historical reasons. The only difference is `kLazyBundle` fetch resource also by provider registered by ResourceProvider, we merge these two types now, the new resource fetching processor is: TemplateResourceFetcher > DynamicComponentFetcher > ResourceProvider.

issue: f-230395787
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
