### PR TITLE
[Infra][lldb]: add String type summary script and register in lynx_lldb.py

### DIFF
--- a/base/include/value/base_string_lldb.py
+++ b/base/include/value/base_string_lldb.py
@@ -1,0 +1,46 @@
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import lldb
+
+def get_string_summary(valobj, internal_dict):
+    """Get summary for lynx::base::String.
+    
+    Args:
+        valobj: The value object of lynx::base::String
+        internal_dict: Internal dictionary
+        
+    Returns:
+        A string containing the string content
+    """
+    try:
+        ref_impl = valobj.GetChildMemberWithName('ref_impl_')
+        if not ref_impl:
+            return '<invalid>'
+        ptr_value = ref_impl.GetValueAsUnsigned()
+        is_tagged = (ptr_value & 1) == 1
+        tag_info = f"[ref_impl_=0x{ptr_value:x}, tagged={is_tagged}] "
+        expr = valobj.EvaluateExpression('((lynx::base::RefCountedStringImpl*)((uintptr_t)ref_impl_ & ~1))->str_')
+        str_value = expr.GetSummary() if expr.IsValid() else None
+        if str_value and str_value != '""':
+            if str_value.startswith('"') and str_value.endswith('"'):
+                str_value = str_value[1:-1]
+            return tag_info + str_value
+        else:
+            return tag_info + "<empty>"
+    except Exception as e:
+        return f'<error: {str(e)}>'
+
+def __lldb_init_module(debugger, internal_dict):
+    """Initialize the LLDB module.
+    
+    Args:
+        debugger: The LLDB debugger
+        internal_dict: Internal dictionary
+    """
+    # Add type summary for lynx::base::String
+    debugger.HandleCommand(
+        'type summary add -F base_string_lldb.get_string_summary -x "^lynx::base::String$" -w liblynx'
+    )
+    debugger.HandleCommand('type category enable liblynx')

--- a/tools/lldb/lynx_lldb.py
+++ b/tools/lldb/lynx_lldb.py
@@ -31,6 +31,7 @@ def __lldb_init_module(debugger, internal_dict):
         'base/include/linked_hash_map_lldb.py',
         'base/include/vector_lldb.py',
         'base/include/value/lynx_value_lldb.py',
+        'base/include/value/base_string_lldb.py',
     ]
 
     for f in scripts:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Background

The `lynx::base::String` class in `base_string.h` encapsulates a pointer to `RefCountedStringImpl`. For optimization, it uses a tagged pointer: when `ref_impl_` is in a tagged state (pointer value +1), the LLDB debugger cannot directly display the `str_` content inside the `RefCountedStringImpl` object.  
The Lynx project already provides several LLDB helper scripts registered in `lynx_lldb.py`. However, there was no type summary for `lynx::base::String` that could display the string content and handle tagged pointers.

## Summary

- Added `base/include/value/base_string_lldb.py`, which provides an LLDB type summary for `lynx::base::String`, compatible with both normal and tagged pointer states.
- Updated `tools/lldb/lynx_lldb.py` to automatically register `base_string_lldb.py`, unifying the entry point for all Lynx LLDB helper scripts.

This change allows developers to directly view the string content of `lynx::base::String` variables in LLDB, regardless of whether the pointer is tagged, greatly improving debugging efficiency and experience.

## Test

- Locally verified with `test/lldb_test/test_string_lldb.cpp`.
- In LLDB, commands like `frame variable str1/str2/str3/static_str` correctly display string content and tag status.
- Covered scenarios: tagged pointer, normal pointer, static string, special characters, copy/assignment, and empty string.

### How to Test

1. **Build the test executable:**
   - Write a test, `test_string_lldb.cpp`, for example, with all the test cases that you want to test.
      ```cpp          
      lynx::base::String str1("Hello World");
      lynx::base::String str2;
      auto* raw = lynx::base::RefCountedStringImpl::Unsafe::RawCreate("WeakRef");
      lynx::base::String str3 = lynx::base::String::Unsafe::ConstructWeakRefStringFromRawRef(raw);
      ...
     ``` 
   -  Compile with debug info enabled (e.g. using `ninja -C out/Default test_string_lldb`).
3. **Start LLDB and import the Lynx LLDB helper scripts:**
   - Launch LLDB with the test executable, e.g.:
     ```bash
     lldb
     ```
   - In LLDB, import the script:
     ```lldb
     command script import tools/lldb/lynx_lldb.py
     ```
4. **Set a breakpoint after all test variables are constructed:**
   - For example, using the command like (adjust line number as needed).
     ```lldb
     breakpoint set --file test_string_lldb.cpp --line 39
     ```
5. **Run the program and inspect variables:**
   -  run the script with command
       ```lldb
        run
       ```
   - Use LLDB commands such as:
     ```lldb
     frame variable str1
     frame variable str2
     frame variable str3
     frame variable static_str
     frame variable manual_tagged
     ...
     ```
   - Observe the output to ensure the string content and tag status are displayed as expected.


### Expected Results

- For each variable, LLDB should display the string content and whether the pointer is tagged, e.g.:
  ```
  (lynx::base::String) str1 = [ref_impl_=0x..., tagged=False] Hello World
  (lynx::base::String) str2 = [ref_impl_=0x..., tagged=True] <empty>
  (lynx::base::String) str3 = [ref_impl_=0x..., tagged=True] WeakRef
  (lynx::base::String) static_str = (lynx::base::String = [ref_impl_=0x..., tagged=True] I am a StaticString)
  ...
  ```

- All scenarios (tagged/untagged, static, empty, special characters, etc.) should be correctly handled and displayed.


## Other

- This PR only includes the LLDB helper script and registration changes. Local test code is not included.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).