### PR TITLE
[Testing] Add timeout and retry mechanism when adb install fails

### DIFF
--- a/tools/rtf/core/container/android_ut_container.py
+++ b/tools/rtf/core/container/android_ut_container.py
@@ -30,6 +30,12 @@ class AndroidUTContainer(Container):
         self.use_real_device = False
         self.clean = True
 
+    def restart_device_handler(self):
+        self.emulator.close()
+        self.emulator.prepare_android_emulator(use_real_device=self.use_real_device)
+        for target in self.targets:
+            target.insert_global_info("device_name", self.emulator.device)
+
     def before_test(self, targets, filter: str):
         result = self.emulator.prepare_android_emulator(
             use_real_device=self.use_real_device
@@ -66,6 +72,9 @@ class AndroidUTContainer(Container):
             if result.is_err():
                 return result
             target.insert_global_info("device_name", self.emulator.device)
+            target.insert_global_info(
+                "restart_device_handler", self.restart_device_handler
+            )
 
         return Ok()
 

--- a/tools/rtf/core/target/android_ut_target.py
+++ b/tools/rtf/core/target/android_ut_target.py
@@ -75,19 +75,37 @@ class AndroidUTTarget(Target):
             pull_ec_file_cmd = f"adb -s {self.global_info['device_name']} pull /sdcard/coverage_{self.name}.ec {RTFEnv.get_project_root_path()}"
             subprocess.check_call(pull_ec_file_cmd, shell=True)
 
-    def install_apk(self):
-        Log.info(f"Installing apk for {self.name}")
-        install_cmd = (
-            f"adb -s {self.global_info['device_name']} install -g {self.target_path}"
+    def install_apk_aux(self):
+        retry_times = 1
+        retry = 0
+        timeout = 120
+        while True:
+            Log.info(f"Installing apk for {self.name}")
+            install_cmd = f"adb -s {self.global_info['device_name']} install -g {self.target_path}"
+            try:
+                subprocess.check_call(install_cmd, shell=True, timeout=timeout)
+                return Ok()
+            except subprocess.TimeoutExpired:
+                Log.error(f"adb install timeout, retry ({retry}/{retry_times})")
+                if retry < retry_times:
+                    retry += 1
+                    handler = self.global_info["restart_device_handler"]
+                    if handler is not None:
+                        handler()
+                else:
+                    break
+            except Exception as e:
+                return Err(
+                    Constants.ANDROID_APK_INSTALL_ERR,
+                    f"adb install failed for {self.name} \n: {e}",
+                )
+        return Err(
+            Constants.ANDROID_APK_INSTALL_ERR,
+            f"adb install {self.target_path} timeout: {timeout}s",
         )
-        try:
-            subprocess.check_call(install_cmd, shell=True)
-            return Ok()
-        except Exception as e:
-            return Err(
-                Constants.ANDROID_APK_INSTALL_ERR,
-                f"adb install failed for {self.name} \n: {e}",
-            )
+
+    def install_apk(self):
+        return self.install_apk_aux()
 
     def run(self):
         result = self.install_apk()

--- a/tools/rtf/plugins/native_ut_plugin.py
+++ b/tools/rtf/plugins/native_ut_plugin.py
@@ -73,8 +73,10 @@ class TraceEventSummary(SummaryConsumer):
         traces = {"traceEvents": []}
         self.accept_aux(traces["traceEvents"], summary)
         Log.info(traces)
-        trace_path = os.path.join(RTFEnv.get_project_root_path(), "native-ut-trace-events.json")
-        with open(trace_path, "w")  as f:
+        trace_path = os.path.join(
+            RTFEnv.get_project_root_path(), "native-ut-trace-events.json"
+        )
+        with open(trace_path, "w") as f:
             f.write(json.dumps(traces))
 
 


### PR DESCRIPTION
If adb install exceeds 120 seconds, it will retry once, and the emulator will be restarted during this process.

Change-Id: I6596d335a6197afe2e7289e4bffc625b761a3c94

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
