### PR TITLE
[BugFix] invoke callback directly if not provider or fetcher set

### DIFF
--- a/core/resource/lynx_resource_loader_darwin.h
+++ b/core/resource/lynx_resource_loader_darwin.h
@@ -44,13 +44,19 @@ class LynxResourceLoaderDarwin : public pub::LynxResourceLoader {
   NSData* LoadJSSource(const std::string& name);
   NSData* LoadLynxJSAsset(const std::string& name, NSURL& bundleUrl, NSURL& debugBundleUrl);
 
-  void FetchScriptByProvider(const std::string& url, CopyableClosure callback);
+  /**
+   * Try to fetch script by ExternalJS Provider, if provider not set, return false;
+   */
+  bool FetchScriptByProvider(const std::string& url, CopyableClosure callback);
 
   /**
-   * Try to fetch template by Generic Fetcher. if generic fetcher not registered, it will fallback.
+   * Try to fetch template by Generic Fetcher. if generic fetcher not set, return false;
    */
   bool FetchTemplateByGenericFetcher(const std::string& url, CopyableClosure callback);
 
+  /**
+   * Try to fetch resource by Generic Fetcher. if generic fetcher not set, return false;
+   */
   bool FetchResourceByGenericFetcher(const std::string& url, CopyableClosure callback);
 
   /**

--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -122,7 +122,7 @@ LynxResourceLoaderDarwin::LynxResourceLoaderDarwin(
       _genericResourceFetcher(genericResourceFetcher),
       _errorReceiver(errorReceiver) {}
 
-void LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
+bool LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
                                                      CopyableClosure callback) {
   id<LynxResourceProvider> provider =
       [_providerRegistry getResourceProviderByKey:LYNX_PROVIDER_TYPE_EXTERNAL_JS];
@@ -130,7 +130,7 @@ void LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
     LOGE("lynx resource provider is null, url: " << url);
     pub::LynxResourceResponse res{.err_code = -1, .err_msg = "lynx resource provider is null."};
     callback(res);
-    return;
+    return false;
   }
   TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_SCRIPT_BY_PROVIDER, "url", url);
   NSString* nsUrl = [NSString stringWithUTF8String:url.c_str()];
@@ -141,6 +141,7 @@ void LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
            FetchExternalResourceComplete(response.data, response.error, nsUrl, weakErrorReceiver,
                                          std::move(callback));
          }];
+  return true;
 }
 
 bool LynxResourceLoaderDarwin::FetchTemplateByGenericFetcher(const std::string& url,
@@ -273,7 +274,13 @@ void LynxResourceLoaderDarwin::LoadResource(
     if (FetchResourceByGenericFetcher(request.url, copyable_callback)) {
       return;
     }
-    FetchScriptByProvider(request.url, std::move(copyable_callback));
+    // 2. try to use external js provider
+    if (FetchScriptByProvider(request.url, copyable_callback)) {
+      return;
+    }
+    // invoke callback directly if no provider or fetcher set;
+    pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
+    copyable_callback(resp);
     return;
   }
 
@@ -301,7 +308,7 @@ void LynxResourceLoaderDarwin::LoadResource(
       return;
     }
 
-    // No available provider or fetcher
+    // invoke callback directly if no provider or fetcher set;
     pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
     copyable_wrapper_callback(resp);
     return;
@@ -320,7 +327,7 @@ void LynxResourceLoaderDarwin::LoadResource(
     if (FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback)) {
       return;
     }
-    // No available provider or fetcher
+    // invoke callback directly if no provider or fetcher set;
     pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
     copyable_wrapper_callback(resp);
     return;

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
@@ -101,21 +101,28 @@ public class LynxResourceLoader {
         if (fetchResourceByGenericFetcher(responseHandler, url)) {
           break;
         }
-        fetchScriptByProvider(responseHandler, url);
+        // 2. try to use external js provider;
+        if (fetchScriptByProvider(responseHandler, url)) {
+          break;
+        }
+        // invoke callback directly if no provider or fetcher set;
+        InvokeNativeCallbackWithBytes(
+            responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
         break;
       case LynxResourceType.LYNX_RESOURCE_TYPE_JS_LAZY_BUNDLE:
         // 1. try to use LynxTemplateResourceFetcher
         if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
           break;
         }
-        // 3. try to use LynxExternalResourceFetcherWrapper
+        // 2. try to use LynxExternalResourceFetcherWrapper
         if (fetchTemplateByFetcherWrapper(responseHandler, url, type)) {
           break;
         }
-        // 2. try to use LynxResourceProvider
+        // 3. try to use LynxResourceProvider
         if (fetchTemplateByProvider(responseHandler, url, type)) {
           break;
         }
+        // invoke callback directly if no provider or fetcher set;
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
         break;
@@ -124,6 +131,7 @@ public class LynxResourceLoader {
         if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
           break;
         }
+        // invoke callback directly if no provider or fetcher set;
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
         break;
@@ -378,12 +386,14 @@ public class LynxResourceLoader {
 
   /**
    * fetch script by LynxResourceProvider
+   *
+   * @return false if provider not set;
    */
-  private void fetchScriptByProvider(long responseHandler, String url) {
+  private boolean fetchScriptByProvider(long responseHandler, String url) {
     LynxResourceProvider provider =
         getResourceProviderByType(LynxResourceType.LYNX_RESOURCE_TYPE_EXTERNAL_JS);
     if (provider == null) {
-      return;
+      return false;
     }
     final LynxResourceRequest request = new LynxResourceRequest(url);
     provider.request(request, new LynxResourceCallback<byte[]>() {
@@ -398,6 +408,7 @@ public class LynxResourceLoader {
             success, response.getData(), error != null ? error.getMessage() : null);
       }
     });
+    return true;
   }
 
   private LynxResourceProvider getResourceProviderByType(int type) {


### PR DESCRIPTION
`lynx.requireModule` is a sync api for javascript to load external script, it will block for 5ms if provider or fetcher is not set. Fix this issue by invoking callback directly if finding out that provider or fetcher is not set.

issue: f-23085786
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
