### PR TITLE
[BugFix] Fix lynx_core.js load failed problem.

### DIFF
--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -7,6 +7,7 @@
 #import <Lynx/LynxError.h>
 #import <Lynx/LynxLog.h>
 #import <Lynx/LynxService.h>
+#import <Lynx/LynxServiceDevToolProtocol.h>
 #import <Lynx/LynxSubErrorCode.h>
 #import "LynxTemplateBundle+Converter.h"
 #include "base/trace/native/trace_event.h"
@@ -353,11 +354,13 @@ NSData* LynxResourceLoaderDarwin::LoadJSSource(const std::string& name) {
   NSString* str = [NSString stringWithUTF8String:name.c_str()];
 
   NSString* path = nil;
-  NSBundle* frameworkBundle = [NSBundle mainBundle];
+  NSBundle* frameworkBundle = [NSBundle bundleForClass:[LynxEnv class]];
+  Class debuggerBridgeClass = [LynxService(LynxServiceDevToolProtocol) debuggerBridgeClass];
+  NSBundle* devtoolFrameworkBundle = [NSBundle bundleForClass:debuggerBridgeClass];
   if ([kAssetsCoreScheme isEqualToString:str]) {
     str = [str componentsSeparatedByString:@"."][0];
-    NSURL* debugBundleUrl = [frameworkBundle URLForResource:@"LynxDebugResources"
-                                              withExtension:@"bundle"];
+    NSURL* debugBundleUrl = [devtoolFrameworkBundle URLForResource:@"LynxDebugResources"
+                                                     withExtension:@"bundle"];
     if (path == nil && debugBundleUrl && LynxEnv.sharedInstance.devtoolEnabled) {
       NSBundle* bundle = [NSBundle bundleWithURL:debugBundleUrl];
       path = [bundle pathForResource:kCoreDebugJS ofType:@"js"];

--- a/devtool/base_devtool/darwin/common/utils/DevToolFileLoadUtils.mm
+++ b/devtool/base_devtool/darwin/common/utils/DevToolFileLoadUtils.mm
@@ -21,7 +21,8 @@
                         }]);
     return;
   }
-  NSURL *debugBundleUrl = [[NSBundle mainBundle] URLForResource:bundleUrl withExtension:@"bundle"];
+  NSURL *debugBundleUrl = [[NSBundle bundleForClass:[self class]] URLForResource:bundleUrl
+                                                                   withExtension:@"bundle"];
   if (!debugBundleUrl) {
     completion(nil, [NSError errorWithDomain:@"com.basedevtool.utils"
                                         code:-1

--- a/devtool/base_devtool/darwin/ios/logbox/DevToolLogBox.mm
+++ b/devtool/base_devtool/darwin/ios/logbox/DevToolLogBox.mm
@@ -269,8 +269,9 @@ NSString *const BRIDGE_JS =
 
 - (NSURL *)getLogBoxPageUrl {
   NSURL *url;
-  NSURL *debugBundleUrl = [[NSBundle mainBundle] URLForResource:@"LynxBaseDevToolResources"
-                                                  withExtension:@"bundle"];
+  NSURL *debugBundleUrl =
+      [[NSBundle bundleForClass:[self class]] URLForResource:@"LynxBaseDevToolResources"
+                                               withExtension:@"bundle"];
   if (debugBundleUrl) {
     NSBundle *bundle = [NSBundle bundleWithURL:debugBundleUrl];
     url = [bundle URLForResource:@"logbox/index" withExtension:@".html"];
@@ -600,8 +601,9 @@ NSString *const BRIDGE_JS =
 }
 
 - (void)loadMappingsWasm {
-  NSURL *debugBundleUrl = [[NSBundle mainBundle] URLForResource:@"LynxBaseDevToolResources"
-                                                  withExtension:@"bundle"];
+  NSURL *debugBundleUrl =
+      [[NSBundle bundleForClass:[self class]] URLForResource:@"LynxBaseDevToolResources"
+                                               withExtension:@"bundle"];
   if (!debugBundleUrl) {
     NSLog(@"Failed to load mappings.wasm: resource bundle not exists");
     return;

--- a/devtool/base_devtool/darwin/ios/logbox/DevToolLogBoxNotification.m
+++ b/devtool/base_devtool/darwin/ios/logbox/DevToolLogBoxNotification.m
@@ -206,8 +206,9 @@ static CGFloat imageMargin = 3.0;
     _closeButton.layer.masksToBounds = YES;
 
     // Set image to _closeButton(iOS)/_closeImage(MacOS).
-    NSURL *debugBundleUrl = [[NSBundle mainBundle] URLForResource:@"LynxBaseDevToolResources"
-                                                    withExtension:@"bundle"];
+    NSURL *debugBundleUrl =
+        [[NSBundle bundleForClass:[self class]] URLForResource:@"LynxBaseDevToolResources"
+                                                 withExtension:@"bundle"];
     if (debugBundleUrl) {
       NSBundle *bundle = [NSBundle bundleWithURL:debugBundleUrl];
       NSString *path = [bundle pathForResource:@"notification_cancel" ofType:@"png"];

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/provider/DemoTemplateResourceFetcher.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/provider/DemoTemplateResourceFetcher.m
@@ -3,6 +3,8 @@
 // LICENSE file in the root directory of this source tree.
 
 #import "DemoTemplateResourceFetcher.h"
+#import <Lynx/LynxService.h>
+#import <Lynx/LynxServiceDevToolProtocol.h>
 #import <TestBenchReplay/TestBenchEnv.h>
 
 @implementation DemoTemplateResourceFetcher
@@ -21,8 +23,10 @@
       res.url = [[NSBundle mainBundle] pathForResource:[localUrl stringByDeletingPathExtension]
                                                 ofType:@"bundle"];
       if (res.url == nil) {
-        NSURL *debugBundleUrl = [[NSBundle mainBundle] URLForResource:@"LynxDebugResources"
-                                                        withExtension:@"bundle"];
+        Class debuggerBridgeClass = [LynxService(LynxServiceDevToolProtocol) debuggerBridgeClass];
+        NSBundle *devtoolFrameworkBundle = [NSBundle bundleForClass:debuggerBridgeClass];
+        NSURL *debugBundleUrl = [devtoolFrameworkBundle URLForResource:@"LynxDebugResources"
+                                                         withExtension:@"bundle"];
         NSBundle *bundle = [NSBundle bundleWithURL:debugBundleUrl];
         localUrl = [NSString stringWithFormat:@"%@%@", subSourceUrl.host, subSourceUrl.path];
         res.url = [bundle pathForResource:[localUrl stringByDeletingPathExtension]


### PR DESCRIPTION
When integrate Lynx with dynamic framework, lynx_core.js won't be loaded because the bundle path of it is wrong. This change fixs the problem.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
