### PR TITLE
[Infra] Fix regex library warnings in skip_pod_lint.py

### DIFF
--- a/tools/ios_tools/skip_pod_lint.py
+++ b/tools/ios_tools/skip_pod_lint.py
@@ -20,7 +20,7 @@ def skip_pod_lint(source):
     pattern = "validate_podspec"
     with open(path,"r",encoding='utf8') as f:
         file_content = f.read()
-        file_content = re.sub(pattern, r"#validate_podspec", file_content, 1)
+        file_content = re.sub(pattern, r"#validate_podspec", file_content, count=1)
     with open(path,"w",encoding='utf8') as f:
         f.write(file_content)
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary
This small PR resolves the regex library warnings:
```python
/tmp/lynx/tools/ios_tools/skip_pod_lint.py:23: DeprecationWarning: 'count' is passed as positional argument
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
