### PR TITLE
[Optimize] remove unused QueryComponent api.

### DIFF
--- a/core/renderer/template_assembler.cc
+++ b/core/renderer/template_assembler.cc
@@ -2491,18 +2491,6 @@ std::shared_ptr<TemplateEntry> TemplateAssembler::RequestTemplateEntryInternal(
   return nullptr;
 }
 
-std::shared_ptr<TemplateEntry> TemplateAssembler::QueryComponent(
-    const std::string& url) {
-  LOGI("QueryComponent from LEPUS: " << url);
-  // check if the lazy-bundle is already loaded.
-  auto entry = FindTemplateEntry(url);
-  if (entry == nullptr && component_loader_ != nullptr) {
-    component_loader_->RequireTemplate(nullptr, url, instance_id_);
-  }
-  // check if the lazy-bundle is loaded success.
-  return FindTemplateEntry(url);
-}
-
 void TemplateAssembler::PreloadLazyBundles(
     const std::vector<std::string>& urls) {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, LAZY_BUNDLE_PRELOAD, "preload_urls",

--- a/core/renderer/template_assembler.h
+++ b/core/renderer/template_assembler.h
@@ -463,8 +463,6 @@ class TemplateAssembler final
   void GetDecodedJSSource(
       std::unordered_map<std::string, std::string>& js_source);
 
-  std::shared_ptr<TemplateEntry> QueryComponent(const std::string& url);
-
   void SendAirPageEvent(const std::string& event, const lepus::Value& value);
 
   void RenderTemplateForAir(const std::shared_ptr<TemplateEntry>& card,


### PR DESCRIPTION
remove QueryComponent api on TemplateAssembler, as it's unused now.

issue: f-23957767
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
