### PR TITLE
[Bugfix] passing null for url when TemplateBundle.fromNative

### DIFF
--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateBundle.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateBundle.java
@@ -78,7 +78,7 @@ public final class TemplateBundle {
   private static TemplateBundle fromNative(long nativePtr) {
     // TODO(nihao.royal) add template size & template url for recycled TemplateBundle.
     String errMsg = nativePtr == 0 ? "native TemplateBundle doesn't exist" : null;
-    return new TemplateBundle(nativePtr, 0, "", errMsg);
+    return new TemplateBundle(nativePtr, 0, null, errMsg);
   }
 
   private void initWithOption(TemplateBundleOption option) {


### PR DESCRIPTION
passing null for url when TemplateBundle.fromNative

issue: f-2304876
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
