### PR TITLE
[Optimize] support accquire page-config info for tasm-decoder.

### DIFF
--- a/core/renderer/tasm/napi_bind.cc
+++ b/core/renderer/tasm/napi_bind.cc
@@ -116,8 +116,9 @@ class TASMAddon : public Napi::Addon<TASMAddon> {
     bool result = reader.Decode();
     if (result) {
       // decode success.
+      auto template_bundle = reader.GetTemplateBundle();
       std::string res = lynx::tasm::LynxTemplateBundleConverter::
-          ConvertTemplateBundleToSerializedString(reader.GetTemplateBundle());
+          ConvertTemplateBundleToSerializedString(template_bundle);
       obj.Set("status", 0);
       obj.Set("result", std::move(res));
       return obj;

--- a/core/template_bundle/lynx_template_bundle_converter.cc
+++ b/core/template_bundle/lynx_template_bundle_converter.cc
@@ -65,7 +65,7 @@ void SerializeMTSBundle(
 
 std::string
 LynxTemplateBundleConverter::ConvertTemplateBundleToSerializedString(
-    const LynxTemplateBundle &template_bundle) {
+    LynxTemplateBundle &template_bundle) {
   rapidjson::Document main_document;
   main_document.SetObject();
   rapidjson::Document::AllocatorType &allocator = main_document.GetAllocator();
@@ -81,6 +81,11 @@ LynxTemplateBundleConverter::ConvertTemplateBundleToSerializedString(
                           template_bundle.enable_css_variable_, allocator);
   main_document.AddMember("enable-css-parser",
                           template_bundle.enable_css_parser_, allocator);
+
+  // put page config;
+  auto page_config = template_bundle.GetPageConfig();
+  main_document.AddMember("page-config", page_config->GetOriginalConfig(),
+                          allocator);
 
   // css
   rapidjson::Document css_document(&allocator);

--- a/core/template_bundle/lynx_template_bundle_converter.h
+++ b/core/template_bundle/lynx_template_bundle_converter.h
@@ -15,7 +15,7 @@ namespace tasm {
 class LynxTemplateBundleConverter final {
  public:
   static std::string ConvertTemplateBundleToSerializedString(
-      const LynxTemplateBundle& template_bundle);
+      LynxTemplateBundle& template_bundle);
 };
 }  // namespace tasm
 }  // namespace lynx

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_base_template_reader.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_base_template_reader.cc
@@ -509,8 +509,8 @@ bool LynxBinaryBaseTemplateReader::DecodeSpecificSection(
       page_config_offset_ = stream_->offset();
       DECODE_STDSTR(config_str);
       EnsurePageConfig();
-      ERROR_UNLESS(
-          config_decoder_->DecodePageConfig(config_str, page_configs_));
+      ERROR_UNLESS(config_decoder_->DecodePageConfig(std::move(config_str),
+                                                     page_configs_));
       break;
     }
     case BinarySection::DYNAMIC_COMPONENT: {

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
@@ -300,7 +300,7 @@ static constexpr const char* const kEnableAsyncFlushSubtree =
     "enableAsyncResolveSubtree";
 
 bool LynxBinaryConfigDecoder::DecodePageConfig(
-    const std::string& config_str, std::shared_ptr<PageConfig>& page_config) {
+    std::string config_str, std::shared_ptr<PageConfig>& page_config) {
   rapidjson::Document doc;
   if (doc.Parse(config_str.c_str()).HasParseError()) {
     LOGE("DecodePageConfig Error!");
@@ -1145,7 +1145,7 @@ bool LynxBinaryConfigDecoder::DecodePageConfig(
   }
 
   config_helper_.HandlePageConfig(doc, page_config);
-
+  page_config->SetOriginalConfig(std::move(config_str));
   ReportGlobalFeatureSwitch(page_config);
   return true;
 }

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.h
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.h
@@ -33,7 +33,7 @@ class LynxBinaryConfigDecoder {
   LynxBinaryConfigDecoder(LynxBinaryConfigDecoder&&) = delete;
   LynxBinaryConfigDecoder& operator=(LynxBinaryConfigDecoder&&) = delete;
 
-  bool DecodePageConfig(const std::string& config_str,
+  bool DecodePageConfig(std::string config_str,
                         std::shared_ptr<PageConfig>& page_config);
   bool DecodeComponentConfig(
       const std::string& config_str,

--- a/core/template_bundle/template_codec/binary_decoder/page_config.h
+++ b/core/template_bundle/template_codec/binary_decoder/page_config.h
@@ -172,6 +172,12 @@ class PageConfig final : public EntryConfig {
     return map;
   }
 
+  inline void SetOriginalConfig(std::string config_str) {
+    original_config_ = std::move(config_str);
+  }
+
+  inline std::string GetOriginalConfig() { return original_config_; }
+
   inline void SetVersion(const std::string& version) { page_version = version; }
 
   inline std::string GetVersion() { return page_version; }
@@ -1474,6 +1480,8 @@ class PageConfig final : public EntryConfig {
   bool need_post_to_platform_{true};
 
   TernaryBool enable_async_resolve_subtree_{TernaryBool::UNDEFINE_VALUE};
+
+  std::string original_config_{};
 
   template <typename T>
   using PageConfigSetter = void (PageConfig::*)(T);

--- a/core/template_bundle/template_codec/wasm_bind.cc
+++ b/core/template_bundle/template_codec/wasm_bind.cc
@@ -27,8 +27,9 @@ lynx::tasm::DecodeResult decode(uintptr_t binaryPtr, size_t length) {
   bool result = reader.Decode();
   if (result) {
     // decode success.
+    auto template_bundle = reader.GetTemplateBundle();
     std::string res = lynx::tasm::LynxTemplateBundleConverter::
-        ConvertTemplateBundleToSerializedString(reader.GetTemplateBundle());
+        ConvertTemplateBundleToSerializedString(template_bundle);
     return {.status = 0, .result = std::move(res)};
   } else {
     // decode failed.


### PR DESCRIPTION
keep `original_config_` as a member of PageConfig, so that we may get the original content and report it or show to the web decoder.

issue: f-2394578
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
