### PR TITLE
[Testing] Fix the README_UT.md path error

### DIFF
--- a/testing/README_UT.md
+++ b/testing/README_UT.md
@@ -120,9 +120,13 @@ tools/hab sync .
 
 2. Gen Xcode workspace
 ```bash
-cd explorer/darwin/ios/LynxExplorer
+cd explorer/darwin/ios/lynx_explorer
 ./bundle_install.sh
 open LynxExplorer.xcworkspace
 ```
 
-3. Select LynxExplorerUnitTest schema and run
+3. Enter the unit test view
+
+View->Navigators->Tests
+
+4. Click to run `UTTest`


### PR DESCRIPTION
should be lynx_exaplorer, not LynxExplorer

Change-Id: I03dec2f3e5f69e48505a904c0378e4b0c64820b1

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
