### PR TITLE
[Testing] Avoid the disturbance caused by printing the full log

### DIFF
--- a/tools/rtf/core/target/target.py
+++ b/tools/rtf/core/target/target.py
@@ -90,8 +90,9 @@ class Target:
         return True
 
     def print_log(self):
-        log_file = open(self.log_file, "r")
-        Log.error(f"{self.name} log: \n{log_file.read()}")
+        with open(self.log_file, "r") as log_file:
+            lines = log_file.readlines()
+            Log.error(f"{self.name} log: \n......\n{''.join(lines[-50:])}")
 
     def run(self):
         pass


### PR DESCRIPTION
The test may generate a large volume of logs during certain stages, but only the last few lines may be relevant to the actual execution. Printing all logs when a test fails can introduce disturbances in troubleshooting, and may also lead to log anomalies or truncation due to performance issues with the logging system.

Change-Id: Ie27dd990cfdc03c759fb5516637ba20a7eaa62fe

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
