### PR TITLE
[BugFix] fix TemplateData crash with un-initialized Map

### DIFF
--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateData.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateData.java
@@ -79,7 +79,7 @@ public final class TemplateData {
   }
 
   private volatile long mNativeData;
-  private Map<String, Object> mData;
+  private volatile Map<String, Object> mData;
   private String mProcessorName;
   private volatile boolean mIsConcurrent;
   private boolean readOnly = false;
@@ -319,7 +319,7 @@ public final class TemplateData {
     }
   }
 
-  private void ensureInternalMap() {
+  private synchronized void ensureInternalMap() {
     if (mData == null) {
       mData = mIsConcurrent ? new NullableConcurrentHashMap<String, Object>()
                             : new HashMap<String, Object>();


### PR DESCRIPTION
as `mData` in TemplateData is a normal field, and it's construction may occurs with `Instruction Rescheduling`, such that `mData` may be assigned with a un-initialized state in one thread, and be used in another thread which causes JVM crash.

add `volatile` flag to disable `Instruction Rescheduling` here.

issue: f-23978467567
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
