### PR TITLE
[BugFix] ensure access darwin ui on main thread.

### DIFF
--- a/platform/darwin/ios/lynx/LynxTemplateRender.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRender.mm
@@ -1961,9 +1961,13 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
   }
 
   if (errorMsg) {
-    if (_delegate) {
-      [_delegate templateRenderOnResetViewAndLayer:self];
-    }
+    __weak LynxTemplateRender* weakSelf = self;
+    [LynxTemplateRender runOnMainThread:^() {
+      __strong LynxTemplateRender* strongSelf = weakSelf;
+      if (strongSelf) {
+        [strongSelf->_delegate templateRenderOnResetViewAndLayer:strongSelf];
+      }
+    }];
 
     [LynxEventReporter clearCacheForInstanceId:_context.instanceId];
     _context.instanceId = kUnknownInstanceId;


### PR DESCRIPTION
loadTemplate may be called from non-main thread, if error occurs will the loading process, `templateRenderOnResetViewAndLayer` will be invoked from non-main thread. we need to ensure it's called on main thread, using `runOnMainThread` to ensure it.

issue: f-6657476535
AutoSubmit: true
AutoLand: release/3.2

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
