### PR TITLE
[BugFix] remove featureCount from template_codec module

### DIFF
--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_base_template_reader.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_base_template_reader.cc
@@ -13,7 +13,6 @@
 
 #include "base/include/timer/time_utils.h"
 #include "base/trace/native/trace_event.h"
-#include "core/services/feature_count/feature_counter.h"
 #include "core/template_bundle/template_codec/binary_decoder/binary_decoder_trace_event_def.h"
 
 #if ENABLE_AIR
@@ -145,12 +144,6 @@ bool LynxBinaryBaseTemplateReader::DecodeHeader() {
     // never use it
     lepus::Value trial_options;
     ERROR_UNLESS(DecodeValue(&trial_options, true));
-  }
-  if (compile_options_.enable_css_class_merge_) {
-    if (compile_options_.enable_css_class_merge_) {
-      report::FeatureCounter::Instance()->Count(
-          report::LynxFeature::CPP_ENABLE_CLASS_MERGE);
-    }
   }
   enable_css_font_face_extension_ = Config::IsHigherOrEqual(
       compile_options_.target_sdk_version_, FEATURE_CSS_FONT_FACE_EXTENSION);

--- a/oliver/lynx-tasm/ChangeLog.md
+++ b/oliver/lynx-tasm/ChangeLog.md
@@ -1,3 +1,6 @@
+# 0.0.10
+* remove `FeatureCount` from template_codec module.
+
 # 0.0.9
 * add 'enableSimpleStyling' to compileOptions. And support encode style objects into template for simplified styling mode.
 

--- a/oliver/lynx-tasm/package.json
+++ b/oliver/lynx-tasm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lynx-js/tasm",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "description": "",
     "main": "index.js",
     "types": "index.d.ts",


### PR DESCRIPTION
featureCount should not appear in template_codec module, as `tasm-decoder` does not support featureCount at all.

issue: f-289375667
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
