### PR TITLE
[Optimize][DevTool] Align the path of switch page in Android and iOS.

### DIFF
--- a/devtool/lynx_devtool/resources/devtool-switch/build.py
+++ b/devtool/lynx_devtool/resources/devtool-switch/build.py
@@ -18,6 +18,9 @@ from tools.js_tools.pnpm_helper import run_pnpm_command
 
 template_dir = "dist/devtoolSwitch.lynx.bundle"
 android_target_dir = os.path.join(
+    root_dir, "platform/android/lynx_devtool/src/main/assets")
+# TODO(mitchilling): remove this deprecated duplication after applications adapt to the new path.
+android_target_dir_deprecated = os.path.join(
     root_dir, "platform/android/lynx_devtool/src/main/assets/devtool_switch")
 ios_target_dir = os.path.join(root_dir,
                               "platform/darwin/ios/lynx_devtool/assets")
@@ -31,28 +34,35 @@ print("========== build devtool switch page ==========")
 os.chdir(current_dir)
 # Execute the pnpm build command
 run_pnpm_command(["pnpm", "build"], current_dir)
+bundle_path = os.path.join(current_dir, template_dir)
 
 print("========== copy devtool switch resource ==========")
 if output:
+    # TODO(mitchilling): need validation for path trespass
     output_path = os.path.join(output, switch_page_dir)
     print(output_path)
     # Create the output directory
     os.makedirs(output_path, exist_ok=True)
     # Copy the file
-    shutil.copy(os.path.join(current_dir, template_dir), output_path)
+    shutil.copy(bundle_path, output_path)
 
 # Delete the old target directory
-if os.path.exists(android_target_dir):
-    shutil.rmtree(android_target_dir)
+android_switch_page_path = os.path.join(android_target_dir, switch_page_dir)
+android_switch_page_path_deprecated = os.path.join(android_target_dir_deprecated, switch_page_dir)
 ios_switch_page_path = os.path.join(ios_target_dir, switch_page_dir)
+if os.path.exists(android_switch_page_path):
+    shutil.rmtree(android_switch_page_path)
+if os.path.exists(android_switch_page_path_deprecated):
+    shutil.rmtree(android_switch_page_path_deprecated)
 if os.path.exists(ios_switch_page_path):
     shutil.rmtree(ios_switch_page_path)
 
 # Create the new target directory
-os.makedirs(os.path.join(android_target_dir, switch_page_dir), exist_ok=True)
+os.makedirs(android_switch_page_path, exist_ok=True)
+os.makedirs(android_switch_page_path_deprecated, exist_ok=True)
 os.makedirs(ios_switch_page_path, exist_ok=True)
 
 # Copy the file to the target directory
-shutil.copy(os.path.join(current_dir, template_dir),
-            os.path.join(android_target_dir, switch_page_dir))
-shutil.copy(os.path.join(current_dir, template_dir), ios_switch_page_path)
+shutil.copy(bundle_path, android_switch_page_path)
+shutil.copy(bundle_path, android_switch_page_path_deprecated)
+shutil.copy(bundle_path, ios_switch_page_path)

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
@@ -10,7 +10,7 @@ import com.lynx.react.bridge.WritableMap;
 
 public class ExplorerModule extends LynxModule {
   static final String DEVTOOL_SWITCH_ASSETS =
-      "file://lynx?local://devtool_switch/switchPage/devtoolSwitch.lynx.bundle";
+      "file://lynx?local://switchPage/devtoolSwitch.lynx.bundle";
 
   public ExplorerModule(Context context) {
     super(context);


### PR DESCRIPTION
In this change, I align the paths of the page files in the two systems so that in the future more work could be done in front-end without worrying about the difference.
To achieve that, I remove the extra folder in Android.
Yet in order not to break DevTool applications who read that switch page file, I duplicate a file as a deprecation approach for potential adaptions.