### PR TITLE
[Optimize] support loadTemplate with bytebuffer

### DIFF
--- a/core/renderer/dom/android/lynx_template_bundle_android.cc
+++ b/core/renderer/dom/android/lynx_template_bundle_android.cc
@@ -48,10 +48,9 @@ std::optional<lynx::base::android::JavaOnlyMap> GetPageConfigMap(
 }
 }  // namespace
 
-jlong ParseTemplate(JNIEnv* env, jclass jcaller, jbyteArray j_binary,
-                    jobjectArray j_buffer) {
-  auto binary =
-      lynx::base::android::JNIConvertHelper::ConvertJavaBinary(env, j_binary);
+jlong ParseTemplateInternal(JNIEnv* env, jclass jcaller,
+                            std::vector<uint8_t>&& binary,
+                            jobjectArray options) {
   auto reader =
       lynx::tasm::LynxBinaryReader::CreateLynxBinaryReader(std::move(binary));
   if (reader.Decode()) {
@@ -61,7 +60,7 @@ jlong ParseTemplate(JNIEnv* env, jclass jcaller, jbyteArray j_binary,
     bundle->PrepareVMByConfigs();
     auto page_config = GetPageConfigMap(env, bundle);
     env->SetObjectArrayElement(
-        j_buffer, 1, page_config ? page_config->jni_object() : nullptr);
+        options, 1, page_config ? page_config->jni_object() : nullptr);
     return reinterpret_cast<int64_t>(bundle);
   } else {
     // decode failed.
@@ -69,9 +68,35 @@ jlong ParseTemplate(JNIEnv* env, jclass jcaller, jbyteArray j_binary,
     auto j_err_str =
         lynx::base::android::JNIConvertHelper::ConvertToJNIStringUTF(
             env, reader.error_message_);
-    env->SetObjectArrayElement(j_buffer, 0, j_err_str.Get());
+    env->SetObjectArrayElement(options, 0, j_err_str.Get());
     return 0;
   }
+}
+
+jlong ParseTemplateFromByteArray(JNIEnv* env, jclass jcaller,
+                                 jbyteArray j_binary, jobjectArray options) {
+  auto binary =
+      lynx::base::android::JNIConvertHelper::ConvertJavaBinary(env, j_binary);
+  return ParseTemplateInternal(env, jcaller, std::move(binary), options);
+}
+
+jlong ParseTemplateFromByteBuffer(JNIEnv* env, jclass jcaller,
+                                  jobject bufferPtr, jobjectArray options) {
+  auto* buffer_ptr =
+      static_cast<uint8_t*>(env->GetDirectBufferAddress(bufferPtr));
+  if (buffer_ptr == nullptr) {
+    LOGE("Error: Not a direct buffer!");
+    return 0;
+  }
+
+  jlong capacity = env->GetDirectBufferCapacity(bufferPtr);
+  if (capacity <= 0) {
+    LOGE("Error: Invalid direct buffer capacity!");
+    return 0;
+  }
+
+  std::vector<uint8_t> buffer(buffer_ptr, buffer_ptr + capacity);
+  return ParseTemplateInternal(env, jcaller, std::move(buffer), options);
 }
 
 jobject GetExtraInfo(JNIEnv* env, jclass jcaller, jlong ptr) {

--- a/core/shell/android/lynx_template_render_android.cc
+++ b/core/shell/android/lynx_template_render_android.cc
@@ -148,7 +148,7 @@ std::shared_ptr<lynx::tasm::PipelineOptions> ProcessLoadTemplateTimingOption(
 }
 
 void InternalLoadTemplate(JNIEnv* env, jlong ptr, jlong lifecycle,
-                          jstring j_url, jbyteArray j_binary,
+                          jstring j_url, std::vector<uint8_t> j_binary,
                           const Value& value, const bool read_only_value,
                           bool enable_pre_painting,
                           const std::string& processor_name,
@@ -181,9 +181,8 @@ void InternalLoadTemplate(JNIEnv* env, jlong ptr, jlong lifecycle,
       enable_recycle_template_bundle;
 
   reinterpret_cast<LynxShell*>(ptr)->LoadTemplate(
-      JNIConvertHelper::ConvertToString(env, j_url),
-      JNIConvertHelper::ConvertJavaBinary(env, j_binary), pipeline_options,
-      template_data);
+      JNIConvertHelper::ConvertToString(env, j_url), std::move(j_binary),
+      pipeline_options, template_data);
   AtomicLifecycle::TryFree(lifecycle_ptr);
 }
 
@@ -502,11 +501,40 @@ void LoadTemplateByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
                                  jobject template_data, jint options,
                                  jobject j_timing_option) {
   std::string processor_name = JNIConvertHelper::ConvertToString(env, name);
-  InternalLoadTemplate(env, ptr, lifecycle, j_url, j_binary,
+  std::vector<uint8_t> vec = JNIConvertHelper::ConvertJavaBinary(env, j_binary);
+  InternalLoadTemplate(env, ptr, lifecycle, j_url, std::move(vec),
                        data ? *(reinterpret_cast<Value*>(data)) : Value(),
                        readOnly, is_pre_painting == 1, processor_name,
                        template_data, enable_recycle_template_bundle,
                        j_timing_option, options);
+}
+
+void LoadTemplateBufferByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
+                                       jlong lifecycle, jstring url,
+                                       jobject bufferPtr, jint is_pre_painting,
+                                       jboolean enable_recycle_template_bundle,
+                                       jlong data, jboolean read_only,
+                                       jstring j_processor_name,
+                                       jobject template_data, jint options,
+                                       jobject timing_option) {
+  std::string processor_name =
+      JNIConvertHelper::ConvertToString(env, j_processor_name);
+  auto* buffer_ptr =
+      static_cast<uint8_t*>(env->GetDirectBufferAddress(bufferPtr));
+  if (buffer_ptr == nullptr) {
+    LOGE("Error: Not a direct buffer!");
+    return;
+  }
+  jlong capacity = env->GetDirectBufferCapacity(bufferPtr);
+  if (capacity <= 0) {
+    return;
+  }
+  std::vector<uint8_t> vec(buffer_ptr, buffer_ptr + capacity);
+  InternalLoadTemplate(env, ptr, lifecycle, url, std::move(vec),
+                       data ? *(reinterpret_cast<Value*>(data)) : Value(),
+                       read_only, is_pre_painting == 1, processor_name,
+                       template_data, enable_recycle_template_bundle,
+                       timing_option, options);
 }
 
 void LoadTemplateBundleByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,

--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -1033,6 +1033,7 @@ public class com::lynx::tasm::LynxLoadMeta::Builder :  {
   public void com.lynx.tasm.LynxLoadMeta.Builder.setLoadMode(LynxLoadMode loadMode);
   public void com.lynx.tasm.LynxLoadMeta.Builder.addLoadOption(LynxLoadOption loadOption);
   public void com.lynx.tasm.LynxLoadMeta.Builder.setLynxViewConfig(Map< String, String > lynxViewConfig);
+  public void com.lynx.tasm.LynxLoadMeta.Builder.setByteBuffer(ByteBuffer buffer);
   public LynxLoadMeta com.lynx.tasm.LynxLoadMeta.Builder.build();
 }
 
@@ -5083,6 +5084,7 @@ public class com::lynx::tasm::LynxLoadMeta :  {
   public String com.lynx.tasm.LynxLoadMeta.getUrl();
   public boolean com.lynx.tasm.LynxLoadMeta.isBundleValid();
   public boolean com.lynx.tasm.LynxLoadMeta.isBinaryValid();
+  public boolean com.lynx.tasm.LynxLoadMeta.isByteBufferValid();
   public byte[] com.lynx.tasm.LynxLoadMeta.getTemplateBinary();
   public TemplateBundle com.lynx.tasm.LynxLoadMeta.getTemplateBundle();
   public TemplateData com.lynx.tasm.LynxLoadMeta.getInitialData();
@@ -5090,6 +5092,7 @@ public class com::lynx::tasm::LynxLoadMeta :  {
   public Map< String, String > com.lynx.tasm.LynxLoadMeta.getLynxViewConfig();
   public LynxLoadMode com.lynx.tasm.LynxLoadMeta.getLoadMode();
   public EnumSet< LynxLoadOption > com.lynx.tasm.LynxLoadMeta.getLoadOption();
+  public ByteBuffer com.lynx.tasm.LynxLoadMeta.getByteBuffer();
   public boolean com.lynx.tasm.LynxLoadMeta.enableDumpElementTree();
   public boolean com.lynx.tasm.LynxLoadMeta.enableRecycleTemplateBundle();
   public boolean com.lynx.tasm.LynxLoadMeta.enableProcessLayout();
@@ -8597,6 +8600,7 @@ public class com::lynx::tasm::TemplateAssembler :  {
 }
 
 public class com::lynx::tasm::TemplateBundle :  {
+  public final String com.lynx.tasm.TemplateBundle.TAG TAG;
   public boolean com.lynx.tasm.TemplateBundle.equals(Object o);
   public Map< String, Object > com.lynx.tasm.TemplateBundle.getExtraInfo();
   public boolean com.lynx.tasm.TemplateBundle.isElementBundleValid();
@@ -8612,6 +8616,7 @@ public class com::lynx::tasm::TemplateBundle :  {
   public PageConfig com.lynx.tasm.TemplateBundle.getPageConfig();
   public boolean com.lynx.tasm.TemplateBundle.constructContext();
   public static TemplateBundle com.lynx.tasm.TemplateBundle.fromTemplate(byte[] template);
+  public static TemplateBundle com.lynx.tasm.TemplateBundle.fromTemplate(ByteBuffer buffer, TemplateBundleOption option);
   public static TemplateBundle com.lynx.tasm.TemplateBundle.fromTemplate(byte[] template, TemplateBundleOption option);
 }
 
@@ -9027,6 +9032,7 @@ public class com::lynx::tasm::base::trace::TraceEventDef :  {
   public final String com.lynx.tasm.base.trace.TraceEventDef.CLIENT_FLING CLIENT_FLING;
   public final String com.lynx.tasm.base.trace.TraceEventDef.CLIENT_ON_FIRST_SCREEN CLIENT_ON_FIRST_SCREEN;
   public final String com.lynx.tasm.base.trace.TraceEventDef.TEMPLATE_BUNDLE_FROM_TEMPLATE TEMPLATE_BUNDLE_FROM_TEMPLATE;
+  public final String com.lynx.tasm.base.trace.TraceEventDef.TEMPLATE_BUNDLE_FROM_BYTEBUFFER TEMPLATE_BUNDLE_FROM_BYTEBUFFER;
   public final String com.lynx.tasm.base.trace.TraceEventDef.TEMPLATE_DATA_FROM_MAP TEMPLATE_DATA_FROM_MAP;
   public final String com.lynx.tasm.base.trace.TraceEventDef.TEMPLATE_DATA_FROM_STRING TEMPLATE_DATA_FROM_STRING;
   public final String com.lynx.tasm.base.trace.TraceEventDef.CLEAN_REF_RUN_CLEAN_TASK_REAPER_THREAD CLEAN_REF_RUN_CLEAN_TASK_REAPER_THREAD;

--- a/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/ResourceHelper.java
+++ b/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/ResourceHelper.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 public final class ResourceHelper {
   /**
@@ -33,6 +34,17 @@ public final class ResourceHelper {
       }
     }
     return bytes;
+  }
+
+  public static ByteBuffer loadAssertAsBuffer(@NonNull Context context, @NonNull String name) {
+    byte[] bytes = loadByteArray(context, name);
+    if (bytes != null) {
+      ByteBuffer directBuffer = ByteBuffer.allocateDirect(bytes.length);
+      directBuffer.put(bytes);
+      directBuffer.flip();
+      return directBuffer;
+    }
+    return null;
   }
 
   /**

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxLoadMeta.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxLoadMeta.java
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.tasm;
 
+import java.nio.ByteBuffer;
 import java.util.EnumSet;
 import java.util.Map;
 
@@ -13,6 +14,7 @@ import java.util.Map;
 public final class LynxLoadMeta {
   String url;
   byte[] binaryData;
+  ByteBuffer byteBuffer;
   TemplateBundle bundle;
   TemplateData initialData;
   TemplateData globalProps;
@@ -20,11 +22,12 @@ public final class LynxLoadMeta {
   int loadOptions;
   Map<String, String> lynxViewConfig;
 
-  private LynxLoadMeta(String url, byte[] binaryData, TemplateBundle bundle,
+  private LynxLoadMeta(String url, byte[] binaryData, ByteBuffer byteBuffer, TemplateBundle bundle,
       TemplateData initialData, TemplateData globalProps, LynxLoadMode loadMode, int loadOptions,
       Map<String, String> lynxViewConfig) {
     this.url = url;
     this.binaryData = binaryData;
+    this.byteBuffer = byteBuffer;
     this.bundle = bundle;
     this.initialData = initialData;
     this.globalProps = globalProps;
@@ -49,6 +52,15 @@ public final class LynxLoadMeta {
    */
   public boolean isBinaryValid() {
     return this.binaryData != null && this.binaryData.length > 0;
+  }
+
+  /**
+   * Check whether the incoming byteBuffer is valid;
+   *
+   * @return True if byteBuffer is valid;
+   */
+  public boolean isByteBufferValid() {
+    return this.byteBuffer != null;
   }
 
   public byte[] getTemplateBinary() {
@@ -92,6 +104,10 @@ public final class LynxLoadMeta {
     return set;
   }
 
+  public ByteBuffer getByteBuffer() {
+    return byteBuffer;
+  }
+
   public boolean enableDumpElementTree() {
     return (this.loadOptions & LynxLoadOption.DUMP_ELEMENT.id()) != 0;
   }
@@ -116,43 +132,40 @@ public final class LynxLoadMeta {
     private TemplateData globalProps;
     private LynxLoadMode loadMode;
     private int loadOptions = 0;
-
+    private ByteBuffer byteBuffer;
     private Map<String, String> lynxViewConfig;
 
     public void setUrl(String url) {
       this.url = url;
     }
-
     public void setBinaryData(byte[] binaryData) {
       this.binaryData = binaryData;
     }
-
     public void setTemplateBundle(TemplateBundle bundle) {
       this.bundle = bundle;
     }
-
     public void setInitialData(TemplateData initialData) {
       this.initialData = initialData;
     }
     public void setGlobalProps(TemplateData globalProps) {
       this.globalProps = globalProps;
     }
-
     public void setLoadMode(LynxLoadMode loadMode) {
       this.loadMode = loadMode;
     }
-
     public void addLoadOption(LynxLoadOption loadOption) {
       this.loadOptions |= loadOption.id();
     }
-
     public void setLynxViewConfig(Map<String, String> lynxViewConfig) {
       this.lynxViewConfig = lynxViewConfig;
     }
+    public void setByteBuffer(ByteBuffer buffer) {
+      this.byteBuffer = buffer;
+    }
 
     public LynxLoadMeta build() {
-      return new LynxLoadMeta(this.url, this.binaryData, this.bundle, this.initialData,
-          this.globalProps, this.loadMode, this.loadOptions, this.lynxViewConfig);
+      return new LynxLoadMeta(this.url, this.binaryData, this.byteBuffer, this.bundle,
+          this.initialData, this.globalProps, this.loadMode, this.loadOptions, this.lynxViewConfig);
     }
   }
 }

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -1488,6 +1488,16 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
               + " enableDumpElementTree: " + enableDumpElementTree);
       loadTemplateBundle(metaData.bundle, metaData.url, metaData.initialData, isPrePainting,
           metaData.loadOptions, new TASMCallback(), timingOption);
+    } else if (metaData.isByteBufferValid()) {
+      this.prepareLynxEngineIfNeeded();
+      this.initLynxEngineWithLoadMeta(metaData);
+      boolean enableRecycleTemplateBundle = metaData.enableRecycleTemplateBundle();
+      LLog.i(TAG,
+          "LoadMeta with ByteBuffer, pre-painting: " + isPrePainting
+              + " ,pre-painting with draw:" + (LynxLoadMode.PRE_PAINTING_DRAW == loadMode)
+              + " enableRecycleTemplateBundle: " + enableRecycleTemplateBundle);
+      loadTemplateByteBuffer(metaData.byteBuffer, metaData.initialData, metaData.url, isPrePainting,
+          metaData.loadOptions, enableRecycleTemplateBundle, new TASMCallback(), timingOption);
     } else if (metaData.isBinaryValid()) {
       if (mDevTool != null) {
         mDevTool.onLoadFromLocalFile(metaData.binaryData, metaData.initialData, metaData.url);
@@ -3129,6 +3139,41 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
     this.loadTemplate(template, initData, url, false, false, callback, timingOption);
   }
 
+  private void loadTemplateByteBuffer(ByteBuffer template, TemplateData initData, String url,
+      boolean isPrePainting, int options, boolean enableRecycleTemplateBundle,
+      NativeFacade.Callback callback, TimingOption timingOption) {
+    if (template == null) {
+      LLog.e(TAG, "Load Template with null template");
+      return;
+    }
+    if ((mNativeFacade == null) || (mNativePtr == 0)) {
+      LLog.e(TAG, "Load Template before inited");
+      return;
+    }
+    long nativePtr = 0;
+    String processorName = null;
+    boolean read_only = false;
+    if (initData != null) {
+      initData.flush();
+      nativePtr = initData.getNativePtr();
+      processorName = initData.processorName();
+      read_only = initData.isReadOnly();
+      initData.markConsumed();
+    }
+    if (nativePtr == 0) {
+      LLog.e(TAG, "Load Template with zero template data");
+    }
+    mNativeFacade.setUrl(url);
+    mNativeFacade.setCallback(callback);
+    //    mNativeFacade.setSize(template.length);
+    if (mDevTool != null) {
+      mDevTool.attachToDebugBridge(url);
+    }
+    nativeLoadTemplateBufferByPreParsedData(mNativePtr, mNativeLifecycle, url, template,
+        isPrePainting ? 1 : 0, enableRecycleTemplateBundle, nativePtr, read_only, processorName,
+        initData, options, timingOption.toJavaOnlyMap());
+  }
+
   private void loadTemplate(byte[] template, TemplateData initData, String url,
       boolean isPrePainting, boolean enableRecycleTemplateBundle, NativeFacade.Callback callback,
       TimingOption timingOption) {
@@ -3819,6 +3864,11 @@ public class LynxTemplateRender implements ILynxEngine, ILynxErrorReceiver {
   private static native void nativeLoadTemplateBundleByPreParsedData(long ptr, long lifecycle,
       String url, long bundlePtr, int isPrePainting, long data, boolean readOnly,
       String processorName, TemplateData templateData, int options, ReadableMap timingOption);
+
+  private static native void nativeLoadTemplateBufferByPreParsedData(long ptr, long lifecycle,
+      String url, ByteBuffer temp, int isPrePainting, boolean enableRecycleTemplateBundle,
+      long data, boolean readOnly, String processorName, TemplateData templateData, int options,
+      ReadableMap timingOption);
 
   private static native void nativePreloadLazyBundles(long ptr, long lifecycle, String[] urls);
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateBundle.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/TemplateBundle.java
@@ -9,9 +9,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import com.lynx.jsbridge.LynxBytecodeCallback;
 import com.lynx.react.bridge.ReadableMap;
-import com.lynx.tasm.LynxEnv;
-import com.lynx.tasm.TemplateBundleOption;
 import com.lynx.tasm.base.CalledByNative;
+import com.lynx.tasm.base.LLog;
 import com.lynx.tasm.base.TraceEvent;
 import com.lynx.tasm.base.trace.TraceEventDef;
 import com.lynx.tasm.common.LepusBuffer;
@@ -29,6 +28,8 @@ import java.util.Map;
  * in advance to obtain the `TemplateBundle` object and consume the App Bundle product.
  */
 public final class TemplateBundle {
+  public static final String TAG = "TemplateBundle";
+
   private final String url;
   private long nativePtr = 0; // native pointer for LynxTemplateBundle.
   private Map<String, Object> extraInfo;
@@ -76,7 +77,7 @@ public final class TemplateBundle {
         // 0: string, error message
         // 1: ReadableMap, pageConfig
         Object[] buffer = new Object[2];
-        long ptr = nativeParseTemplate(template, buffer);
+        long ptr = nativeParseTemplateFromByteArray(template, buffer);
         result = new TemplateBundle(
             ptr, template.length, url, (String) buffer[0], (ReadableMap) buffer[1]);
       } else {
@@ -89,7 +90,7 @@ public final class TemplateBundle {
 
   /**
    * @apidoc
-   * @brief Input Lynx template binary content and return the parsed `TemplateBundle` object.
+   * @brief Input Lynx Bundle binary content and return the parsed `TemplateBundle` object.
    * @param template Template binary content.
    * @return The `TemplateBundle` object.
    * @note When the input `template` is `null`, this method returns `null` directly.
@@ -98,6 +99,47 @@ public final class TemplateBundle {
    */
   public static TemplateBundle fromTemplate(byte[] template) {
     return internalBuildTemplate(template, null);
+  }
+
+  /**
+   * @apidoc
+   * @brief Input ByteBuffer that represents Lynx Bundle content and return the parsed
+   * `TemplateBundle` object.
+   * @param buffer ByteBuffer that represents Lynx Bundle content
+   * @return The `TemplateBundle` object.
+   * @note When the input `buffer` is `null`, this method returns `null` directly.
+   * @note When the input `buffer` is not `DirectByteBuffer`, returns an invalid TemplateBundle.
+   * @note When the input `template` is not a correct `Lynx` template data,
+   * an invalid `TemplateBundle` is returned.
+   */
+  public static TemplateBundle fromTemplate(ByteBuffer buffer, TemplateBundleOption option) {
+    TemplateBundle bundle = null;
+    if (buffer == null) {
+      return bundle;
+    }
+    if (!buffer.isDirect()) {
+      LLog.i(TAG, "TemplateBundle only supports DirectByteBuffer.");
+      bundle = new TemplateBundle(0, buffer.limit(), option.getUrl(),
+          "TemplateBundle only supports DirectByteBuffer.", null);
+      return bundle;
+    }
+
+    // TODO(nihao.royal): support security check after SecurityService support buffer.
+    TraceEvent.beginSection(TraceEventDef.TEMPLATE_BUNDLE_FROM_BYTEBUFFER);
+    if (checkIfEnvPrepared()) {
+      // 0: string, error message
+      // 1: ReadableMap, pageConfig
+      Object[] options = new Object[2];
+      long ptr = nativeParseTemplateFromByteBuffer(buffer, options);
+      bundle = new TemplateBundle(
+          ptr, buffer.limit(), option.getUrl(), (String) options[0], (ReadableMap) options[1]);
+    } else {
+      bundle =
+          new TemplateBundle(0, buffer.limit(), option.getUrl(), "LynxEnv is not prepared.", null);
+    }
+    bundle.initWithOption(option);
+    TraceEvent.endSection(TraceEventDef.TEMPLATE_BUNDLE_FROM_BYTEBUFFER);
+    return bundle;
   }
 
   public static TemplateBundle fromTemplate(byte[] template, TemplateBundleOption option) {
@@ -284,7 +326,8 @@ public final class TemplateBundle {
   private static native void nativePostJsCacheGenerationTask(
       long bundle, String bytecodeSourceUrl, boolean useV8, LynxBytecodeCallback callback);
 
-  private static native long nativeParseTemplate(byte[] temp, Object[] buffer);
+  private static native long nativeParseTemplateFromByteArray(byte[] temp, Object[] options);
+  private static native long nativeParseTemplateFromByteBuffer(ByteBuffer bytes, Object[] options);
   private static native void nativeReleaseBundle(long ptr);
   private static native Object nativeGetExtraInfo(long ptr);
   private static native boolean nativeGetContainsElementTree(long ptr);

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/base/trace/TraceEventDef.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/base/trace/TraceEventDef.java
@@ -88,6 +88,8 @@ public class TraceEventDef {
   public static final String CLIENT_FLING = "Client.onFling";
   public static final String CLIENT_ON_FIRST_SCREEN = "Client.onFirstScreen";
   public static final String TEMPLATE_BUNDLE_FROM_TEMPLATE = "TemplateBundle.fromTemplate";
+  public static final String TEMPLATE_BUNDLE_FROM_BYTEBUFFER =
+      "TemplateBundle.fromTemplateWithByteBuffer";
   public static final String TEMPLATE_DATA_FROM_MAP = "TemplateData.FromMap";
   public static final String TEMPLATE_DATA_FROM_STRING = "TemplateData.FromString";
   public static final String CLEAN_REF_RUN_CLEAN_TASK_REAPER_THREAD =


### PR DESCRIPTION
As described, we wants to support loadTemplate with directByteBuffer directly, we that it's easy to optimize the `Load & Parse` period of Lynx Pipeline.

Using native buffer is known to be faster and better compatibility with non-blocking IO.
    
issue: f-6712645708
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
