### PR TITLE
[Optimize] support decodeImage for ImageService.

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -2066,6 +2066,7 @@ public interface com::lynx::tasm::service::ILynxImageService {
   public boolean com.lynx.tasm.service.ILynxImageService.pauseAnimation(@NonNull Drawable animatable);
   public boolean com.lynx.tasm.service.ILynxImageService.stopAnimation(@NonNull Drawable animatable);
   public void com.lynx.tasm.service.ILynxImageService.prefetchImage( @NonNull String uri, @Nullable Object callerContext, @Nullable ReadableMap params);
+  public void com.lynx.tasm.service.ILynxImageService.decodeImage(@NonNull ImageRequestInfo imageRequestInfo, @NonNull ImageLoadListener listener);
   public void com.lynx.tasm.service.ILynxImageService.releaseImage(@NonNull ImageRequestInfo imageRequestInfo);
   public void com.lynx.tasm.service.ILynxImageService.releaseAnimDrawable(@NonNull Drawable drawable);
   public boolean com.lynx.tasm.service.ILynxImageService.canParseUrl(@NonNull String url);
@@ -2345,6 +2346,7 @@ public class com::lynx::tasm::image::model::ImageRequestInfo :  {
   public boolean com.lynx.tasm.image.model.ImageRequestInfo.isEnableResourceHint();
   public boolean com.lynx.tasm.image.model.ImageRequestInfo.isEnableDownSampling();
   public boolean com.lynx.tasm.image.model.ImageRequestInfo.isUseLocalCache();
+  public boolean com.lynx.tasm.image.model.ImageRequestInfo.isForceStaticImage();
   public Integer com.lynx.tasm.image.model.ImageRequestInfo.getDiskCacheChoice();
   public boolean com.lynx.tasm.image.model.ImageRequestInfo.isEnableAsyncRequest();
   public Object com.lynx.tasm.image.model.ImageRequestInfo.getCallerContext();
@@ -2385,6 +2387,8 @@ public class com::lynx::tasm::image::model::ImageRequestInfoBuilder :  {
   public boolean com.lynx.tasm.image.model.ImageRequestInfoBuilder.isEnableResourceHint();
   public boolean com.lynx.tasm.image.model.ImageRequestInfoBuilder.isUseLocalCache();
   public ImageRequestInfoBuilder com.lynx.tasm.image.model.ImageRequestInfoBuilder.setEnableAsyncRequest(boolean mEnableAsyncRequest);
+  public boolean com.lynx.tasm.image.model.ImageRequestInfoBuilder.isForceStaticImage();
+  public ImageRequestInfoBuilder com.lynx.tasm.image.model.ImageRequestInfoBuilder.setForceStaticImage(boolean forceStaticImage);
   public int com.lynx.tasm.image.model.ImageRequestInfoBuilder.getCacheChoice();
   public List< BitmapPostProcessor > com.lynx.tasm.image.model.ImageRequestInfoBuilder.getProcessors();
   public ImageRequestInfo com.lynx.tasm.image.model.ImageRequestInfoBuilder.build();

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/image/model/ImageRequestInfo.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/image/model/ImageRequestInfo.java
@@ -42,6 +42,8 @@ public class ImageRequestInfo {
 
   private boolean mUseLocalCache;
 
+  private boolean mForceStaticImage = false;
+
   ImageRequestInfo(ImageRequestInfoBuilder builder) {
     mUrl = builder.getUrl();
     mResizeWidth = builder.getResizeWidth();
@@ -59,6 +61,7 @@ public class ImageRequestInfo {
     mCallerContext = builder.getCallerContext();
     mAutoPlay = builder.isEnableAnimationAutoPlay();
     mUseLocalCache = builder.isUseLocalCache();
+    mForceStaticImage = builder.isForceStaticImage();
   }
 
   public String getUrl() {
@@ -107,6 +110,10 @@ public class ImageRequestInfo {
 
   public boolean isUseLocalCache() {
     return mUseLocalCache;
+  }
+
+  public boolean isForceStaticImage() {
+    return mForceStaticImage;
   }
 
   public @DiskCacheChoice Integer getDiskCacheChoice() {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/image/model/ImageRequestInfoBuilder.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/image/model/ImageRequestInfoBuilder.java
@@ -41,6 +41,8 @@ public class ImageRequestInfoBuilder {
 
   private boolean mUseLocalCache;
 
+  private boolean mForceStaticImage = false;
+
   public static ImageRequestInfoBuilder newBuilderWithSource(String url) {
     return new ImageRequestInfoBuilder().setUrl(url);
   }
@@ -176,6 +178,15 @@ public class ImageRequestInfoBuilder {
 
   public ImageRequestInfoBuilder setEnableAsyncRequest(boolean mEnableAsyncRequest) {
     this.mEnableAsyncRequest = mEnableAsyncRequest;
+    return this;
+  }
+
+  public boolean isForceStaticImage() {
+    return mForceStaticImage;
+  }
+
+  public ImageRequestInfoBuilder setForceStaticImage(boolean forceStaticImage) {
+    this.mForceStaticImage = forceStaticImage;
     return this;
   }
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/service/ILynxImageService.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/service/ILynxImageService.java
@@ -95,6 +95,14 @@ public interface ILynxImageService extends IServiceProvider {
       @NonNull String uri, @Nullable Object callerContext, @Nullable ReadableMap params);
 
   /**
+   * Retrieve Bitmap of input requestInfo;
+   *
+   * @param imageRequestInfo Information about the image request.
+   * @param listener Listener for image loading callbacks.
+   */
+  void decodeImage(@NonNull ImageRequestInfo imageRequestInfo, @NonNull ImageLoadListener listener);
+
+  /**
    * Releases resources associated with the given image request.
    *
    * @param imageRequestInfo Information about the image request to release.

--- a/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/LynxImageService.java
+++ b/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/LynxImageService.java
@@ -15,6 +15,7 @@ import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.cache.common.CacheKey;
+import com.facebook.common.executors.CallerThreadExecutor;
 import com.facebook.common.executors.UiThreadImmediateExecutorService;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.datasource.BaseDataSubscriber;
@@ -25,8 +26,12 @@ import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.fresco.animation.drawable.AnimatedDrawable2;
 import com.facebook.fresco.animation.drawable.BaseAnimationListener;
 import com.facebook.imagepipeline.cache.MemoryCache;
+import com.facebook.imagepipeline.common.ImageDecodeOptions;
 import com.facebook.imagepipeline.common.ImageDecodeOptionsBuilder;
 import com.facebook.imagepipeline.common.Priority;
+import com.facebook.imagepipeline.common.ResizeOptions;
+import com.facebook.imagepipeline.core.ImagePipeline;
+import com.facebook.imagepipeline.datasource.BaseBitmapDataSubscriber;
 import com.facebook.imagepipeline.image.CloseableImage;
 import com.facebook.imagepipeline.image.CloseableStaticBitmap;
 import com.facebook.imagepipeline.request.ImageRequest;
@@ -297,6 +302,52 @@ public class LynxImageService implements ILynxImageService {
       prefetchImageToBitmapCache(builder.build(), callerContext);
     } else {
       prefetchImageToDiskCache(builder.build(), callerContext, priorityString);
+    }
+  }
+
+  @Override
+  public void decodeImage(
+      @NonNull ImageRequestInfo imageRequestInfo, @NonNull ImageLoadListener listener) {
+    if (imageRequestInfo != null) {
+      ImagePipeline imagePipeline = Fresco.getImagePipeline();
+      ImageRequest imageRequest =
+          ImageRequestBuilder.newBuilderWithSource(Uri.parse(imageRequestInfo.getUrl()))
+              .setResizeOptions(
+                  new ResizeOptions(Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE))
+              .setImageDecodeOptions(ImageDecodeOptions.newBuilder()
+                                         .setBitmapConfig(imageRequestInfo.getConfig())
+                                         .setForceStaticImage(imageRequestInfo.isForceStaticImage())
+                                         .build())
+              .build();
+
+      DataSource<CloseableReference<CloseableImage>> dataSource =
+          imagePipeline.fetchDecodedImage(imageRequest, null);
+
+      BaseBitmapDataSubscriber subscriber = new BaseBitmapDataSubscriber() {
+        @Override
+        protected void onNewResultImpl(Bitmap bitmap) {
+          if (bitmap != null) {
+            listener.onSuccess(new ImageContent(bitmap), imageRequestInfo,
+                new ImageInfo(bitmap.getWidth(), bitmap.getHeight(), false));
+          } else {
+            listener.onFailure(
+                ImageErrorCodeUtils.LYNX_IMAGE_UNKNOWN_EXCEPTION, new Throwable("empty bitmap!"));
+          }
+        }
+
+        @Override
+        protected void onFailureImpl(DataSource<CloseableReference<CloseableImage>> dataSource) {
+          if (dataSource.getFailureCause() != null) {
+            listener.onFailure(
+                ImageErrorCodeUtils.checkImageException(dataSource.getFailureCause()),
+                dataSource.getFailureCause());
+          } else {
+            listener.onFailure(ImageErrorCodeUtils.LYNX_IMAGE_UNKNOWN_EXCEPTION,
+                new Throwable("imageLoadFailed."));
+          }
+        }
+      };
+      dataSource.subscribe(subscriber, CallerThreadExecutor.getInstance());
     }
   }
 


### PR DESCRIPTION
support decodeImage for ImageService, so that lynx sdk may fetch bitmap directly through ImageService

issue: f-2384856
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
