### PR TITLE
[BugFix] fix nullpointerexception with shouldRedirectUrl

### DIFF
--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxViewClient.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxViewClient.java
@@ -236,7 +236,7 @@ public abstract class LynxViewClient
    * @return A url string that fit int with the support scheme list or null
    */
   @Deprecated
-  public String shouldRedirectImageUrl(String url) {
+  public @Nullable String shouldRedirectImageUrl(String url) {
     return null;
   }
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/image/ImageUrlRedirectUtils.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/image/ImageUrlRedirectUtils.java
@@ -94,7 +94,12 @@ public class ImageUrlRedirectUtils {
       TraceEvent.beginSection(TraceEventDef.IMAGE_SHOULD_REDIRECT_IMAGE_URL, props);
     }
 
-    String redirectUrl = interceptor.shouldRedirectImageUrl(origUrl);
+    String redirectUrl = null;
+    try {
+      redirectUrl = interceptor.shouldRedirectImageUrl(origUrl);
+    } catch (Exception e) {
+      LLog.d(TAG, "shouldRedirectImageUrl occurred with exception: " + e.getMessage());
+    }
     TraceEvent.endSection(TraceEventDef.IMAGE_SHOULD_REDIRECT_IMAGE_URL);
 
     if (redirectUrl != null) {


### PR DESCRIPTION
the default implementation of `shouldRedirectImageUrl` for LynxViewClient returns null, if the implementation implements with kotlin and call `super.shouldRedirectImageUrl` it may occurs with nullpointerexception. catch this exception to avoid CreateUI errors.

issue: f-23048756
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
