### PR TITLE
[Optimize][Explorer] Deprecate openDevtoolSwitchPage and use openSche…

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
@@ -9,6 +9,7 @@ import com.lynx.jsbridge.LynxModule;
 import com.lynx.react.bridge.WritableMap;
 
 public class ExplorerModule extends LynxModule {
+  @Deprecated
   static final String DEVTOOL_SWITCH_ASSETS =
       "file://lynx?local://switchPage/devtoolSwitch.lynx.bundle";
 
@@ -51,6 +52,7 @@ public class ExplorerModule extends LynxModule {
     LynxModuleAdapter.getInstance().pageBack();
   }
 
+  @Deprecated
   @LynxMethod
   public void openDevtoolSwitchPage() {
     LynxModuleAdapter.getInstance().openSchema(DEVTOOL_SWITCH_ASSETS);

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/ExplorerModule.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/ExplorerModule.m
@@ -10,7 +10,8 @@
 #import "TasmDispatcher.h"
 #import "UIHelper.h"
 
-NSString *const DEVTOOL_SWITCH_URL = @"file://lynx?local://switchPage/devtoolSwitch.lynx.bundle";
+NSString *const DEVTOOL_SWITCH_URL __attribute__((deprecated)) =
+    @"file://lynx?local://switchPage/devtoolSwitch.lynx.bundle";
 
 @implementation ExplorerModule
 
@@ -78,7 +79,7 @@ NSString *const DEVTOOL_SWITCH_URL = @"file://lynx?local://switchPage/devtoolSwi
   };
 }
 
-- (void)openDevToolSwitchPage {
+- (void)openDevToolSwitchPage __attribute__((deprecated)) {
   [[TasmDispatcher sharedInstance] openTargetUrl:DEVTOOL_SWITCH_URL];
 }
 

--- a/explorer/homepage/components/settingspage/index.tsx
+++ b/explorer/homepage/components/settingspage/index.tsx
@@ -48,7 +48,9 @@ export default function SettingsPage(props: SettingsPageProps) {
   type Theme = 'Dark' | 'Light';
 
   const openDevtoolSwitchPage = () => {
-    NativeModules.ExplorerModule.openDevtoolSwitchPage();
+    NativeModules.ExplorerModule.openSchema(
+      'file://lynx?local://switchPage/devtoolSwitch.lynx.bundle'
+    );
   };
 
   const getIcon = (name: keyof typeof icons) => {

--- a/explorer/homepage/typing.d.ts
+++ b/explorer/homepage/typing.d.ts
@@ -20,6 +20,9 @@ declare global {
       openSchema(url: string): void;
       getSettingInfo(): Record<string, unknown>;
       setThreadMode(index: number): void;
+      /**
+       * @deprecated Use `openSchema()` instead.
+       */
       openDevtoolSwitchPage(): void;
       saveThemePreferences(key: string, value: string): void;
     };


### PR DESCRIPTION
…ma instead

After the URLs of switch pages on Android and iOS being aligned in previous change https://github.com/lynx-family/lynx/pull/1406, now let's deprecate the customized API - openDevtoolSwitchPage. We will eventually remove the definitions of the native modules when there are no more usages that we know of.

