### PR TITLE
[Optimize][Darwin] support loadExternalByteCode with loadResource

### DIFF
--- a/core/resource/lynx_resource_loader_darwin.h
+++ b/core/resource/lynx_resource_loader_darwin.h
@@ -57,7 +57,8 @@ class LynxResourceLoaderDarwin : public pub::LynxResourceLoader {
   /**
    * Try to fetch resource by Generic Fetcher. if generic fetcher not set, return false;
    */
-  bool FetchResourceByGenericFetcher(const std::string& url, CopyableClosure callback);
+  bool FetchResourceByGenericFetcher(const std::string& url, LynxResourceRequestType type,
+                                     CopyableClosure callback);
 
   /**
    * Try to fetch template by LynxResourceProvider registered with string type:

--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -129,8 +129,6 @@ bool LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
       [_providerRegistry getResourceProviderByKey:LYNX_PROVIDER_TYPE_EXTERNAL_JS];
   if (provider == nil) {
     LOGE("lynx resource provider is null, url: " << url);
-    pub::LynxResourceResponse res{.err_code = -1, .err_msg = "lynx resource provider is null."};
-    callback(res);
     return false;
   }
   TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_SCRIPT_BY_PROVIDER, "url", url);
@@ -171,12 +169,12 @@ bool LynxResourceLoaderDarwin::FetchTemplateByGenericFetcher(const std::string& 
 }
 
 bool LynxResourceLoaderDarwin::FetchResourceByGenericFetcher(const std::string& url,
+                                                             LynxResourceRequestType type,
                                                              CopyableClosure callback) {
   if (_genericResourceFetcher != nil) {
     TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_RESOURCE_BY_GENERIC_FETCHER, "url", url);
     NSString* nsUrl = [NSString stringWithUTF8String:url.c_str()];
-    LynxResourceRequest* request =
-        [[LynxResourceRequest alloc] initWithUrl:nsUrl type:LynxResourceTypeDynamicComponent];
+    LynxResourceRequest* request = [[LynxResourceRequest alloc] initWithUrl:nsUrl type:type];
     __block __weak id<LynxErrorReceiverProtocol> weakErrorReceiver = _errorReceiver;
     [_genericResourceFetcher fetchResource:request
                                 onComplete:^(NSData* _Nullable data, NSError* _Nullable error) {
@@ -268,11 +266,24 @@ void LynxResourceLoaderDarwin::LoadResource(
     return;
   }
 
+  if (request.type == pub::LynxResourceType::kExternalByteCode) {
+    auto copyable_callback = fml::MakeCopyable(std::move(callback));
+    // 1. try to use LynxGenericResourceFetcher
+    if (FetchResourceByGenericFetcher(request.url, LynxResourceTypeExternalByteCode,
+                                      copyable_callback)) {
+      return;
+    }
+
+    // invoke callback directly if no provider or fetcher set;
+    pub::LynxResourceResponse resp{.err_code = -1, .err_msg = "No available provider or fetcher."};
+    copyable_callback(resp);
+  }
+
   // fetch ExternalJS
   if (request.type == pub::LynxResourceType::kExternalJs) {
     auto copyable_callback = fml::MakeCopyable(std::move(callback));
     // 1. try to use LynxGenericResourceFetcher
-    if (FetchResourceByGenericFetcher(request.url, copyable_callback)) {
+    if (FetchResourceByGenericFetcher(request.url, LynxResourceTypeExternalJS, copyable_callback)) {
       return;
     }
     // 2. try to use external js provider


### PR DESCRIPTION
type `kExternalByteCode` is now supported in `LynxResourceLoader::LoadResource` api, since `FetchResourceByGenericFetcher` is a common logic to loadResource for any generic resources, type should be a params passed from caller instead of specifing `LynxResourceTypeDynamicComponent` by default.

doc: https://github.com/lynx-family/lynx/discussions/1503

issue: #1503
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
