### PR TITLE
[Optimize] init layoutTick with LUIBodyView

### DIFF
--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -3970,8 +3970,8 @@ public class LynxUIKitAPIAdapter : NSObject {
 }
 
 public class LynxUILayoutTick : LynxLayoutTick {
-  public instancetype LynxUILayoutTick::initWithRoot:block:(LynxView *root,[block] nonnull LynxOnLayoutBlock block);
-  public void LynxUILayoutTick::attach:(LynxView *_Nonnull root);
+  public instancetype LynxUILayoutTick::initWithRoot:block:(UIView< LUIBodyView > *root,[block] nonnull LynxOnLayoutBlock block);
+  public void LynxUILayoutTick::attach:(UIView< LUIBodyView > *_Nonnull root);
 }
 
 public class LynxUIListCellContentProducer : NSObject {

--- a/platform/darwin/ios/lynx/shadow_node/LynxUILayoutTick.h
+++ b/platform/darwin/ios/lynx/shadow_node/LynxUILayoutTick.h
@@ -2,21 +2,20 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#import <Lynx/LUIBodyView.h>
 #import <Lynx/LynxLayoutTick.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class LynxView;
-
 @interface LynxUILayoutTick : LynxLayoutTick
 
-- (instancetype)initWithRoot:(LynxView*)root block:(nonnull LynxOnLayoutBlock)block;
+- (instancetype)initWithRoot:(UIView<LUIBodyView>*)root block:(nonnull LynxOnLayoutBlock)block;
 
 /**
  * attach view for request layout
  * @param root root view
  */
-- (void)attach:(LynxView* _Nonnull)root;
+- (void)attach:(UIView<LUIBodyView>* _Nonnull)root;
 
 @end
 

--- a/platform/darwin/ios/lynx/shadow_node/LynxUILayoutTick.m
+++ b/platform/darwin/ios/lynx/shadow_node/LynxUILayoutTick.m
@@ -7,13 +7,13 @@
 
 @interface LynxUILayoutTick ()
 
-@property(nonatomic, weak) LynxView* root;
+@property(nonatomic, weak) UIView<LUIBodyView>* root;
 
 @end
 
 @implementation LynxUILayoutTick
 
-- (instancetype)initWithRoot:(LynxView*)root block:(LynxOnLayoutBlock)block {
+- (instancetype)initWithRoot:(UIView<LUIBodyView>*)root block:(LynxOnLayoutBlock)block {
   self = [super initWithBlock:block];
   if (self) {
     _root = root;
@@ -36,7 +36,7 @@
   }
 }
 
-- (void)attach:(LynxView* _Nonnull)root {
+- (void)attach:(UIView<LUIBodyView>* _Nonnull)root {
   _root = root;
 }
 


### PR DESCRIPTION
as frame also needs to mark needsLayout, layoutTick should be init with UIView<LUIBodyView>, LynxView & LynxFrameView now implements `LUIBodyView` protocol now.

issue: f-6167114849

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
