### PR TITLE
[Infra] Prepare for sdk release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -75,7 +75,7 @@ jobs:
           allowUpdates: true
 
   android-sdk-release:
-    runs-on: ${{ inputs.dry-run == false && 'ubuntu-latest' || 'lynx-ubuntu-22.04-large' }}
+    runs-on: 'lynx-ubuntu-22.04-large'
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -85,13 +85,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
-      - name: Setup Android enviroment
-        if: ${{ inputs.dry-run == false }}
-        uses: ./lynx/.github/actions/setup-android-env
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
         with:
-          cache-backend: ${{ inputs.dry-run == false && 'github' || 'lynx-infra' }}
+          cache-backend: 'lynx-infra'
       - name: Build artifact
         run: |-
           cd $GITHUB_WORKSPACE/lynx

--- a/explorer/darwin/ios/lynx_explorer/Podfile
+++ b/explorer/darwin/ios/lynx_explorer/Podfile
@@ -43,7 +43,7 @@ target 'LynxExplorer' do
   
   pod 'TestBenchReplay', :path => '../lynx_test_bench'
 
-  pod 'PrimJS', '2.12.1-alpha.3', :subspecs => ['quickjs', 'napi']
+  pod 'PrimJS', '2.13.2', :subspecs => ['quickjs', 'napi']
 
   pod 'SDWebImage','5.15.5'
   pod 'SDWebImageWebPCoder', '0.11.0'

--- a/platform/android/lynx_android/build.gradle
+++ b/platform/android/lynx_android/build.gradle
@@ -310,8 +310,8 @@ dependencies {
     androidTestImplementation "com.google.auto.service:auto-service-annotations:1.0-rc5"
     androidTestAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
-    implementation 'org.lynxsdk.lynx:primjs:2.12.1-alpha.3'
-    extractJNI 'org.lynxsdk.lynx:primjs:2.12.1-alpha.3'
+    implementation 'org.lynxsdk.lynx:primjs:2.13.2'
+    extractJNI 'org.lynxsdk.lynx:primjs:2.13.2'
     extractJNI 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
     api project(':LynxJSSDK')


### PR DESCRIPTION
1. Update primjs version to 2.13.2

2. Use self-host runner to publish android SDK to improve release efficiency.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
