### PR TITLE
[BugFix] fix nested query component.

### DIFF
--- a/core/resource/lazy_bundle/lazy_bundle_loader.cc
+++ b/core/resource/lazy_bundle/lazy_bundle_loader.cc
@@ -169,13 +169,16 @@ bool LazyBundleLoader::DispatchOnComponentLoaded(TemplateAssembler* tasm,
     return false;
   }
 
+  // TODO(nihao.royal): add test case for nested query component cases.
+  auto option_handle = url_to_lifecycle_option_map_.extract(url);
+  if (option_handle.empty()) {
+    return false;
+  }
+
   bool need_dispatch = false;
-  for (const auto& option : iter->second) {
+  for (const auto& option : option_handle.mapped()) {
     need_dispatch = option->OnLazyBundleLifecycleEnd(tasm) || need_dispatch;
   }
-  // FIXME(zhoupeng.z): erase url rather than iter, because map maybe change in
-  // `OnLazyBundleLifecycleEnd`. Fix this double check later.
-  url_to_lifecycle_option_map_.erase(url);
 
   return need_dispatch;
 }


### PR DESCRIPTION
Nested calling query component may cause crash now, it's caused by modifing `url_to_lifecycle_option_map_` while looping `url_to_lifecycle_option_map_`, eg: calling `queryComponent` in callback of `queryComponent`. It's reasonable to use `extract` to accquire lifecycleOption list from `url_to_lifecycle_option_map_` first, and then call `OnLazyBundleLifecycleEnd` for each option. `QueryComponent` called in `OnLazyBundleLifecycleEnd` will just return because templateEntry is cached now.

TODO: adding test cases for nested query component cases.

issue: f-6731310586
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
