### PR TITLE
[Optimize] enable primjs runtime checker for special cases

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -245,7 +245,7 @@ deps = {
     "third_party/quickjs/src": {
         "type": "git",
         "url": "https://github.com/lynx-family/primjs.git",
-        "commit": "3b75efc72dda3cf34586e524ec34b028f55ac7e3",
+        "commit": "c2b98b243c0bbbc774587b682d0207a55a47da70",
         "ignore_in_git": True,
     },
     "third_party/debug_router/src": {

--- a/core/renderer/template_assembler.cc
+++ b/core/renderer/template_assembler.cc
@@ -1222,6 +1222,13 @@ void TemplateAssembler::AddFont(const lepus::Value& font) {
   page_proxy()->element_manager()->AddFontFace(font);
 }
 
+void TemplateAssembler::PushRuntimeValidTid() {
+  auto default_entry = FindEntry(tasm::DEFAULT_ENTRY_NAME);
+  if (default_entry) {
+    default_entry->GetVm()->PushContextValidTid();
+  }
+}
+
 void TemplateAssembler::SetLazyBundleLoader(
     const std::shared_ptr<LazyBundleLoader>& loader) {
   element_manager_delegate_.SetBundleLoader(loader);

--- a/core/renderer/template_assembler.h
+++ b/core/renderer/template_assembler.h
@@ -290,6 +290,9 @@ class TemplateAssembler final : public TemplateEntryHolder,
 
   void AddFont(const lepus::Value& font);
 
+  // Invoked if engine thread switched;
+  void PushRuntimeValidTid();
+
   // Render page with page data that rendered on server side.
   void RenderPageWithSSRData(
       std::vector<uint8_t> data,

--- a/core/renderer/template_entry.cc
+++ b/core/renderer/template_entry.cc
@@ -53,10 +53,7 @@ bool TemplateEntry::ConstructContext(TemplateAssembler* assembler,
   auto source_type = LepusContextSourceType::kFromRuntime;
   bool enable_use_context_pool =
       use_context_pool || template_bundle().EnableUseContextPool();
-  // TODO(nihao.royal): maybe add a platform interface to enable the runtime
-  // leak checker later;
-  bool enable_runtime_leak_check = LynxEnv::GetInstance().IsDevToolEnabled();
-  if (enable_use_context_pool && !enable_runtime_leak_check) {
+  if (enable_use_context_pool) {
     // 1. try to take context for local pool
     if (template_bundle().context_pool_) {
       vm_context_ = template_bundle().context_pool_->TakeContextSafely();
@@ -93,10 +90,6 @@ bool TemplateEntry::ConstructContext(TemplateAssembler* assembler,
     uint32_t mode = tasm::performance::MemoryMonitor::ScriptingEngineMode();
     vm_context_ = lepus::Context::CreateContext(is_lepusng_binary,
                                                 disable_tracing_gc, mode);
-  }
-
-  if (enable_runtime_leak_check) {
-    vm_context_->EnableRuntimeLeakCheck(true);
   }
 
   if (!vm_context_) {

--- a/core/runtime/vm/lepus/context.h
+++ b/core/runtime/vm/lepus/context.h
@@ -244,6 +244,8 @@ class Context {
 
   virtual void EnableRuntimeLeakCheck(bool enable){};
 
+  virtual void PushContextValidTid(){};
+
   virtual void UpdateVMOuterObjSize(int size){};
 
   virtual bool IsTracingGCEnabled() { return false; }

--- a/core/runtime/vm/lepus/quick_context.cc
+++ b/core/runtime/vm/lepus/quick_context.cc
@@ -225,6 +225,11 @@ QuickContext::QuickContext(bool disable_tracing_gc, int runtime_mode)
       use_lepus_strict_mode_(false),
       debuginfo_outside_(false),
       current_this_(LEPUS_UNDEFINED) {
+  // TODO(nihao.royal): maybe add a platform interface to enable the runtime
+  // leak checker later;
+  if (tasm::LynxEnv::GetInstance().IsDevToolEnabled()) {
+    EnableRuntimeLeakCheck(true);
+  }
   LEPUSLepusRefCallbacks callbacks = Context::GetLepusRefCall();
   RegisterLepusRefCallbacks(runtime_, &callbacks);
   LEPUS_SetMaxStackSize(context(), static_cast<size_t>(ULLONG_MAX));
@@ -1028,6 +1033,10 @@ lepus::Value QuickContext::GetCurrentThis(lepus::Value* argv, int32_t offset) {
 
 void QuickContext::EnableRuntimeLeakCheck(bool enable) {
   SetObjectCtxCheckStatus(context(), enable);
+}
+
+void QuickContext::PushContextValidTid() {
+  LEPUS_PushObjectCheckTid(context());
 }
 
 void QuickContext::UpdateVMOuterObjSize(int size) {

--- a/core/runtime/vm/lepus/quick_context.h
+++ b/core/runtime/vm/lepus/quick_context.h
@@ -197,6 +197,8 @@ class QuickContext : private LEPUSRuntimeData,
 
   virtual void EnableRuntimeLeakCheck(bool enable) override;
 
+  virtual void PushContextValidTid() override;
+
   virtual void UpdateVMOuterObjSize(int size) override;
 
   virtual bool IsTracingGCEnabled() override;

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -1128,6 +1128,8 @@ void LynxShell::OnThreadStrategyUpdated() {
   engine_actor_->Act([current_strategy = current_strategy_](auto& engine) {
     engine->GetTasm()->page_proxy()->element_manager()->SetThreadStrategy(
         current_strategy);
+    // To enable MTS runtime tid check;
+    engine->GetTasm()->PushRuntimeValidTid();
   });
 }
 

--- a/platform/harmony/oh-package.json5
+++ b/platform/harmony/oh-package.json5
@@ -8,7 +8,7 @@
   "main": "",
   "version": "0.0.1",
   "dependencies": {
-    "@lynx/primjs": "0.0.1-alpha.3"
+    "@lynx/primjs": "0.0.1-alpha.5"
   },
   "dynamicDependencies": {},
   "overrides": {

--- a/third_party/quickjs/include/quickjs.h
+++ b/third_party/quickjs/include/quickjs.h
@@ -1617,6 +1617,7 @@ void LEPUS_SetFuncFileName(LEPUSContext *, LEPUSValue, const char *);
 void InitLynxTraceEnv(void *(*)(const char *), void (*)(void *));
 
 void SetObjectCtxCheckStatus(LEPUSContext *ctx, bool enable);
+bool LEPUS_PushObjectCheckTid(LEPUSContext *ctx);
 
 void UpdateOuterObjSize(LEPUSRuntime *rt, int size);
 


### PR DESCRIPTION
there are some cases that primjs will be used cross multi threads:
1. vm precreate, primjs will be created in some other threads and then used by engine thread;
2. engine thread will be switched if native api invoked.

considering for above cases, call `LEPUS_PushObjectCheckTid` to ignore such tids during check.

issue: f-23957679047
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
