### PR TITLE
[Infra] to optimize tasm-publish workflow

### DIFF
--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: cache backend for habitat
     default: 'lynx-infra'
     required: false
+  target:
+    description: habitat target
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -47,6 +51,11 @@ runs:
     - name: run habitat sync
       shell: bash
       working-directory: lynx
-      run: tools/hab sync .
+      run: |
+        if [[ "${{ inputs.target }}" == "" ]]; then
+          tools/hab sync .
+        else
+          tools/hab sync . --target ${{ inputs.target }}
+        fi
       env:
         HABITAT_CONCURRENCY: ${{ inputs.concurrency }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,6 @@ jobs:
       - name: Build Darwin Tasm
         run: |
           source tools/envsetup.sh
-          tools/hab sync . -f --target tasm
           python3 tools/oliver/lynx-tasm/gn_to_cmake_oliver.py
           pushd oliver/lynx-tasm
           npm install

--- a/.github/workflows/tasm-publish.yml
+++ b/.github/workflows/tasm-publish.yml
@@ -1,10 +1,49 @@
 name: tasm_publish
 
-on: workflow_dispatch
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'oliver/lynx-tasm/package.json'
+  workflow_dispatch:
 
 jobs:
+  check-version-change:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check_version.outputs.changed }}
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v4.2.2
+        with:
+          path: lynx
+
+      - name: Check version changed
+        id: check_version
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual trigger detected"
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            cd $GITHUB_WORKSPACE/lynx
+            git show ${{ github.event.before }}:oliver/lynx-tasm/package.json > prev_package.json
+            cp oliver/lynx-tasm/package.json curr_package.json
+            echo "Previous version: $prev_version"
+            echo "Current version: $curr_version"
+            if [[ "$prev_version" != "$curr_version" ]]; then
+              echo "Push trigger detected, Version changed"
+              echo "changed=true" >> $GITHUB_OUTPUT
+            else
+              echo "Version did not change"
+              echo "changed=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
   tasm-linux-build:
     runs-on: ubuntu-latest
+    needs: [check-version-change]
+    if: ${{ needs.check-version-change.outputs.changed == 'true' }}
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -20,19 +59,15 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.33.6
-      - name: Install Python Dependencies
-        uses: nick-fields/retry@v2
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m pip install PyYAML -i https://pypi.org/simple
+          cache-backend: github
+          target: tasm
       - name: Build Linux Tasm
         run: |-
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
-          tools/hab sync . -f --target tasm
           pushd oliver/lynx-tasm
           npm install
           npm run build:release:linux
@@ -45,6 +80,8 @@ jobs:
 
   tasm-darwin-build:
     runs-on: macOS-latest
+    needs: [check-version-change]
+    if: ${{ needs.check-version-change.outputs.changed == 'true' }}
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -60,19 +97,15 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.33.6
-      - name: Install Python Dependencies
-        uses: nick-fields/retry@v2
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m pip install PyYAML -i https://pypi.org/simple
+          cache-backend: github
+          target: tasm
       - name: Build Darwin Tasm
         run: |-
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
-          tools/hab sync . -f --target tasm
           pushd oliver/lynx-tasm
           npm install
           npm run build:release:darwin
@@ -86,6 +119,7 @@ jobs:
   tasm-publish:
     runs-on: macOS-latest
     needs: [tasm-linux-build, tasm-darwin-build]
+    if: ${{ needs.check-version-change.outputs.changed == 'true' }}
     steps:
       - name: Download Source
         uses: actions/checkout@v4.2.2
@@ -102,19 +136,15 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: 7.33.6
-      - name: Install Python Dependencies
-        uses: nick-fields/retry@v2
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
         with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |-
-            set -e
-            python3 -m pip install PyYAML -i https://pypi.org/simple
+          cache-backend: github
+          target: tasm
       - name: Build Wasm Binary
         run: |-
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
-          tools/hab sync . -f --target tasm
           pushd oliver/lynx-tasm
           npm install
           npm run build:wasm


### PR DESCRIPTION
As described, use cache in mac runner to optimize tasm-publish workflow. change `tasm-publish` workflow event to trigger by `push` event & check if `$version` in package.json changed.

AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
