### PR TITLE
[Optimize] remove redudant param of loadResource api.

### DIFF
--- a/core/public/lynx_resource_loader.h
+++ b/core/public/lynx_resource_loader.h
@@ -52,6 +52,10 @@ struct ResourceLoadTiming {
 struct LynxResourceRequest {
   std::string url;
   LynxResourceType type;
+
+  // TODO(nihao.royal): used by lazy bundle now, need to be removed in long
+  // term.
+  bool request_in_current_thread{true};
 };
 
 struct LynxResourceResponse {
@@ -91,7 +95,7 @@ class LynxResourceLoader
   virtual ~LynxResourceLoader() = default;
 
   virtual void LoadResource(
-      const LynxResourceRequest& request, bool request_in_current_thread,
+      const LynxResourceRequest& request,
       base::MoveOnlyClosure<void, LynxResourceResponse&> callback) = 0;
 
   virtual void LoadResourcePath(

--- a/core/resource/external_resource/external_resource_loader.cc
+++ b/core/resource/external_resource/external_resource_loader.cc
@@ -30,9 +30,8 @@ ExternalResourceInfo ExternalResourceLoader::LoadScript(const std::string& url,
   auto request =
       pub::LynxResourceRequest{url, pub::LynxResourceType::kExternalJs};
   resource_loader_->LoadResource(
-      request, true,
-      [promise =
-           std::move(promise)](pub::LynxResourceResponse& response) mutable {
+      request, [promise = std::move(promise)](
+                   pub::LynxResourceResponse& response) mutable {
         promise.set_value(ExternalResourceInfo(std::move(response.data),
                                                response.err_code,
                                                std::move(response.err_msg)));
@@ -55,9 +54,8 @@ void ExternalResourceLoader::LoadScriptAsync(const std::string& url,
   auto request =
       pub::LynxResourceRequest{url, pub::LynxResourceType::kExternalJs};
   resource_loader_->LoadResource(
-      request, true,
-      [url, callback_id,
-       weak_self = weak_from_this()](pub::LynxResourceResponse& response) {
+      request, [url, callback_id, weak_self = weak_from_this()](
+                   pub::LynxResourceResponse& response) {
         auto self = weak_self.lock();
         if (!self) {
           LOGI("LoadScriptAsync::self is null");
@@ -93,9 +91,8 @@ ExternalResourceInfo ExternalResourceLoader::LoadByteCode(
   auto request =
       pub::LynxResourceRequest{url, pub::LynxResourceType::kExternalByteCode};
   resource_loader_->LoadResource(
-      request, true,
-      [promise =
-           std::move(promise)](pub::LynxResourceResponse& response) mutable {
+      request, [promise = std::move(promise)](
+                   pub::LynxResourceResponse& response) mutable {
         promise.set_value(ExternalResourceInfo(std::move(response.data),
                                                response.err_code,
                                                std::move(response.err_msg)));
@@ -126,7 +123,7 @@ void ExternalResourceLoader::LoadLazyBundle(
   auto request =
       pub::LynxResourceRequest{url, pub::LynxResourceType::kLazyBundle};
   resource_loader_->LoadResource(
-      request, true,
+      request,
       [url, callback_id, component_ids = ids, weak_self = weak_from_this()](
           pub::LynxResourceResponse& response) mutable {
         auto self = weak_self.lock();
@@ -198,9 +195,8 @@ std::vector<uint8_t> ExternalResourceLoader::LoadJSSource(
   auto request = pub::LynxResourceRequest{
       .url = url, .type = pub::LynxResourceType::kAssets};
   resource_loader_->LoadResource(
-      request, true,
-      [promise =
-           std::move(promise)](pub::LynxResourceResponse& response) mutable {
+      request, [promise = std::move(promise)](
+                   pub::LynxResourceResponse& response) mutable {
         promise.set_value(std::move(response.data));
       });
   return future.get();

--- a/core/resource/lazy_bundle/lazy_bundle_loader.cc
+++ b/core/resource/lazy_bundle/lazy_bundle_loader.cc
@@ -111,7 +111,7 @@ void LazyBundleLoader::LoadFrameBundle(const std::string& src) {
   // TODO(zhoupeng.z): support to load frame bundle on platform layer
   auto request = pub::LynxResourceRequest{src, pub::LynxResourceType::kFrame};
   resource_loader_->LoadResource(
-      request, true,
+      request,
       [src, weak_self = weak_from_this()](pub::LynxResourceResponse& response) {
         auto self = weak_self.lock();
         if (!self) {
@@ -195,9 +195,8 @@ void LazyBundleLoader::RequireTemplate(RadonLazyComponent* lazy_bundle,
   auto request =
       pub::LynxResourceRequest{url, pub::LynxResourceType::kLazyBundle};
   resource_loader_->LoadResource(
-      request, true,
-      [url, weak_self = weak_from_this(), lazy_bundle,
-       instance_id](pub::LynxResourceResponse& response) {
+      request, [url, weak_self = weak_from_this(), lazy_bundle,
+                instance_id](pub::LynxResourceResponse& response) {
         auto self = weak_self.lock();
         if (!self) {
           return;
@@ -228,12 +227,11 @@ void LazyBundleLoader::PreloadTemplates(const std::vector<std::string>& urls) {
     return;
   }
   std::for_each(urls.begin(), urls.end(), [this](const auto& url) {
-    auto request =
-        pub::LynxResourceRequest{url, pub::LynxResourceType::kLazyBundle};
+    auto request = pub::LynxResourceRequest{
+        url, pub::LynxResourceType::kLazyBundle, false};
     resource_loader_->LoadResource(
-        request, false,
-        [url,
-         weak_self = weak_from_this()](pub::LynxResourceResponse& response) {
+        request, [url, weak_self = weak_from_this()](
+                     pub::LynxResourceResponse& response) {
           auto self = weak_self.lock();
           if (!self) {
             return;

--- a/core/resource/lynx_resource_loader_android.cc
+++ b/core/resource/lynx_resource_loader_android.cc
@@ -47,7 +47,7 @@ namespace lynx {
 namespace shell {
 
 void LynxResourceLoaderAndroid::LoadResource(
-    const pub::LynxResourceRequest& request, bool request_in_current_thread,
+    const pub::LynxResourceRequest& request,
     base::MoveOnlyClosure<void, pub::LynxResourceResponse&> callback) {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, LOAD_RESOURCE,
               [&request](lynx::perfetto::EventContext ctx) {
@@ -67,7 +67,8 @@ void LynxResourceLoaderAndroid::LoadResource(
   auto j_url = JNIConvertHelper::ConvertToJNIStringUTF(env, request.url);
   Java_LynxResourceLoader_loadResource(
       env, local_ref.Get(), reinterpret_cast<jlong>(response_handler),
-      j_url.Get(), static_cast<int>(request.type), request_in_current_thread);
+      j_url.Get(), static_cast<int>(request.type),
+      request.request_in_current_thread);
 }
 
 void LynxResourceLoaderAndroid::ResponseHandler::HandleResponse(

--- a/core/resource/lynx_resource_loader_android.h
+++ b/core/resource/lynx_resource_loader_android.h
@@ -35,7 +35,6 @@ class LynxResourceLoaderAndroid : public pub::LynxResourceLoader {
   ~LynxResourceLoaderAndroid() override = default;
 
   void LoadResource(const pub::LynxResourceRequest& request,
-                    bool request_in_current_thread,
                     base::MoveOnlyClosure<void, pub::LynxResourceResponse&>
                         callback) override;
 

--- a/core/resource/lynx_resource_loader_darwin.h
+++ b/core/resource/lynx_resource_loader_darwin.h
@@ -34,7 +34,7 @@ class LynxResourceLoaderDarwin : public pub::LynxResourceLoader {
                            id<LynxGenericResourceFetcher> genericResourceFetcher);
   ~LynxResourceLoaderDarwin() override = default;
 
-  void LoadResource(const pub::LynxResourceRequest& request, bool request_in_current_thread,
+  void LoadResource(const pub::LynxResourceRequest& request,
                     base::MoveOnlyClosure<void, pub::LynxResourceResponse&> callback) override;
 
  private:

--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -217,8 +217,7 @@ bool LynxResourceLoaderDarwin::FetchTemplateByProvider(const std::string& url,
 }
 
 bool LynxResourceLoaderDarwin::FetchTemplateByFetcherWrapper(const std::string& url,
-                                                             CopyableClosure callback,
-                                                             bool request_in_current_thread) {
+                                                             CopyableClosure callback, bool sync) {
   // use fetcher_wrapper to fetch template.
   __block volatile BOOL invoked = NO;
   __block NSObject* object = [[NSObject alloc] init];
@@ -247,13 +246,11 @@ bool LynxResourceLoaderDarwin::FetchTemplateByFetcherWrapper(const std::string& 
                                    .err_msg = [errMsg UTF8String]};
     callback(resp);
   };
-  return [_fetcher_wrapper fetchResource:nsUrl
-                         withLoadedBlock:fetcherBlock
-                                    sync:request_in_current_thread];
+  return [_fetcher_wrapper fetchResource:nsUrl withLoadedBlock:fetcherBlock sync:sync];
 }
 
 void LynxResourceLoaderDarwin::LoadResource(
-    const pub::LynxResourceRequest& request, bool request_in_current_thread,
+    const pub::LynxResourceRequest& request,
     base::MoveOnlyClosure<void, pub::LynxResourceResponse&> callback) {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, LOAD_RESOURCE, [&request](lynx::perfetto::EventContext ctx) {
     ctx.event()->add_debug_annotations("url", request.url);
@@ -313,7 +310,7 @@ void LynxResourceLoaderDarwin::LoadResource(
 
     // 2. try to use LynxExternalResourceFetcherWrapper
     if (FetchTemplateByFetcherWrapper(request.url, copyable_wrapper_callback,
-                                      request_in_current_thread)) {
+                                      request.request_in_current_thread)) {
       return;
     }
     // 3. try to use LynxResourceProvider

--- a/core/resource/lynx_resource_loader_harmony.cc
+++ b/core/resource/lynx_resource_loader_harmony.cc
@@ -113,7 +113,7 @@ LynxResourceLoaderHarmony::LynxResourceLoaderHarmony(napi_env env,
 LynxResourceLoaderHarmony::~LynxResourceLoaderHarmony() {}
 
 void LynxResourceLoaderHarmony::LoadResource(
-    const pub::LynxResourceRequest& request, bool request_in_current_thread,
+    const pub::LynxResourceRequest& request,
     base::MoveOnlyClosure<void, pub::LynxResourceResponse&> callback) {
   pub::ResourceLoadTiming timing;
 

--- a/core/resource/lynx_resource_loader_harmony.h
+++ b/core/resource/lynx_resource_loader_harmony.h
@@ -75,7 +75,6 @@ class LynxResourceLoaderHarmony : public pub::LynxResourceLoader {
   }
 
   void LoadResource(const pub::LynxResourceRequest& request,
-                    bool request_in_current_thread,
                     base::MoveOnlyClosure<void, pub::LynxResourceResponse&>
                         callback) override;
 


### PR DESCRIPTION
make `request_in_current_thread` a member of LynxResourceRequest, in long term, it should be removed.

issue: f-123947676
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
