### PR TITLE
[Infra] Remove unused so artifact in android release

### DIFF
--- a/platform/android/publish.gradle
+++ b/platform/android/publish.gradle
@@ -69,29 +69,6 @@ Task createSourceJar(String baseName) {
     }
 }
 
-def collectSoSymbols(String flavor) {
-    def soSymbolsPathMap = [:]
-    project.android.libraryVariants.all { variant ->
-        def flavorFolder = "${flavor}Release"
-        println "variant.name $variant.name flavorFolder=$flavorFolder"
-        if (variant.name != flavorFolder) {
-            return
-        }
-        def nativeBuildTask = project.tasks.findByName("externalNativeBuild${variant.name.capitalize()}")
-        if (nativeBuildTask != null) {
-            def folder = nativeBuildTask.getObjFolder()
-            println "project $project.path variant $variant.name folder=$folder"
-            FileTree fileTree = project.fileTree(folder)
-            fileTree.include "**/*.so"
-            fileTree.files.each { item ->
-                soSymbolsPathMap[item.name[0..(item.name.lastIndexOf('.')-1)]] = item.path
-            }
-        }
-    }
-    println "project $project.path soSymbolsPathMap=${soSymbolsPathMap}"
-    return soSymbolsPathMap
-}
-
 def configureSigning(pom) {
     def signingKeyId = findProperty("signing.keyId")
     def signingPassword = findProperty("signing.password")
@@ -196,16 +173,6 @@ afterEvaluate {
                         artifactId ARTIFACT_NAME
                         version baseVersion
                         artifact(getAARPath("$project.buildDir/outputs/aar"))
-                        // Obtain all the so symbol tables of the component.
-                        def soSymbolsPathMap = collectSoSymbols("noasan")
-                        // Add so symbol tables into the component artifact.
-                        if (!soSymbolsPathMap.isEmpty()) {
-                            soSymbolsPathMap.each { name, path ->
-                                artifact(path) {
-                                    classifier name
-                                }
-                            }
-                        }
                         // collect source jar and add it into the component artifact.
                         Task sourceJar = createSourceJar("release-source")
                         artifact sourceJar
@@ -251,16 +218,6 @@ afterEvaluate {
                         artifactId ARTIFACT_NAME
                         version devVersion
                         artifact(getAARPath("$project.buildDir/outputs/aar", true))
-                        // Obtain all the so symbol tables of the component.
-                        def soSymbolsPathMap = collectSoSymbols("dev")
-                        // Add so symbol tables into the component artifact.
-                        if (!soSymbolsPathMap.isEmpty()) {
-                            soSymbolsPathMap.each { name, path ->
-                                artifact(path) {
-                                    classifier name
-                                }
-                            }
-                        }
                         // collect source jar and add it into the component artifact.
                         Task sourceJarDev = createSourceJar("dev-sources")
                         artifact sourceJarDev


### PR DESCRIPTION
During the Android SDK release process, remove the logic that unnecessarily adds SO files to the artifact. SO files can be obtained from the AAR on Maven.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
