### PR TITLE
[BugFix] Crash Fix For SwithEngineThread called before loadTemplate.

### DIFF
--- a/core/renderer/template_assembler.cc
+++ b/core/renderer/template_assembler.cc
@@ -1229,7 +1229,10 @@ void TemplateAssembler::AddFont(const lepus::Value& font) {
 void TemplateAssembler::PushRuntimeValidTid() {
   auto default_entry = FindEntry(tasm::DEFAULT_ENTRY_NAME);
   if (default_entry) {
-    default_entry->GetVm()->PushContextValidTid();
+    auto vm = default_entry->GetVm();
+    if (vm) {
+      vm->PushContextValidTid();
+    }
   }
 }
 


### PR DESCRIPTION
in case that switchEngineThread is triggered before LoadTemplate, VMContext in TemplateEntry will be nullptr, make a protection for such cases.

AutoSubmit: true
issue: f-6736790078

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
