### PR TITLE
[Feature] add LynxContext as params of LynxResourceRequest.

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -5502,12 +5502,14 @@ public class com::lynx::tasm::provider::LynxResourceRequest :  {
 
 public class com::lynx::tasm::resourceprovider::LynxResourceRequest :  {
   public com.lynx.tasm.resourceprovider.LynxResourceRequest.LynxResourceRequest(String url, LynxResourceType type);
+  public com.lynx.tasm.resourceprovider.LynxResourceRequest.LynxResourceRequest(String url, LynxResourceType type, LynxContext context);
+  public void com.lynx.tasm.resourceprovider.LynxResourceRequest.setAsyncMode(AsyncMode mode);
+  public void com.lynx.tasm.resourceprovider.LynxResourceRequest.setParams(Map< String, Object > params);
   public String com.lynx.tasm.resourceprovider.LynxResourceRequest.getUrl();
   public LynxResourceType com.lynx.tasm.resourceprovider.LynxResourceRequest.getResourceType();
-  public void com.lynx.tasm.resourceprovider.LynxResourceRequest.setAsyncMode(AsyncMode mode);
   public AsyncMode com.lynx.tasm.resourceprovider.LynxResourceRequest.getAsyncMode();
-  public void com.lynx.tasm.resourceprovider.LynxResourceRequest.setParams(Map< String, Object > params);
   public Map< String, Object > com.lynx.tasm.resourceprovider.LynxResourceRequest.getParams();
+  public LynxContext com.lynx.tasm.resourceprovider.LynxResourceRequest.getLynxContext();
 }
 
 public class com::lynx::tasm::provider::LynxResourceResponse :  {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/resourceprovider/LynxResourceRequest.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/resourceprovider/LynxResourceRequest.java
@@ -3,8 +3,12 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.tasm.resourceprovider;
 
+import com.lynx.tasm.behavior.LynxContext;
 import java.util.Map;
 
+/**
+ * Request Object that identifies the Current Resource Request.
+ */
 public final class LynxResourceRequest {
   public enum LynxResourceType {
     LynxResourceTypeGeneric,
@@ -30,35 +34,87 @@ public final class LynxResourceRequest {
 
   private final String url;
   private final LynxResourceType resourceType;
+  private final LynxContext lynxContext;
   private Map<String, Object> params;
   private AsyncMode asyncMode;
 
+  /**
+   * Construct a resource request object.
+   * @param url url of the requesting resource
+   * @param type type of the requesting resource
+   */
   public LynxResourceRequest(String url, LynxResourceType type) {
+    this(url, type, null);
+  }
+
+  /**
+   * Construct a resource request object.
+   * @param url url of the requesting resource
+   * @param type type of the requesting resource
+   * @param context the current lynxContext instance;
+   */
+  public LynxResourceRequest(String url, LynxResourceType type, LynxContext context) {
     this.url = url;
     this.resourceType = type;
+    this.lynxContext = context;
   }
 
-  public String getUrl() {
-    return this.url;
-  }
-
-  public LynxResourceType getResourceType() {
-    return this.resourceType;
-  }
-
+  /**
+   * Set the mode of current resource request
+   * @param mode
+   *  - EXACTLY_ASYNC: This request should be requested asynchronously
+   *  - EXACTLY_SYNC: This request should be requested synchronously
+   *  - MOST_SYNC: sync resource request if offline file existed, otherwise async.
+   */
   public void setAsyncMode(AsyncMode mode) {
     this.asyncMode = mode;
   }
 
-  public AsyncMode getAsyncMode() {
-    return this.asyncMode;
-  }
-
+  /**
+   * Set the additional params of the current resource request
+   * @param params the additional params
+   */
   public void setParams(Map<String, Object> params) {
     this.params = params;
   }
 
+  /**
+   * Get the url of the requesting resource
+   * @return resource url
+   */
+  public String getUrl() {
+    return this.url;
+  }
+
+  /**
+   * Get the type of the requesting resource
+   * @return resource type
+   */
+  public LynxResourceType getResourceType() {
+    return this.resourceType;
+  }
+
+  /**
+   * Get the thread mode of the requesting resource
+   * @return thread mode
+   */
+  public AsyncMode getAsyncMode() {
+    return this.asyncMode;
+  }
+
+  /**
+   * Get the additional params of the current resource request.
+   * @return the additional params
+   */
   public Map<String, Object> getParams() {
     return this.params;
+  }
+
+  /**
+   * get the current lynxContext instance;
+   * @return LynxContext
+   */
+  public LynxContext getLynxContext() {
+    return this.lynxContext;
   }
 }

--- a/platform/darwin/common/lynx/public/resource/LynxResourceRequest.h
+++ b/platform/darwin/common/lynx/public/resource/LynxResourceRequest.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class LynxUIContext;
+
 typedef NS_ENUM(NSInteger, LynxResourceRequestAsyncMode) {
   EXACTLY_ASYNC,
   EXACTLY_SYNC,
@@ -38,10 +40,14 @@ typedef NS_ENUM(NSInteger, LynxResourceRequestType) {
 @property(nonatomic, readonly, assign) LynxResourceRequestType type;
 @property(nonatomic, readwrite, strong) id requestParams;
 @property(nonatomic, readwrite, assign) LynxResourceRequestAsyncMode mode;
+@property(nonatomic, weak, readonly) LynxUIContext* uiContext;
 
 - (instancetype)initWithUrl:(NSString*)url;
 - (instancetype)initWithUrl:(NSString*)url type:(LynxResourceRequestType)type;
 - (instancetype)initWithUrl:(NSString*)url andRequestParams:(id)requestParams;
+- (instancetype)initWithUrl:(NSString*)url
+                       type:(LynxResourceRequestType)type
+                    context:(nullable LynxUIContext*)context;
 
 // Only for LynxResourceFetcher use. Return the full request parameters for forest.
 - (LynxServiceResourceRequestParameters* _Nullable)getLynxResourceServiceRequestParams;

--- a/platform/darwin/common/lynx/resource/LynxResourceRequest.m
+++ b/platform/darwin/common/lynx/resource/LynxResourceRequest.m
@@ -29,6 +29,17 @@
   return self;
 }
 
+- (instancetype)initWithUrl:(NSString *)url
+                       type:(LynxResourceRequestType)type
+                    context:(LynxUIContext *)context {
+  if (self = [super init]) {
+    _url = url;
+    _type = type;
+    _uiContext = context;
+  }
+  return self;
+}
+
 - (LynxServiceResourceRequestParameters *_Nullable)getLynxResourceServiceRequestParams {
   if (_requestParams != nil &&
       [_requestParams isKindOfClass:[LynxServiceResourceRequestParameters class]]) {

--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -2857,9 +2857,11 @@ public class LynxResourceRequest : NSObject {
   public LynxResourceRequestType LynxResourceRequest::type type;
   public id LynxResourceRequest::requestParams requestParams;
   public LynxResourceRequestAsyncMode LynxResourceRequest::mode mode;
+  public LynxUIContext* LynxResourceRequest::uiContext uiContext;
   public instancetype LynxResourceRequest::initWithUrl:(NSString *url);
   public instancetype LynxResourceRequest::initWithUrl:type:(NSString *url,[type] LynxResourceRequestType type);
   public instancetype LynxResourceRequest::initWithUrl:andRequestParams:(NSString *url,[andRequestParams] id requestParams);
+  public instancetype LynxResourceRequest::initWithUrl:type:context:(NSString *url,[type] LynxResourceRequestType type,[context] nullable LynxUIContext *context);
   public LynxServiceResourceRequestParameters *_Nullable LynxResourceRequest::getLynxResourceServiceRequestParams();
 }
 

--- a/platform/harmony/api/lynx_harmony.api
+++ b/platform/harmony/api/lynx_harmony.api
@@ -232,11 +232,12 @@ export interface TemplateProviderResult {
 }
 
 export class LynxResourceRequest {
-  constructor(url: string, type: LynxResourceType);
+  constructor(url: string, type: LynxResourceType, context: LynxContext);
   url: string;
   type: LynxResourceType;
   params?: Record<string, Object>;
   mode?: LynxResourceAsyncMode;
+  context: LynxContext | undefined;
 }
 
 export enum LynxResourceType {

--- a/platform/harmony/lynx_harmony/src/main/ets/provider/LynxResourceRequest.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/provider/LynxResourceRequest.ets
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { LynxContext } from '../tasm/LynxContext';
+
 export enum LynxResourceType {
   LYNX_RESOURCE_TYPE_GENERIC = 0,
   LYNX_RESOURCE_TYPE_IMAGE = 1,
@@ -34,9 +36,11 @@ export class LynxResourceRequest {
   type: LynxResourceType;
   params?: Record<string, Object>;
   mode?: LynxResourceAsyncMode;
+  context: LynxContext | undefined;
 
-  constructor(url: string, type: LynxResourceType) {
+  constructor(url: string, type: LynxResourceType, context?: LynxContext) {
     this.url = url;
     this.type = type;
+    this.context = context;
   }
 }


### PR DESCRIPTION
As described, add LynxContext as params of LynxResourceRequest. so that ResourceFetcher providers could be aware of current request lynx instance.

AutoSubmit: true
doc: https://github.com/lynx-family/lynx/issues/1425
issue: #1425

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
