### PR TITLE
[Infra] Harmony explorer build cache

### DIFF
--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -15,6 +15,13 @@ inputs:
     description: habitat target
     default: ''
     required: false
+  # actions/cache stores files with relative directory, which causes inconsistency between self-hosted runner and
+  # container runner. Therefore, add this temporary option to modify cache key prefix as a workaround. Delete this when
+  # we are able to adjust the container runner's directory structure to the same as self-hosted runner.
+  cache-key-prefix:
+    description: cache key prefix for cache action
+    default: 'hab'
+    required: false
 
 runs:
   using: composite
@@ -24,9 +31,9 @@ runs:
       uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
       with:
         path: ~/.habitat_cache
-        key: hab-${{ runner.os }}-${{ hashFiles('lynx/.habitat', 'lynx/DEPS') }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.os }}-${{ hashFiles('lynx/.habitat', 'lynx/DEPS') }}
         restore-keys: |
-          hab-${{ runner.os }}-
+          ${{ inputs.cache-key-prefix }}-${{ runner.os }}-
 
     - name: setup cache action
       if: ${{ inputs.cache-backend == 'github' }}

--- a/.github/actions/harmony-explorer-build/action.yml
+++ b/.github/actions/harmony-explorer-build/action.yml
@@ -5,12 +5,10 @@ description: build harmony explorer hap
 runs:
   using: composite
   steps:
-    - name: Python Setup
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
     - name: Install Common Dependencies
       uses: ./lynx/.github/actions/common-deps
+      with:
+        cache-key-prefix: 'hab-container'
     - name: Build Explorer App
       shell: bash
       working-directory: lynx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,9 +513,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynx
-      - name: change permission
-        run: |
-          sudo chmod 777 /
       - name: Build Explorer App
         uses: ./lynx/.github/actions/harmony-explorer-build
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -81,7 +81,7 @@ jobs:
   harmony-explorer-build:
     runs-on: lynx-custom-container
     container:
-      image: ghcr.io/lynx-family/ubuntu24.04-harmony@sha256:601a0169922d3929a2f77cb0ceda89a3c76b168e1a95e2d419465b295ed2a1d6
+      image: ghcr.io/lynx-family/ubuntu24.04-harmony@sha256:8eb0ee8da7e8592669f0fcd41d0e1bc818b33a75e27943521f57af87d04db2fb
       credentials:
         username: lynx-family
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -95,9 +95,6 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynx
-      - name: change permission
-        run: |
-          sudo chmod 777 /
       - name: Build Explorer App
         uses: ./lynx/.github/actions/harmony-explorer-build
       - name: push explorer to release
@@ -216,15 +213,10 @@ jobs:
       - name: Get latest tag
         id: get-latest-tag
         uses: ./lynx/.github/actions/get-latest-tag
-      - name: Set Access Permission
-        run: |
-          sudo chmod 777 /
-      - name: Python Setup
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
+        with:
+          cache-key-prefix: 'hab-container'
       - name: Generate Change Log
         run: |
           cd $GITHUB_WORKSPACE/lynx


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

Add a temporary option to fix container runner not able to consume habitat cache.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
