### PR TITLE
[Testing] Add catch and re-run mechanism in E2E

### DIFF
--- a/testing/integration_test/test_script/lib/test_runner/test_runner.py
+++ b/testing/integration_test/test_script/lib/test_runner/test_runner.py
@@ -171,8 +171,10 @@ class TestRunner:
                     # After capturing the exception, restart the app and rerun the current test case once.
                     _run_case()
                 except socket.error as e:
-                    if e.errno == errno.EPIPE:
-                        self._test.log_info('-------- Meets Socket Broken Pipe Exception, restart app --------')
+                    if e.errno in [errno.EPIPE, errno.EBADF]:
+                        self._test.log_info('-------- Meets Socket Broken Pipe Exception --------')
+                        self._test.log_info(traceback.format_exc())
+                        self._test.log_info('-------- Restart App And Rerun case --------')
                         self.restart_and_connect_app()
                         # After capturing the exception, restart the app and rerun the current test case once.
                         _run_case()


### PR DESCRIPTION
During the execution of E2E tasks, capture socket exceptions and re-run the case once when an exception occurs to improve the success rate.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
