### PR TITLE
[Optimize] make `encoder.h` deps standalone

### DIFF
--- a/core/template_bundle/template_codec/binary_encoder/encoder.h
+++ b/core/template_bundle/template_codec/binary_encoder/encoder.h
@@ -6,8 +6,6 @@
 #include <string>
 #include <vector>
 
-#include "core/template_bundle/template_codec/generator/base_struct.h"
-
 namespace lynx {
 namespace tasm {
 enum EncodeSSRError {
@@ -16,6 +14,19 @@ enum EncodeSSRError {
   ERR_NOT_SSR,
   ERR_BUF,
   ERR_DATA_EMPTY
+};
+
+struct EncodeResult {
+  int status;
+  std::string error_msg;
+  std::vector<uint8_t> buffer;
+  std::string lepus_code;
+  std::string lepus_debug;
+  std::string section_size;
+};
+struct DecodeResult {
+  int status;
+  std::string result;
 };
 
 lynx::tasm::EncodeResult encode(const std::string& options_str);

--- a/core/template_bundle/template_codec/generator/base_struct.h
+++ b/core/template_bundle/template_codec/generator/base_struct.h
@@ -17,20 +17,6 @@
 namespace lynx {
 namespace tasm {
 
-struct EncodeResult {
-  int status;
-  std::string error_msg;
-  std::vector<uint8_t> buffer;
-  std::string lepus_code;
-  std::string lepus_debug;
-  std::string section_size;
-};
-
-struct DecodeResult {
-  int status;
-  std::string result;
-};
-
 // Options used in encode time, but not be used in run time.
 struct GeneratorOptions {
   std::string cli_version_{};


### PR DESCRIPTION
As `encoder.h` may be exposed to developer to invoke method inside, we need to make sure that `encoder.h` does not deps any class that should not be exposed.

issue: f-23904875
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
