### PR TITLE
[Infra] add clangd related files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ core/build/gen/
 /core/build/jni/gen
 /core/build/jni/BUILD.gn
 **/build/gen
-
+.cache/
+compile_commands.json
 
 # Auto generated error code files
 /platform/darwin/common/lynx/LynxErrorBehavior.m


### PR DESCRIPTION
`clangd` search workspace root for `compile_commands.json` file, which is auto-generated by `ninja`, and produce cache files in `.cache` dir. They should all be ignored in `.gitignore`

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
