### PR TITLE
[BugFix] add `FindTemplateBundle` api to support getCustomSections.

### DIFF
--- a/core/renderer/template_assembler.cc
+++ b/core/renderer/template_assembler.cc
@@ -3388,7 +3388,7 @@ ContextProxyInLepus* TemplateAssembler::GetContextProxy(
 
 lepus::Value TemplateAssembler::GetCustomSection(
     const std::string& key, const std::string& bundle_name) {
-  auto bundle = FindTemplateEntry(bundle_name);
+  auto* bundle = FindTemplateBundle(bundle_name);
   return bundle ? bundle->GetCustomSection(key) : lepus::Value();
 }
 

--- a/core/renderer/template_entry_holder.cc
+++ b/core/renderer/template_entry_holder.cc
@@ -41,6 +41,21 @@ std::shared_ptr<TemplateEntry> TemplateEntryHolder::FindTemplateEntry(
   return entry_iter == template_entries_.end() ? nullptr : entry_iter->second;
 }
 
+LynxTemplateBundle* TemplateEntryHolder::FindTemplateBundle(
+    const std::string& entry_name) {
+  auto bundle_iter = template_entries_.find(entry_name);
+  if (bundle_iter != template_entries_.end()) {
+    return &bundle_iter->second->template_bundle();
+  }
+
+  auto preload_bundle_iter = preload_template_bundles_.find(entry_name);
+  if (preload_bundle_iter != preload_template_bundles_.end()) {
+    return &preload_bundle_iter->second;
+  }
+
+  return nullptr;
+}
+
 void TemplateEntryHolder::ForEachEntry(
     base::MoveOnlyClosure<void, const std::shared_ptr<TemplateEntry>&> func) {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, TEMPLATE_ENTRY_HOLDER_FOR_EACH_ENTRY);

--- a/core/renderer/template_entry_holder.h
+++ b/core/renderer/template_entry_holder.h
@@ -38,6 +38,8 @@ class TemplateEntryHolder {
   std::shared_ptr<TemplateEntry> FindTemplateEntry(
       const std::string& entry_name);
 
+  LynxTemplateBundle* FindTemplateBundle(const std::string& entry_name);
+
   /**
    * insert bundle for preloading lazy bundle
    */


### PR DESCRIPTION
When `loadScript` is called, we need to find the associated AppBundle resource with `FindTemplateBundle` api instead of `FindTemplateEntry` function, because the bundle fetched by FetchBundle exist in `preload_template_bundles_` container.

At the same time we unifiy the `FindTemplateEntry` and `FindEntry` functions, they the actually the same function that does the same thing, the only difference is that `FindTemplateEntry` returns nullptr if entry not exist, and `FindEntry` may just abort.

using
```
static base::NoDestructor<std::shared_ptr<TemplateEntry>> null_entry(nullptr);
```
we unifiy this two methods, making logic more clearer.

issue: f-978374646
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
