### PR TITLE
[Infra] Support publish dev version for harmony

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -33,6 +33,7 @@ jobs:
             echo "Version is invalid"
             exit 1
           fi
+
   android-explorer-build:
     timeout-minutes: 60
     runs-on: lynx-ubuntu-22.04-large
@@ -184,6 +185,7 @@ jobs:
           component: all
 
   harmony-sdk-publish:
+    name: Publish Harmony SDK (${{ matrix.label }})
     runs-on: lynx-custom-container
     container:
       image: ghcr.io/lynx-family/ubuntu24.04-harmony@sha256:8eb0ee8da7e8592669f0fcd41d0e1bc818b33a75e27943521f57af87d04db2fb
@@ -193,6 +195,18 @@ jobs:
     defaults:
       run:
         shell: bash
+    needs: get-version
+    strategy:
+      matrix:
+        include:
+          - version_suffix: ''
+            modules: 'default'
+            build_param: ''
+            label: 'formal'
+          - version_suffix: '-dev'
+            modules: 'lynx lynx_devtool'
+            build_param: '--dev'
+            label: 'dev'
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -222,14 +236,14 @@ jobs:
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
           COMMIT_ID=$(git rev-list -n 1 ${{ steps.get-latest-tag.outputs.latest-tag }})
-          python3 explorer/harmony/script/generate_changelog.py --version ${{ needs.get-version.outputs.version }} --modules default --base_commit $COMMIT_ID
+          python3 explorer/harmony/script/generate_changelog.py --version ${{ needs.get-version.outputs.version }}${{ matrix.version_suffix }} --modules ${{ matrix.modules }} --base_commit $COMMIT_ID
       - name: Build Harmony SDK
         run: |
           cd $GITHUB_WORKSPACE/lynx
           source tools/envsetup.sh
           pushd platform/harmony && ohpm install && popd
           pushd explorer/harmony && ohpm install && popd
-          python3 explorer/harmony/script/build.py --build_lynx_core --build_har --modules default --override_version ${{ needs.get-version.outputs.version }}
+          python3 explorer/harmony/script/build.py ${{ matrix.build_param }} --build_lynx_core --build_har --modules ${{ matrix.modules }} --override_version ${{ needs.get-version.outputs.version }}${{ matrix.version_suffix }}
       - name: Publish Harmony SDK
         run: |
           cd $GITHUB_WORKSPACE/lynx
@@ -241,4 +255,4 @@ jobs:
           ohpm config set publish_registry https://ohpm.openharmony.cn/ohpm
           export PUBLISH_ID=${{ secrets.HARMONY_PUBLISH_ID }}
           export KEY_PATH=$GITHUB_WORKSPACE/lynx/publish_key
-          python3 explorer/harmony/script/publish.py --modules default --version ${{ needs.get-version.outputs.version }}
+          python3 explorer/harmony/script/publish.py --modules ${{ matrix.modules }} --version ${{ needs.get-version.outputs.version }}${{ matrix.version_suffix }}


### PR DESCRIPTION
Use a switch to isolate accessability-label and lynx-test-tag to avoid being unable to run UI automation with lynx-test-tag after enabling accessibility on the page.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
