### PR TITLE
[Infra] Skip overwrite release note when publish artifacts

### DIFF
--- a/.github/actions/ios-sdk-publish/action.yml
+++ b/.github/actions/ios-sdk-publish/action.yml
@@ -39,6 +39,7 @@ runs:
         artifacts: '${{ github.workspace }}/lynx/*.zip'
         replacesArtifacts: true
         allowUpdates: true
+        body: ''
     - name: Publish to CocoaPods Repo
       env:
         COCOAPODS_TRUNK_TOKEN: ${{ inputs.cocoapods_trunk_token }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,6 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: '${{ github.workspace }}/lynx/explorer/android/lynx_explorer/build/outputs/apk/noasan/release/LynxExplorer-noasan-release.apk'
           allowUpdates: true
+          body: ''
 
   ios-explorer-build:
     timeout-minutes: 60
@@ -78,6 +79,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: '${{ github.workspace }}/lynx/LynxExplorer-${{ matrix.arch }}.app.tar.gz'
           allowUpdates: true
+          body: ''
 
   harmony-explorer-build:
     runs-on: lynx-custom-container
@@ -105,6 +107,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: '${{ github.workspace }}/lynx/explorer/harmony/lynx_explorer/build/default/outputs/default/lynx_explorer-default-unsigned.hap'
           allowUpdates: true
+          body: ''
 
   android-sdk-release:
     runs-on: lynx-ubuntu-22.04-large


### PR DESCRIPTION
Skip overwrite release note when publish artifacts to git hub release.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
