### PR TITLE
[Infra] Modify the judgment logic for Android dev version

### DIFF
--- a/platform/android/publish.gradle
+++ b/platform/android/publish.gradle
@@ -40,10 +40,14 @@ boolean isAndroidModule() {
 }
 
 boolean hasDevFlavor() {
-    if (!isAndroidModule()) {
+    if (!isAndroidModule() || !project.android.productFlavors.any { it.name == "dev" }) {
         return false
     }
-    return project.android.productFlavors.any { it.name == "dev" }
+    def executedTasks = gradle.startParameter.taskNames*.toLowerCase()    
+    boolean isDevTaskExecuted = executedTasks.any { taskName ->
+        taskName.contains("dev")
+    }
+    return isDevTaskExecuted
 }
 
 Task createSourceJar(String baseName) {


### PR DESCRIPTION
Decouple the release of the dev version from the official version, and only read the dev artifact AAR when releasing the dev version.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
