### PR TITLE
[Infra] Optimize get-latest-tag logic in github workflow

### DIFF
--- a/.github/actions/get-latest-tag/action.yml
+++ b/.github/actions/get-latest-tag/action.yml
@@ -2,6 +2,11 @@ name: Get Latest Ancestor Tag
 
 description: Get the latest ancestor tag of the current commit.
 
+inputs:
+  current-tag:
+    description: The current publishing tag
+    required: true
+
 outputs:
   latest-tag:
     description: 'The latest tag'
@@ -17,7 +22,7 @@ runs:
       run: |
         set -e
         pwd
-        ANCESTOR_TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+        ANCESTOR_TAG=$(git describe --tags --exclude=${{ inputs.current-tag }} --abbrev=0 2>/dev/null)
         echo "ANCESTOR_TAG=$ANCESTOR_TAG" >> $GITHUB_ENV
 
     - name: get latest tag from api
@@ -26,8 +31,14 @@ runs:
       run: |
         REPO="${{ github.repository }}"
         LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | jq -r '.tag_name')
-        if [ "$LATEST_TAG" = "null" ]; then
-          LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/tags" | jq -r '.[0].name')
+        if [ "$LATEST_TAG" = "null" ] || [ "$LATEST_TAG" = "${{ inputs.current-tag }}" ]; then
+          LATEST_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases?per_page=20" \
+            | jq -r --arg CURRENT "${{ inputs.current-tag }}" \
+              '.[] | select(
+                .draft == false and 
+                .tag_name != $CURRENT
+              ) | .tag_name' \
+            | head -n 1)
         fi
         echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -230,6 +230,8 @@ jobs:
       - name: Get latest tag
         id: get-latest-tag
         uses: ./lynx/.github/actions/get-latest-tag
+        with:
+          current-tag: ${{ needs.get-version.outputs.version }}
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
         with:


### PR DESCRIPTION
Optimize the get-latest-tag logic in the GitHub workflow to prevent the latest-tag from retrieving the version number of the currently being released version during the release process.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
