### PR TITLE
[Feature] Add recent urls to Lynx Explorer

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -31,6 +31,7 @@ import com.lynx.explorer.provider.DemoGenericResourceFetcher;
 import com.lynx.explorer.provider.DemoMediaResourceFetcher;
 import com.lynx.explorer.provider.DemoTemplateResourceFetcher;
 import com.lynx.explorer.utils.QueryMapUtils;
+import com.lynx.explorer.utils.URLManager;
 import com.lynx.tasm.LynxBooleanOption;
 import com.lynx.tasm.LynxView;
 import com.lynx.tasm.LynxViewBuilder;
@@ -61,6 +62,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
   private LynxView mLynxView;
   private String mFrontendTheme;
   private TimingHandler.ExtraTimingInfo extraTimingInfo = new TimingHandler.ExtraTimingInfo();
+  private URLManager urlManager;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -68,17 +70,26 @@ public class LynxViewShellActivity extends AppCompatActivity {
     extraTimingInfo.mOpenTime = System.currentTimeMillis();
     extraTimingInfo.mContainerInitStart = System.currentTimeMillis();
 
+    // Initialize URL manager
+    urlManager = URLManager.getInstance(this);
+
     Intent intent = getIntent();
     String url = intent.getStringExtra(URL_KEY);
     if (url == null) {
       url = HOME_PAGE_URL;
     }
-
+    
+    // Add URL to history
+      if (!url.equals(HOME_PAGE_URL) ){
+        urlManager.addToHistory(url);
+      }
+    
+    
     setTopBarAppearance(url);
     mLynxContainer = findViewById(R.id.lynx_container);
 
     extraTimingInfo.mContainerInitEnd = System.currentTimeMillis();
-
+    
     openTargetUrl(url);
   }
 
@@ -97,6 +108,15 @@ public class LynxViewShellActivity extends AppCompatActivity {
       return true;
     }
     return super.onOptionsItemSelected(item);
+  }
+
+  // Pushes the list again after closing the url on going back to homepage
+  @Override
+  protected void onResume() {
+      super.onResume();
+      if (mLynxView != null) {
+          mLynxView.updateGlobalProps(getGlobalProps(this));
+      }
   }
 
   private String getStorageItem(String key) {
@@ -211,7 +231,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
       Log.i(TAG, "openTargetUrl failed: url is null.");
       return;
     }
-
+    
     LynxViewBuilder builder = new LynxViewBuilder();
     builder.addBehaviors(new ImageBehavior().create());
     builder.addBehaviors(new XElementBehaviors().create());
@@ -311,6 +331,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
     } else {
       globalProps.put("frontendTheme", "light");
     }
+    globalProps.put("recentUrls", urlManager.getRecentUrls());
 
     return TemplateData.fromMap(globalProps);
   }

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/utils/URLManager.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/utils/URLManager.java
@@ -1,0 +1,123 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.explorer.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Log;
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class URLManager {
+    private static final String TAG = "URLManager";
+    private static final String PREFS_NAME = "URLManagerPrefs";
+    private static final String KEY_RECENT_URLS = "recent_urls";
+    private static final int MAX_SIZE = 5;
+    
+    private static URLManager instance;
+    private Context context;
+    private SharedPreferences prefs;
+    private List<Map<String, String>> recentUrls;
+    
+    private URLManager(Context context) {
+        this.context = context.getApplicationContext();
+        this.prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        loadRecentUrls();
+    }
+    
+    public static synchronized URLManager getInstance(Context context) {
+        if (instance == null) {
+            instance = new URLManager(context);
+        }
+        return instance;
+    }
+    
+    public void addToHistory(String url) {
+        if (!isValidUrl(url)) {
+            return;
+        }
+
+        LocalDateTime unformattedDate = LocalDateTime.now();
+        DateTimeFormatter myFormatObj = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm:ss");
+        String date = unformattedDate.format(myFormatObj);
+        Map<String, String> urlEntry = new HashMap<>();
+        urlEntry.put("url", url);
+        urlEntry.put("time", date);
+        // Add to front of lists
+        for (int ind = 0; ind < recentUrls.size(); ind++){
+            if (url.equals(recentUrls.get(ind).get("url"))){
+                recentUrls.remove(ind);
+                break;
+            }
+        }
+        
+        recentUrls.add(0, urlEntry);
+        
+        //Remove extra urls
+        while (recentUrls.size() > MAX_SIZE) {
+            recentUrls.remove(recentUrls.size() - 1);
+        }
+        
+        saveRecentUrls();
+        
+        Log.d(TAG, "Added URL to history: " + url);
+    }
+    
+    public List<Map<String, String>> getRecentUrls() {
+        return new ArrayList<>(recentUrls);
+    }
+    
+    public boolean isValidUrl(String url) {
+        if (url == null || url.trim().isEmpty()) {
+            return false;
+        }
+        
+        // Check supported URL schemes
+        return url.startsWith("file://lynx?local://") ||
+               url.startsWith("assets://") ||
+               url.startsWith("http://") ||
+               url.startsWith("https://");
+    }
+    
+    public void clearHistory() {
+        recentUrls.clear();
+        saveRecentUrls();
+    }
+    
+    private void loadRecentUrls() {
+        String urls_in_recent = this.prefs.getString(KEY_RECENT_URLS, "");
+        recentUrls = new ArrayList<Map<String, String>>();
+        if (!urls_in_recent.isEmpty()){
+            String[] fileOutputs = urls_in_recent.split(",");
+            for (int ind = 0; ind < fileOutputs.length; ind++){
+                String[] lineOutputs = fileOutputs[ind].split("\\|");
+                Map<String, String> entry = new HashMap<>();
+                if (lineOutputs.length >= 2){
+                    entry.put("url", lineOutputs[0]);
+                    entry.put("time", lineOutputs[1]);
+                    recentUrls.add(entry);
+                }
+            }
+
+        }
+    }
+    
+    private void saveRecentUrls() {
+        ArrayList<String> url_inputs = new ArrayList<String>();
+        for (int ind = 0; ind < recentUrls.size(); ind++){
+            String urlAndDate = recentUrls.get(ind).get("url")+ "\\|" + recentUrls.get(ind).get("time");
+            url_inputs.add(urlAndDate);
+        }
+        String saving_urls = String.join(",", url_inputs);
+        SharedPreferences.Editor editor = this.prefs.edit();
+        editor.putString(KEY_RECENT_URLS, saving_urls);
+        editor.apply();
+        Log.d(TAG, "Recent URLs saved:" + saving_urls);
+    }
+}

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxInitProcessor.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxInitProcessor.m
@@ -11,6 +11,7 @@
 #import <SDWebImageWebPCoder/SDWebImageWebPCoder.h>
 #import "ExplorerModule.h"
 #import "TemplateProvider.h"
+#import "NativeLocalStorageModule.h"
 
 @implementation LynxInitProcessor
 
@@ -41,6 +42,8 @@ static LynxInitProcessor *_instance = nil;
 
   // register global JS module
   [globalConfig registerModule:ExplorerModule.class];
+  // register global JS module
+  [globalConfig registerModule:NativeLocalStorageModule.class];
 
   // prepare global config
   [env prepareConfig:globalConfig];

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/NativeLocalStorageModule.h
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/NativeLocalStorageModule.h
@@ -1,0 +1,14 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Foundation/Foundation.h>
+#import <Lynx/LynxModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NativeLocalStorageModule : NSObject <LynxModule>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/NativeLocalStorageModule.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/NativeLocalStorageModule.m
@@ -1,0 +1,50 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import "NativeLocalStorageModule.h"
+
+@interface NativeLocalStorageModule()
+@property (strong, nonatomic) NSUserDefaults *localStorage;
+@end
+
+@implementation NativeLocalStorageModule
+
+static NSString *const NativeLocalStorageKey = @"MyLocalStorage";
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _localStorage = [[NSUserDefaults alloc] initWithSuiteName:NativeLocalStorageKey];
+    }
+    return self;
+}
+
++ (NSString *)name {
+    return @"NativeLocalStorageModule";
+}
+
++ (NSDictionary<NSString *, NSString *> *)methodLookup {
+    return @{
+        @"setStorageItem" : NSStringFromSelector(@selector(setStorageItem:value:)),
+        @"getStorageItem" : NSStringFromSelector(@selector(getStorageItem:)),
+        @"clearStorage" : NSStringFromSelector(@selector(clearStorage))
+    };
+}
+
+- (void)setStorageItem:(NSString *)key value:(NSString *)value {
+    [self.localStorage setObject:value forKey:key];
+}
+
+- (NSString*)getStorageItem:(NSString *)key {
+    NSString *value = [self.localStorage stringForKey:key];
+    return value;
+}
+
+- (void)clearStorage {
+    NSDictionary *keys = [self.localStorage dictionaryRepresentation];
+    for (NSString *key in keys) {
+        [self.localStorage removeObjectForKey:key];
+    }
+}
+
+@end

--- a/explorer/homepage/components/homepage/index.scss
+++ b/explorer/homepage/components/homepage/index.scss
@@ -122,3 +122,65 @@
   height: 32px;
   width: 32px;
 }
+
+.recent-items__light {
+  @include box;
+  background: var(--box-light);
+  display: flex;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-bottom: 0;
+  padding: 0;
+}
+
+.recent-items__dark {
+  @include box;
+  background: var(--box-dark);
+  display: flex;
+  flex-direction: column;
+  margin-top: 0px;
+  margin-bottom: 0;
+}
+
+.recent-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+.recent-item-url {
+  font-weight: bold;
+  color: #007AFF;
+  margin-right: 6px;
+  padding-top: 6px;
+  padding-left: 6px;
+
+}
+.recent-item-time {
+  font-weight: bold;
+  color: #007AFF;
+  padding-left: 6px;
+  padding-bottom: 6px;
+}
+
+.recent-item-divider__light {
+  height: 1px;
+  background: #e0e0e0;
+  margin: 0 8px;
+}
+
+.recent-item-divider__dark {
+  height: 1px;
+  background: #444444;
+  margin: 0 8px;
+}
+
+.recent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  padding-right: 12px;
+}

--- a/explorer/homepage/components/homepage/index.tsx
+++ b/explorer/homepage/components/homepage/index.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { useState } from '@lynx-js/react';
+import { useState, useEffect } from '@lynx-js/react';
 import './index.scss';
 
 import ExplorerIconDark from '@assets/images/explorer-dark.png?inline';
@@ -23,6 +23,27 @@ interface HomePageProps {
 
 export default function HomePage(props: HomePageProps) {
   const [inputValue, setInputValue] = useState('');
+  // For iOS, manage recentUrls locally; for Android, use global
+  const [recentUrlsState, setRecentUrlsState] = useState<{ url: string; time: string }[]>([]);
+  const isIOS = SystemInfo.platform === 'iOS';
+  // Normalize recentUrls to always be array of { url, time }
+  const rawRecentUrls = isIOS
+    ? recentUrlsState
+    : lynx.__globalProps?.recentUrls || [];
+  const recentUrls = Array.isArray(rawRecentUrls)
+    ? rawRecentUrls.map(item =>
+      typeof item === 'string'
+        ? { url: item, time: '' }
+        : item
+    )
+    : [];
+  // Clear recent URLs
+  const clearRecentUrls = () => {
+    if (isIOS) { // currently feature available only for ios
+      setRecentUrlsState([]);
+      NativeModules.NativeLocalStorageModule.clearStorage();
+    }
+  };
 
   const icons = {
     Scan: {
@@ -46,9 +67,32 @@ export default function HomePage(props: HomePageProps) {
     NativeModules.ExplorerModule.openScan();
   };
 
+  // Load recent URLs from storage
+  useEffect(() => {
+    if (isIOS) {
+      const stored = NativeModules.NativeLocalStorageModule.getStorageItem('recentUrls');
+      if (stored) {
+        try {
+          setRecentUrlsState(JSON.parse(stored));
+        } catch {}
+      }
+    }
+  }, []);
+
   const openSchema = () => {
     'background only';
     NativeModules.ExplorerModule.openSchema(inputValue);
+
+    // for ios to save recent urls
+    if (isIOS && inputValue) {
+      const updated = [
+        { url: inputValue, time: new Date().toLocaleString(undefined, { year: 'numeric', month: '2-digit', 
+          day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false}) },
+        ...recentUrlsState.filter(item => item.url !== inputValue),
+      ].slice(0, 5); // keep max 5
+      setRecentUrlsState(updated);
+      NativeModules.NativeLocalStorageModule.setStorageItem('recentUrls', JSON.stringify(updated));
+    }
   };
 
   const openShowcasePage = () => {
@@ -100,21 +144,18 @@ export default function HomePage(props: HomePageProps) {
         <image src={getIcon('Explorer')} className="logo" mode="aspectFit" />
         <text className={withTheme('home-title')}>Lynx Explorer</text>
         <view className="scan">
-          {(() => {
-            if (SystemInfo.platform === 'iOS') {
-              return <></>;
-            }
-            return (
-              <image
-                src={getIcon('Scan')}
-                className="scan-icon"
-                bindtap={openScan}
-                accessibility-element={true}
-                accessibility-label="Open Scan"
-                accessibility-traits="button"
-              />
-            );
-          })()}
+          {isIOS ? (
+            <></>
+          ) : (
+            <image
+              src={getIcon('Scan')}
+              className="scan-icon"
+              bindtap={openScan}
+              accessibility-element={true}
+              accessibility-label="Open Scan"
+              accessibility-traits="button"
+            />
+          )}
         </view>
       </view>
 
@@ -156,6 +197,48 @@ export default function HomePage(props: HomePageProps) {
         <view style="margin: auto 5% auto auto; justify-content: center">
           <image src={getIcon('Forward')} className="forward-icon" />
         </view>
+      </view>
+
+      <view className='open-recently'>
+        <view className='recent-header'>
+          <text className={withTheme('bold-text')}>Open Recently</text>
+          {isIOS && recentUrls.length > 0 && ( // currently only for ios
+            <text
+              className={withTheme('text')}
+              style={{ marginLeft: 12, cursor: 'pointer', color: '#007AFF' }}
+              bindtap={clearRecentUrls}
+              accessibility-element={true}
+              accessibility-label="Clear All"
+              accessibility-traits="button"
+            >
+              Clear All
+            </text>
+        )}
+        </view>
+        {recentUrls.length === 0 ? (
+          <text className={withTheme('text')}>No recent URLs</text>
+        ) : (
+          <view className={withTheme("recent-items")}>
+            {recentUrls.map((item, idx) => (
+              <>
+                <view
+                  key={idx}
+                  className={withTheme('recent-item')}
+                  bindtap={() => {
+                    'background only';
+                    NativeModules.ExplorerModule.openSchema(item.url);
+                  }}
+                >
+                  <text className="recent-item-url">{item.url}</text>
+                  <text className="recent-item-time">{item.time}</text>
+                </view>
+                {idx < recentUrls.length - 1 && (
+                  <view className={withTheme("recent-item-divider")} />
+                )}
+              </>
+            ))}
+          </view>
+        )}
       </view>
     </view>
   );

--- a/explorer/homepage/typing.d.ts
+++ b/explorer/homepage/typing.d.ts
@@ -34,6 +34,7 @@ declare module '@lynx-js/types' {
     preferredTheme?: string;
     theme: string;
     isNotchScreen: boolean;
+    recentUrls?: Array<{ url: string; time: string } | string>;
   }
 
   interface IntrinsicElements extends Lynx.IntrinsicElements {
@@ -67,6 +68,14 @@ export interface InputProps extends StandardProps {
    */
   'text-color'?: string;
 }
+
+declare let NativeModules: { // from native modules guide on Lynx website
+  NativeLocalStorageModule: {
+    setStorageItem(key: string, value: string): void;
+    getStorageItem(key: string): string | null;
+    clearStorage(): void;
+  };
+};
 
 export type InputEvent = BaseEvent<'input', { value: string }>;
 export type BlurEvent = BaseEvent<'blur', { value: string }>;


### PR DESCRIPTION
Summary of change:
Adds a feature to show the most recent used urls
when building and using the Android and iOS builds of Lynx Explorer. 
The urls will persist even when the app is closed. 
Click on the urls to open them up again. This is for Issue #2013

Note: Saving urls when scanning is currently only
available on Android & clearing all recent urls
is currently only available on iOS.

IMPORTANT: When running the build command for iOS, after it completes 
and creates the LynxExplorer.xcworkspace, manually add the 
NativeLocalStorageModule.h and .m files into the modules folder in the
Xcode workspace as they might not appear. This allows the iOS build to save urls.

Example from iPhone simulator:
<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2025-08-28 at 19 09 05" src="https://github.com/user-attachments/assets/ca324f6f-1aca-4f8c-900e-b9a3fabea78e" />

