### PR TITLE
[BugFix] Prevent use-after-free in ResponseHandlerProxy listener call…

### DIFF
--- a/core/runtime/bindings/common/resource/response_handler_proxy.h
+++ b/core/runtime/bindings/common/resource/response_handler_proxy.h
@@ -17,7 +17,8 @@
 namespace lynx {
 namespace runtime {
 
-class ResponseHandlerProxy {
+class ResponseHandlerProxy
+    : std::enable_shared_from_this<ResponseHandlerProxy> {
  public:
   class Delegate {
    public:
@@ -54,11 +55,15 @@ class ResponseHandlerProxy {
   virtual void AddResourceListener(
       base::MoveOnlyClosure<void, tasm::BundleResourceInfo> closure) {
     promise_->AddCallback(
-        [this, &closure](tasm::BundleResourceInfo bundle_info) {
-          delegate_.InvokeResponsePromiseCallback(
-              [bundle_info, closure = std::move(closure)]() {
-                closure(bundle_info);
-              });
+        [weak_self = weak_from_this(), closure = std::move(closure)](
+            tasm::BundleResourceInfo bundle_info) mutable {
+          auto self = weak_self.lock();
+          if (self) {
+            self->delegate_.InvokeResponsePromiseCallback(
+                [bundle_info, closure = std::move(closure)]() {
+                  closure(bundle_info);
+                });
+          }
         });
   };
 


### PR DESCRIPTION
…backs

Fix race condition where ResponseHandlerProxy listener callbacks could be invoked after the proxy object has been released. This was causing crashes in corner cases where the callback outlived the proxy.

Changes:
- Make ResponseHandlerProxy inherit from std::enable_shared_from_this
- Use weak_ptr in AddResourceListener callback to safely check if proxy still exists before invoking delegate callbacks
- Prevent callback execution if proxy has been destroyed

issue: f-6750309504
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
