### PR TITLE
[BugFix][harmony] Fix the issue of the missing Harmony log initializa…

### DIFF
--- a/core/base/harmony/logging_harmony.cc
+++ b/core/base/harmony/logging_harmony.cc
@@ -19,7 +19,6 @@ namespace logging {
 namespace {
 
 static alog_write_func_ptr s_alog_write = nullptr;
-static bool s_use_sys_log = false;
 
 alog_write_func_ptr GetLynxLogWriteFunction() { return s_alog_write; }
 
@@ -78,9 +77,8 @@ napi_value LynxLog::NativeInitLynxLog(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1] = {nullptr};
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
-  InitLynxLogging(
-      GetLynxLogWriteFunction, PrintLogMessageByLogDelegate,
-      tasm::LynxEnv::GetInstance().IsDevToolEnabled() || s_use_sys_log);
+  InitLynxLogging(GetLynxLogWriteFunction, PrintLogMessageByLogDelegate,
+                  tasm::LynxEnv::GetInstance().IsDevToolEnabled());
   return nullptr;
 }
 
@@ -88,7 +86,12 @@ napi_value LynxLog::NativeUseSysLog(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value args[1] = {nullptr};
   napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
-  s_use_sys_log = NapiUtil::ConvertToBoolean(env, args[0]);
+  bool s_use_sys_log = NapiUtil::ConvertToBoolean(env, args[0]);
+  if (s_use_sys_log) {
+    EnableLogOutputByPlatform();
+  } else {
+    DisableLogOutputByPlatform();
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
…tion process.

Background:
  When `tasm::LynxEnv::GetInstance().IsDevToolEnabled() = false`, calling `LLog.useSysLog(true)` from the platform layer cannot properly enable the HiLog channel for C++ layer logs, resulting in the inability to output logs normally.

Modifications:
  Adjust the logic of `NativeUseSysLog()` in logging_harmony.cc to ensure that the logs can be initialized correctly.

AutoSubmit:true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
