### PR TITLE
[BugFix] storing pre-register bundle with bundlemanager

### DIFF
--- a/core/renderer/template_entry_holder.cc
+++ b/core/renderer/template_entry_holder.cc
@@ -79,7 +79,14 @@ void TemplateEntryHolder::InsertLynxTemplateBundle(
    */
   if (template_entries_.find(url) == template_entries_.end()) {
     TryPostJSBundle(url, bundle);
-    preload_template_bundles_.try_emplace(url, std::move(bundle));
+    preload_template_bundles_.try_emplace(url, bundle);
+  }
+
+  // TODO: It's reasonable that using component_loader as bundle_manager
+  // so we need to insert pre registered bundle into bundle manager.
+  // refactoring it later!
+  if (component_loader_) {
+    component_loader_->InsertTemplateBundle(url, std::move(bundle));
   }
 }
 


### PR DESCRIPTION
Actually, lazy_bundle_loader act as the real bundleManager for lynxEngine, so it's reasonable that we store the pre-registered bundle into bundlemanager. so that bts runtime may successfully get the pre-registered bundle.

issue: f-98236465
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
