### PR TITLE
[BugFix] fix prepainting issue with volatile mBodyView

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -9518,7 +9518,7 @@ public class com::lynx::tasm::behavior::ui::UIBody::UIBodyView : FrameLayout, co
   public void com.lynx.tasm.behavior.ui.UIBody.UIBodyView.setChildrenDrawingOrderEnabled(boolean enabled);
   public boolean com.lynx.tasm.behavior.ui.UIBody.UIBodyView.dispatchHoverEvent(MotionEvent event);
   public boolean com.lynx.tasm.behavior.ui.UIBody.UIBodyView.requestSendAccessibilityEvent(View child, android.view.accessibility.AccessibilityEvent event);
-  public void com.lynx.tasm.behavior.ui.UIBody.UIBodyView.SetShouldInterceptRequestLayout(boolean intercept);
+  public void com.lynx.tasm.behavior.ui.UIBody.UIBodyView.setShouldInterceptRequestLayout(boolean intercept);
   public boolean com.lynx.tasm.behavior.ui.UIBody.UIBodyView.HasPendingRequestLayout();
   public LynxBooleanOption com.lynx.tasm.behavior.ui.UIBody.UIBodyView.getLongTaskMonitorEnabled();
   public boolean com.lynx.tasm.behavior.ui.UIBody.UIBodyView.isAccessibilityDisabled();

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -1493,6 +1493,9 @@ public class LynxTemplateRender
     }
 
     if (metaData.getLoadMode() == LynxLoadMode.PRE_PAINTING) {
+      if (mBodyView != null) {
+        mBodyView.setShouldInterceptRequestLayout(true);
+      }
       mLynxContext.setInPreLoad(true);
     }
 
@@ -1823,6 +1826,9 @@ public class LynxTemplateRender
 
     if (context.isInPreLoad()) {
       LLog.i(TAG, "updateData after pre load, url:" + mUrl);
+      if (mBodyView != null) {
+        mBodyView.setShouldInterceptRequestLayout(false);
+      }
       context.setInPreLoad(false);
     }
 
@@ -1919,6 +1925,9 @@ public class LynxTemplateRender
     }
     if (context.isInPreLoad()) {
       LLog.i(TAG, "updateData after pre load, url:" + mUrl);
+      if (mBodyView != null) {
+        mBodyView.setShouldInterceptRequestLayout(false);
+      }
       context.setInPreLoad(false);
     }
     if (prepareUpdateData(data)) {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxContext.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxContext.java
@@ -1356,9 +1356,6 @@ public abstract class LynxContext extends LynxBaseContext implements ExceptionHa
   @RestrictTo(RestrictTo.Scope.LIBRARY)
   public void setInPreLoad(boolean preload) {
     mInPreLoad = preload;
-    if (mUIBody != null && mUIBody.getBodyView() != null) {
-      mUIBody.getBodyView().SetShouldInterceptRequestLayout(preload);
-    }
     if (mEventEmitter != null) {
       mEventEmitter.setInPreLoad(preload);
     }

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/UIBody.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/ui/UIBody.java
@@ -656,7 +656,7 @@ public class UIBody extends UIGroup<UIBodyView> {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    public void SetShouldInterceptRequestLayout(boolean intercept) {
+    public void setShouldInterceptRequestLayout(boolean intercept) {
       mInterceptRequestLayout = intercept;
     }
 


### PR DESCRIPTION
In prepainting mode, we need to mark bodyView with ShouleInterceptRequestLayout on, we access uiBodyView by lynxContext before, it's dangerouse as uiBodyView in lynxContext may change while engine reuse, we should access uiBodyView directly by templateRender.

issue: f-6751352071
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
