### PR TITLE
[Optimize][DevTool][Part2] Add debuggable for lynx_devtool_ng

### DIFF
--- a/devtool/embedder/core/devtoolng_delegate_embedder.cc
+++ b/devtool/embedder/core/devtoolng_delegate_embedder.cc
@@ -9,7 +9,8 @@
 namespace lynx {
 namespace devtool {
 
-DevToolNGDelegateEmbedder::DevToolNGDelegateEmbedder() : session_id_(0) {}
+DevToolNGDelegateEmbedder::DevToolNGDelegateEmbedder()
+    : LynxDevToolNG(true), session_id_(0) {}
 
 void DevToolNGDelegateEmbedder::SetDevtoolPlatformAbility(
     const std::shared_ptr<devtool::DevToolPlatformFacade>& platform_ptr) {

--- a/devtool/lynx_devtool/android/lynx_devtool_ng_android.cc
+++ b/devtool/lynx_devtool/android/lynx_devtool_ng_android.cc
@@ -14,8 +14,8 @@
 #include "platform/android/lynx_devtool/src/main/jni/gen/LynxDevToolNGDelegate_jni.h"
 #include "platform/android/lynx_devtool/src/main/jni/gen/LynxDevToolNGDelegate_register_jni.h"
 
-jlong CreateLynxDevToolNG(JNIEnv* env, jobject jcaller) {
-  auto* ptr = new lynx::devtool::LynxDevToolNG();
+jlong CreateLynxDevToolNG(JNIEnv* env, jobject jcaller, jboolean debuggable) {
+  auto* ptr = new lynx::devtool::LynxDevToolNG(static_cast<bool>(debuggable));
   auto sp_ptr = new std::shared_ptr<lynx::devtool::LynxDevToolNG>(ptr);
   return reinterpret_cast<jlong>(sp_ptr);
 }

--- a/devtool/lynx_devtool/lynx_devtool_ng.cc
+++ b/devtool/lynx_devtool/lynx_devtool_ng.cc
@@ -42,8 +42,9 @@ static constexpr char kTypeSetStopAtEntry[] = "SetStopAtEntry";
 static constexpr char kTypeGetFetchDebugInfo[] = "GetFetchDebugInfo";
 static constexpr char kTypeSetFetchDebugInfo[] = "SetFetchDebugInfo";
 
-LynxDevToolNG::LynxDevToolNG()
-    : devtool_mediator_(std::make_shared<LynxDevToolMediator>()) {
+LynxDevToolNG::LynxDevToolNG(bool debuggable)
+    : devtool_mediator_(std::make_shared<LynxDevToolMediator>()),
+      debuggable_(debuggable) {
   static std::once_flag flag;
   std::call_once(flag, [] {
     auto& global_dispatcher =
@@ -66,6 +67,12 @@ LynxDevToolNG::LynxDevToolNG()
   if (lynx::tasm::LynxEnv::GetInstance().IsDevToolEnabled() ||
       lynx::tasm::LynxEnv::GetInstance().IsDebugModeEnabled()) {
     RegisterInstanceDomainAgents();
+  } else if (debuggable) {
+    std::unordered_set<std::string> activated_domains =
+        lynx::tasm::LynxEnv::GetInstance().GetActivatedCDPDomains();
+    for (const auto& domain : activated_domains) {
+      RegisterInstanceDomainAgents(domain);
+    }
   }
 }
 

--- a/devtool/lynx_devtool/lynx_devtool_ng.h
+++ b/devtool/lynx_devtool/lynx_devtool_ng.h
@@ -18,7 +18,7 @@ namespace devtool {
 class LynxDevToolNG : public lynx::devtool::AbstractDevTool,
                       public std::enable_shared_from_this<LynxDevToolNG> {
  public:
-  LynxDevToolNG();
+  explicit LynxDevToolNG(bool debuggable);
   ~LynxDevToolNG() override;
 
   int32_t Attach(const std::string& url) override;
@@ -45,6 +45,7 @@ class LynxDevToolNG : public lynx::devtool::AbstractDevTool,
   std::shared_ptr<LynxDevToolMediator> devtool_mediator_;
   int32_t session_id_ = -1;
   int32_t instance_id_ = -1;
+  bool debuggable_ = false;
 
  private:
   void UpdateSessionInfo();

--- a/devtool/testing/mock/lynx_devtool_ng_mock.h
+++ b/devtool/testing/mock/lynx_devtool_ng_mock.h
@@ -14,7 +14,7 @@ namespace lynx {
 namespace testing {
 class LynxDevToolNGMock : public lynx::devtool::LynxDevToolNG {
  public:
-  LynxDevToolNGMock() = default;
+  LynxDevToolNGMock() : LynxDevToolNG(true) {}
   ~LynxDevToolNGMock() override = default;
 
   int32_t Attach(const std::string& url) override;

--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -2126,7 +2126,7 @@ public interface com::lynx::tasm::base::ILogDelegate {
 
 public interface com::lynx::tasm::service::ILynxDevToolService {
   public default Class<? extends IServiceProvider > com.lynx.tasm.service.ILynxDevToolService.getServiceClass();
-  public LynxBaseInspectorOwnerNG com.lynx.tasm.service.ILynxDevToolService.createInspectorOwner(@Nullable LynxView view);
+  public LynxBaseInspectorOwnerNG com.lynx.tasm.service.ILynxDevToolService.createInspectorOwner(@Nullable LynxView view, boolean debuggable);
   public ILynxLogBox com.lynx.tasm.service.ILynxDevToolService.createLogBox(@NonNull LynxDevtool devtool);
   public Class<? extends com.lynx.jsbridge.LynxModule > com.lynx.tasm.service.ILynxDevToolService.getDevToolSetModuleClass();
   public Class<? extends com.lynx.jsbridge.LynxModule > com.lynx.tasm.service.ILynxDevToolService.getDevToolWebSocketModuleClass();

--- a/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/LynxDevtool.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/LynxDevtool.java
@@ -49,6 +49,7 @@ public class LynxDevtool {
   private WeakReference<LynxView> mView = null;
   private WeakReference<LynxTemplateRender> mRender = null;
   private ILynxViewStateListener mStateListener;
+  private boolean mDebuggable = false;
 
   public LynxDevtool(LynxView view, LynxTemplateRender render, boolean debuggable) {
     init(view, render, debuggable, render.getLynxContext().getContext());
@@ -66,6 +67,7 @@ public class LynxDevtool {
 
       mView = new WeakReference<>(view);
       mRender = new WeakReference<>(render);
+      mDebuggable = debuggable;
       if (LynxEnv.inst().isLynxDebugEnabled()) {
         LLog.i(TAG,
             "devtoolEnabled:" + LynxEnv.inst().isDevtoolEnabled() + ", logBoxEnabled:"
@@ -73,8 +75,8 @@ public class LynxDevtool {
 
         sDevToolService = LynxServiceCenter.inst().getService(ILynxDevToolService.class);
 
-        if (LynxEnv.inst().isDevtoolEnabled() && sDevToolService != null) {
-          mOwner = sDevToolService.createInspectorOwner(view);
+        if ((LynxEnv.inst().isDevtoolEnabled() || debuggable) && sDevToolService != null) {
+          mOwner = sDevToolService.createInspectorOwner(view, debuggable);
           if (mOwner != null) {
             LLog.i(TAG, "owner init");
           }

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/service/ILynxDevToolService.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/service/ILynxDevToolService.java
@@ -28,7 +28,7 @@ public interface ILynxDevToolService extends IServiceProvider {
   default Class<? extends IServiceProvider> getServiceClass() {
     return ILynxDevToolService.class;
   }
-  LynxBaseInspectorOwnerNG createInspectorOwner(@Nullable LynxView view);
+  LynxBaseInspectorOwnerNG createInspectorOwner(@Nullable LynxView view, boolean debuggable);
   ILynxLogBox createLogBox(@NonNull LynxDevtool devtool);
   Class<? extends com.lynx.jsbridge.LynxModule> getDevToolSetModuleClass();
   Class<? extends com.lynx.jsbridge.LynxModule> getDevToolWebSocketModuleClass();

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxDevToolNGDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxDevToolNGDelegate.java
@@ -17,8 +17,8 @@ public class LynxDevToolNGDelegate {
   private final AtomicBoolean mHasDestroy = new AtomicBoolean(false);
   private final Object mDevToolLock = new Object();
 
-  public LynxDevToolNGDelegate() {
-    mLynxDevToolNGPtr = nativeCreateLynxDevToolNG();
+  public LynxDevToolNGDelegate(boolean debuggable) {
+    mLynxDevToolNGPtr = nativeCreateLynxDevToolNG(debuggable);
   }
 
   public int getSessionId() {
@@ -29,7 +29,7 @@ public class LynxDevToolNGDelegate {
     return mSessionId != 0;
   }
 
-  private native long nativeCreateLynxDevToolNG();
+  private native long nativeCreateLynxDevToolNG(boolean debuggable);
 
   public void sendMessageToDebugPlatform(@NonNull String type, @NonNull String msg) {
     if (mHasDestroy.get()) {

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxGlobalDebugBridge.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxGlobalDebugBridge.java
@@ -54,7 +54,11 @@ public class LynxGlobalDebugBridge
     private static final LynxGlobalDebugBridge INSTANCE = new LynxGlobalDebugBridge();
   }
 
-  private static class DevToolAgentDispatcher extends LynxInspectorOwner {}
+  private static class DevToolAgentDispatcher extends LynxInspectorOwner {
+    public DevToolAgentDispatcher() {
+      super(null, true); // Global debug bridge always operates in debuggable mode
+    }
+  }
 
   private LynxGlobalDebugBridge() {
     mAgentDispatcher = new DevToolAgentDispatcher();

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxInspectorOwner.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxInspectorOwner.java
@@ -87,12 +87,12 @@ public class LynxInspectorOwner implements LynxBaseInspectorOwnerNG {
   private TemplateData cachedGlobalProps = null;
   private TemplateData cachedTemplateData = TemplateData.fromMap(new HashMap<>());
 
-  public LynxInspectorOwner() {
-    init();
+  public LynxInspectorOwner(boolean debuggable) {
+    init(debuggable);
   }
 
-  public LynxInspectorOwner(LynxView lynxView) {
-    init();
+  public LynxInspectorOwner(LynxView lynxView, boolean debuggable) {
+    init(debuggable);
 
     // Base Data
     mLynxView = new WeakReference<>(lynxView);
@@ -131,11 +131,11 @@ public class LynxInspectorOwner implements LynxBaseInspectorOwnerNG {
     }
   }
 
-  public void init() {
+  public void init(boolean debuggable) {
     if (!LynxEnv.inst().isDevLibraryLoaded()) {
       LynxDevtoolEnv.inst().loadNativeDevtoolLibrary();
     }
-    mLynxDevToolNG = new LynxDevToolNGDelegate();
+    mLynxDevToolNG = new LynxDevToolNGDelegate(debuggable);
   }
 
   public void attachLynxUIOwnerToAgent(LynxUIOwner uiOwner) {

--- a/platform/android/lynx_service/lynx_service_devtool/src/main/java/com/lynx/service/devtool/LynxDevToolService.kt
+++ b/platform/android/lynx_service/lynx_service_devtool/src/main/java/com/lynx/service/devtool/LynxDevToolService.kt
@@ -42,9 +42,9 @@ class LynxDevToolService : ILynxDevToolService {
     }
 
 
-    override fun createInspectorOwner(view: LynxView?): LynxBaseInspectorOwnerNG? {
+    override fun createInspectorOwner(view: LynxView?, debuggable: Boolean): LynxBaseInspectorOwnerNG? {
         try {
-            return LynxInspectorOwner(view)
+            return LynxInspectorOwner(view, debuggable)
         } catch (e: ClassNotFoundException) {
             LLog.e(TAG, "createInspectorOwner failed, ${e.message}")
             return null

--- a/platform/darwin/common/lynx/devtool_wrapper/LynxDevtool.mm
+++ b/platform/darwin/common/lynx/devtool_wrapper/LynxDevtool.mm
@@ -31,19 +31,21 @@
 
   LynxPageReloadHelper *_reloader;
   id<LynxViewStateListener> _lynxViewStateListener;
+  BOOL _debuggable;
 }
 
 - (nonnull instancetype)initWithLynxView:(LynxView *)view debuggable:(BOOL)debuggable {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, DEVTOOL_INIT_WITH_LYNX_VIEW);
   _lynxView = view;
+  _debuggable = debuggable;
 
   if (LynxEnv.sharedInstance.lynxDebugEnabled) {
     id<LynxServiceDevToolProtocol> devtoolService = LynxService(LynxServiceDevToolProtocol);
     if (!devtoolService) {
       _LogW(@"LynxServiceDevToolProtocol instance not found");
     }
-    if (LynxEnv.sharedInstance.devtoolEnabled && devtoolService) {
-      _owner = [devtoolService createInspectorOwnerWithLynxView:view];
+    if ((LynxEnv.sharedInstance.devtoolEnabled || debuggable) && devtoolService) {
+      _owner = [devtoolService createInspectorOwnerWithLynxView:view debuggable:debuggable];
     } else {
       _owner = nil;
     }

--- a/platform/darwin/common/lynx/public/service/LynxServiceDevToolProtocol.h
+++ b/platform/darwin/common/lynx/public/service/LynxServiceDevToolProtocol.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @required
 
-- (id<LynxBaseInspectorOwner>)createInspectorOwnerWithLynxView:(LynxView *)lynxView;
+- (id<LynxBaseInspectorOwner>)createInspectorOwnerWithLynxView:(LynxView *)lynxView
+                                                    debuggable:(BOOL)debuggable;
 
 - (id<LynxLogBoxProtocol>)createLogBoxWithLynxView:(LynxView *)lynxView;
 

--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -3012,7 +3012,7 @@ public protocol LynxServiceContainerProtocol-p : <NSObject> {
 }
 
 public protocol LynxServiceDevToolProtocol-p : <LynxServiceProtocol> {
-  public id< LynxBaseInspectorOwner > LynxServiceDevToolProtocol-p::createInspectorOwnerWithLynxView:(LynxView *lynxView);
+  public id< LynxBaseInspectorOwner > LynxServiceDevToolProtocol-p::createInspectorOwnerWithLynxView:debuggable:(LynxView *lynxView,[debuggable] BOOL debuggable);
   public id< LynxLogBoxProtocol > LynxServiceDevToolProtocol-p::createLogBoxWithLynxView:(LynxView *lynxView);
   public Class< LynxContextModule > LynxServiceDevToolProtocol-p::devtoolSetModuleClass();
   public Class< LynxContextModule > LynxServiceDevToolProtocol-p::devtoolWebSocketModuleClass();

--- a/platform/darwin/ios/lynx_devtool/LynxDevToolNGDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/LynxDevToolNGDarwinDelegate.h
@@ -11,7 +11,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LynxDevToolNGDarwinDelegate : NSObject
-- (instancetype)init;
+- (instancetype)initWithDebuggable:(BOOL)debuggable;
 
 - (int)getSessionId;
 

--- a/platform/darwin/ios/lynx_devtool/LynxDevToolNGDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/LynxDevToolNGDarwinDelegate.mm
@@ -72,11 +72,11 @@ class DevToolMessageHandlerIos : public DevToolMessageHandler {
   std::shared_ptr<lynx::devtool::LynxDevToolNG> devtool_ng_;
 }
 
-- (instancetype)init {
+- (instancetype)initWithDebuggable:(BOOL)debuggable {
   self = [super init];
   if (self) {
     session_id_ = 0;
-    devtool_ng_ = std::make_shared<lynx::devtool::LynxDevToolNG>();
+    devtool_ng_ = std::make_shared<lynx::devtool::LynxDevToolNG>(static_cast<bool>(debuggable));
   }
   return self;
 }

--- a/platform/darwin/ios/lynx_devtool/LynxInspectorOwner.h
+++ b/platform/darwin/ios/lynx_devtool/LynxInspectorOwner.h
@@ -18,8 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface LynxInspectorOwner : NSObject <LynxBaseInspectorOwnerNG>
 
-- (instancetype)init;
-- (nonnull instancetype)initWithLynxView:(nullable LynxView *)view;
+- (instancetype)initWithDebuggable:(BOOL)debuggable;
+- (nonnull instancetype)initWithLynxView:(nullable LynxView *)view debuggable:(BOOL)debuggable;
 - (void)setReloadHelper:(nullable LynxPageReloadHelper *)reloadHelper;
 - (void)setDebugInfoInterceptor:(nonnull id<LynxDebugInfoRecorderProtocol>)debugInfoRecorder;
 - (void)call:(NSString *_Nonnull)function withParam:(NSString *_Nullable)params;

--- a/platform/darwin/ios/lynx_devtool/LynxInspectorOwner.mm
+++ b/platform/darwin/ios/lynx_devtool/LynxInspectorOwner.mm
@@ -71,36 +71,38 @@
   LynxTemplateData* _templateData;
 }
 
-- (instancetype)init {
+- (instancetype)initWithDebuggable:(BOOL)debuggable {
   self = [super init];
   // LynxDevToolNGDarwinDelegate
-  _devtoolNG = [[LynxDevToolNGDarwinDelegate alloc] init];
+  _devtoolNG = [[LynxDevToolNGDarwinDelegate alloc] initWithDebuggable:debuggable];
   return self;
 }
 
-- (nonnull instancetype)initWithLynxView:(nullable LynxView*)view {
-  _lynxView = view;
-  _isDebugging = NO;
+- (nonnull instancetype)initWithLynxView:(nullable LynxView*)view debuggable:(BOOL)debuggable {
+  self = [super init];
+  if (self) {
+    _lynxView = view;
+    _isDebugging = NO;
 
-  // DevMenu
-  _devMenu = [[LynxDevMenu alloc] initWithInspectorOwner:self];
+    // DevMenu
+    _devMenu = [[LynxDevMenu alloc] initWithInspectorOwner:self];
 
-  // PageReload
-  _reloadHelper = nil;
+    // PageReload
+    _reloadHelper = nil;
 
-  // DevToolPlatformDarwinDelegate
-  _platform = [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:_lynxView];
+    // DevToolPlatformDarwinDelegate
+    _platform = [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:_lynxView];
 
-  // LynxDevToolNGDarwinDelegate
-  _devtoolNG = [[LynxDevToolNGDarwinDelegate alloc] init];
+    // LynxDevToolNGDarwinDelegate
+    _devtoolNG = [[LynxDevToolNGDarwinDelegate alloc] initWithDebuggable:debuggable];
 
-  // init template data
-  _templateData = [[LynxTemplateData alloc] initWithDictionary:@{}];
+    // init template data
+    _templateData = [[LynxTemplateData alloc] initWithDictionary:@{}];
 
 #if ENABLE_TRACE_PERFETTO || ENABLE_TRACE_SYSTRACE
-  [[LynxFrameViewTrace shareInstance] attachView:view];
+    [[LynxFrameViewTrace shareInstance] attachView:view];
 #endif
-
+  }
   return self;
 }
 

--- a/platform/darwin/ios/lynx_service/devtool/LynxDevToolService.mm
+++ b/platform/darwin/ios/lynx_service/devtool/LynxDevToolService.mm
@@ -4,26 +4,29 @@
 
 #import <Lynx/LynxService.h>
 #import <LynxService/LynxDevToolService.h>
+#import <objc/message.h>
 
 @LynxServiceRegister(LynxDevToolService) @implementation LynxDevToolService
 
 #pragma mark - LynxServiceDevToolProtocol
 
-- (id<LynxBaseInspectorOwner>)createInspectorOwnerWithLynxView:(LynxView *)lynxView {
+- (id<LynxBaseInspectorOwner>)createInspectorOwnerWithLynxView:(LynxView *)lynxView
+                                                    debuggable:(BOOL)debuggable {
   Class inspectorOwnerClass = NSClassFromString(@"LynxInspectorOwner");
   if (!inspectorOwnerClass) {
     return nil;
   }
 
-  SEL initSelector = NSSelectorFromString(@"initWithLynxView:");
-  if (![inspectorOwnerClass instancesRespondToSelector:initSelector]) {
+  SEL initSelector = NSSelectorFromString(@"initWithLynxView:debuggable:");
+  id allocated = [inspectorOwnerClass alloc];
+
+  if (![allocated respondsToSelector:initSelector]) {
     return nil;
   }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
-  return [[inspectorOwnerClass alloc] performSelector:initSelector withObject:lynxView];
-#pragma clang diagnostic pop
+  id (*InitFunc)(id, SEL, id, BOOL) = (id(*)(id, SEL, id, BOOL))objc_msgSend;
+  id instance = InitFunc(allocated, initSelector, lynxView, debuggable);
+  return instance;
 }
 
 - (id<LynxLogBoxProtocol>)createLogBoxWithLynxView:(LynxView *)lynxView {


### PR DESCRIPTION
summary: add instance-level bool value `debuggable` for lynx_devtool_ng.

In order to pass it in from the time of initializing the LynxView to determine whether to enable the debugging switch at the single LynxView instance-level. This is the 2nd part of this series of changes.

issue: m-6736726249

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
