### PR TITLE
fix:  refactor LynxInitProcessor to use env instance

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxInitProcessor.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxInitProcessor.m
@@ -36,7 +36,7 @@ static LynxInitProcessor *_instance = nil;
   [globalConfig registerModule:ExplorerModule.class];
 
   // prepare global config
-  [[LynxEnv sharedInstance] prepareConfig:globalConfig];
+  [env prepareConfig:globalConfig];
 }
 
 - (void)setupLynxService {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

Small fix, since we are already retrieving env in this function it's better to directly use it instead of querying for it sharedInstance again.  

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
