### PR TITLE
[BugFix] Mark QuickContext Construction Tid As Valid.

### DIFF
--- a/core/runtime/vm/lepus/quick_context.cc
+++ b/core/runtime/vm/lepus/quick_context.cc
@@ -230,6 +230,7 @@ QuickContext::QuickContext(bool disable_tracing_gc, int runtime_mode)
   // leak checker later;
   if (tasm::LynxEnv::GetInstance().IsDevToolEnabled()) {
     EnableRuntimeLeakCheck(true);
+    PushContextValidTid();
   }
   LEPUSLepusRefCallbacks callbacks = Context::GetLepusRefCall();
   RegisterLepusRefCallbacks(runtime_, &callbacks);


### PR DESCRIPTION
As we need to enable QuickContext tid check by default now, QuickContext async create should be considered now. Mark the tid of QuickContext Construction as valid tid.

issue: f-23987656
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
