### PR TITLE
[Refactor] Make LynxResourceResponse generic in onFailed method

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -5795,7 +5795,7 @@ public class com::lynx::tasm::resourceprovider::LynxResourceResponse :  {
   public ResponseState com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.getState();
   public Throwable com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.getError();
   public T com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.getData();
-  public static LynxResourceResponse com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.onFailed(Throwable error);
+  public static< T > LynxResourceResponse< T > com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.onFailed(Throwable error);
   public static< T > LynxResourceResponse< T > com.lynx.tasm.resourceprovider.LynxResourceResponse< T >.onSuccess(T data);
 }
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/resourceprovider/LynxResourceResponse.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/resourceprovider/LynxResourceResponse.java
@@ -24,8 +24,8 @@ public final class LynxResourceResponse<T> {
     return this.data;
   }
 
-  public static LynxResourceResponse onFailed(Throwable error) {
-    LynxResourceResponse response = new LynxResourceResponse();
+  public static <T> LynxResourceResponse<T> onFailed(Throwable error) {
+    LynxResourceResponse<T> response = new LynxResourceResponse<T>();
     response.state = ResponseState.FAILED;
     response.error = error;
     return response;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

When integrating Lynx Android for new HelloWorld template in Kotlin: https://github.com/lynx-community/cli/pull/1, I found that LynxResourceResponse is inheriting the type from the parent, in my case it was `ByteArray`, but when throwing error the type is different. 

To solve it I think the best solution will be to allow `onFailed` method to allow using custom types instead of `Any`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
