### PR TITLE
[Infra] Remove lynx_v8_bridge so.

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
@@ -46,6 +46,8 @@ public class ExplorerApplication extends Application {
         ILynxImageService.class, LynxImageService.getInstance());
     LynxServiceCenter.inst().registerService(ILynxLogService.class, LynxLogService.INSTANCE);
     LynxServiceCenter.inst().registerService(ILynxHttpService.class, LynxHttpService.INSTANCE);
+    // debug environment need to register devtool service for debuging.
+    LynxServiceCenter.inst().registerService(LynxDevToolService.getINSTANCE());
   }
 
   // merge it into InitProcessor later.

--- a/platform/android/lynx_android/BUILD.gn
+++ b/platform/android/lynx_android/BUILD.gn
@@ -31,9 +31,6 @@ cmake_target("lynx_android") {
     ":lynx_android_public_config",
     ":lynx_android_private_config",
   ]
-  if (!enable_lite) {
-    sub_cmake_target = [ "../../../core/runtime/jsi/v8:lynx_v8_bridge" ]
-  }
 }
 
 group("lynx_android_lib") {

--- a/platform/android/lynx_android/build.gradle
+++ b/platform/android/lynx_android/build.gradle
@@ -310,8 +310,9 @@ dependencies {
     androidTestImplementation "com.google.auto.service:auto-service-annotations:1.0-rc5"
     androidTestAnnotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
-    implementation 'org.lynxsdk.lynx:primjs:2.13.2'
-    extractJNI 'org.lynxsdk.lynx:primjs:2.13.2'
+    implementation 'org.lynxsdk.lynx:primjs:2.13.2-rc.2'
+    // dev revision contains napi-v8.so
+    extractJNI 'org.lynxsdk.lynx:primjs:2.13.2-rc.2-dev'
     extractJNI 'org.lynxsdk.lynx:v8so:11.1.277.3'
 
     api project(':LynxJSSDK')

--- a/platform/android/lynx_devtool/build.gradle
+++ b/platform/android/lynx_devtool/build.gradle
@@ -258,6 +258,7 @@ dependencies {
 
     implementation 'org.lynxsdk.lynx:debug-router:0.0.15'
     implementation 'org.lynxsdk.lynx:v8so:11.1.277.3'
+    implementation 'org.lynxsdk.lynx:primjs:2.13.2-rc.2-dev'
     
     compileOnly("com.squareup.okhttp3:okhttp:3.10.0")
     androidTestImplementation("com.squareup.okhttp3:mockwebserver:3.10.0")


### PR DESCRIPTION
Remove lynx_v8_bridge so and use dev version of primjs to extract libnapi-v8.so for lynxdevtool. At the same time, register devtool service to fix devtool connection problem.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
