### PR TITLE
[BugFix] fetchBundle supports double value as timeout.

### DIFF
--- a/core/runtime/bindings/common/resource/BUILD.gn
+++ b/core/runtime/bindings/common/resource/BUILD.gn
@@ -13,7 +13,7 @@ response_promise_shared_sources = [
 lynx_core_source_set("promise") {
   sources = response_promise_shared_sources
 
-  deps = []
+  deps = [ "../../../../../base/src:base_log" ]
 
   public_deps = []
 }

--- a/core/runtime/bindings/common/resource/response_handler_proxy.h
+++ b/core/runtime/bindings/common/resource/response_handler_proxy.h
@@ -40,7 +40,7 @@ class ResponseHandlerProxy
    * if promise get a std::nullopt, it will return with code
    * `LYNX_BUNDLE_RESOURCE_INFO_TIMEOUT`
    */
-  tasm::BundleResourceInfo WaitAndGetResource(long timeout) {
+  tasm::BundleResourceInfo WaitAndGetResource(double timeout) {
     auto result = promise_->Wait(timeout);
     if (result.has_value()) {
       return *result;

--- a/core/runtime/bindings/common/resource/response_promise.h
+++ b/core/runtime/bindings/common/resource/response_promise.h
@@ -66,9 +66,9 @@ class ResponsePromise {
     callbacks_.emplace_back(std::move(callback));
   }
 
-  std::optional<T> Wait(long timeout) {
+  std::optional<T> Wait(double timeout) {
     LOGI("ResponsePromise: Wait " << timeout << " " << this);
-    if (future_.wait_for(std::chrono::seconds(timeout)) ==
+    if (future_.wait_for(std::chrono::duration<double>(timeout)) ==
         std::future_status::ready) {
       return future_.get();
     }

--- a/core/runtime/bindings/common/resource/response_promise_unittest.cc
+++ b/core/runtime/bindings/common/resource/response_promise_unittest.cc
@@ -20,9 +20,57 @@ TEST_F(ResponsePromiseTest, TestResponsePromiseAddCallback) {
 
 TEST_F(ResponsePromiseTest, TestResponsePromiseWait) {
   ResponsePromise<int32_t> response_promise;
-  response_promise.SetValue(42);
+  // set value after 500ms;
+  std::thread setter_thread([&response_promise]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    response_promise.SetValue(42);
+  });
   auto result = response_promise.Wait(0);
+
+  setter_thread.join();
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(ResponsePromiseTest, TestResponsePromiseWait2) {
+  ResponsePromise<int32_t> response_promise;
+  // set value after 500ms;
+  std::thread setter_thread([&response_promise]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    response_promise.SetValue(42);
+  });
+  auto result = response_promise.Wait(1);
+
+  setter_thread.join();
+  ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result.value(), 42);
+}
+
+TEST_F(ResponsePromiseTest, TestResponsePromiseWaitDouble) {
+  ResponsePromise<int32_t> response_promise;
+
+  // set value after 500ms;
+  std::thread setter_thread([&response_promise]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    response_promise.SetValue(42);
+  });
+
+  auto start = std::chrono::steady_clock::now();
+  auto result =
+      response_promise.Wait(1.0);  // Waiting for 1s, make sure that the setter
+                                   // thread is already triggered.
+  auto end = std::chrono::steady_clock::now();
+
+  setter_thread.join();
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 42);
+
+  auto duration_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+          .count();
+
+  EXPECT_GE(duration_ms, 400);
+  EXPECT_LE(duration_ms, 600);
 }
 
 TEST_F(ResponsePromiseTest, TestResponsePromiseAddCallbackAfterSetValue) {

--- a/core/runtime/bindings/jsi/resource/response_handler_in_js.cc
+++ b/core/runtime/bindings/jsi/resource/response_handler_in_js.cc
@@ -57,7 +57,7 @@ Value ResponseHandlerInJS::WaitingForResponse(Runtime& rt) {
                 "ResponseHandler.wait's first param must be number."));
           }
 
-          long timeout = static_cast<long>(args[0].getNumber());
+          double timeout = args[0].getNumber();
           auto result = WaitAndGetResource(timeout);
           return ConvertBundleInfoToPiperValue(result);
         }


### PR DESCRIPTION
ResponseHandler now using seconds as params for `wait`, it's needed to support double value as params so that `fetchBundle` may support waits with Decimals precisely.

issue: f-98263565
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
