### PR TITLE
[BugFix] Missing field copy in CopyForAsyncDecode may causes abnormal CPU/memory consumption

### DIFF
--- a/core/template_bundle/template_codec/binary_decoder/template_binary_reader.cc
+++ b/core/template_bundle/template_codec/binary_decoder/template_binary_reader.cc
@@ -219,6 +219,7 @@ void TemplateBinaryReader::CopyForAsyncDecode(TemplateBinaryReader& other) {
   enable_css_variable_ = other.enable_css_variable_;
   enable_css_variable_multi_default_value_ =
       other.enable_css_variable_multi_default_value_;
+  enable_css_font_face_extension_ = other.enable_css_font_face_extension_;
   css_section_range_ = other.css_section_range_;
   lepus_chunk_route_ = other.lepus_chunk_route_;
   template_bundle().SetStringList(other.GetStringList());


### PR DESCRIPTION
## Summary

When `LynxLoadOptionRecycleTemplateBundle` option is enabled, loading a card bundle with multiple `@font-face` rules in CSS file causes reading abnormal for-loop size in `DecodeCSSFontFaceToken` (1.7 billion in my case).

Fixed by copying missing `enable_css_font_face_extension_` field.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
