### PR TITLE
[BugFix] using correct resourcetype when fetchTemplate

### DIFF
--- a/core/resource/lynx_resource_loader_darwin.h
+++ b/core/resource/lynx_resource_loader_darwin.h
@@ -52,7 +52,8 @@ class LynxResourceLoaderDarwin : public pub::LynxResourceLoader {
   /**
    * Try to fetch template by Generic Fetcher. if generic fetcher not set, return false;
    */
-  bool FetchTemplateByGenericFetcher(const std::string& url, CopyableClosure callback);
+  bool FetchTemplateByGenericFetcher(const std::string& url, LynxResourceRequestType type,
+                                     CopyableClosure callback);
 
   /**
    * Try to fetch resource by Generic Fetcher. if generic fetcher not set, return false;

--- a/core/resource/lynx_resource_loader_darwin.mm
+++ b/core/resource/lynx_resource_loader_darwin.mm
@@ -144,12 +144,12 @@ bool LynxResourceLoaderDarwin::FetchScriptByProvider(const std::string& url,
 }
 
 bool LynxResourceLoaderDarwin::FetchTemplateByGenericFetcher(const std::string& url,
+                                                             LynxResourceRequestType type,
                                                              CopyableClosure callback) {
   if (_templateResourceFetcher != nil) {
     TRACE_EVENT(LYNX_TRACE_CATEGORY, FETCH_TEMPLATE_BY_GENERIC_FETCHER, "url", url);
     NSString* nsUrl = [NSString stringWithUTF8String:url.c_str()];
-    LynxResourceRequest* request =
-        [[LynxResourceRequest alloc] initWithUrl:nsUrl type:LynxResourceTypeDynamicComponent];
+    LynxResourceRequest* request = [[LynxResourceRequest alloc] initWithUrl:nsUrl type:type];
     [_templateResourceFetcher
         fetchTemplate:request
            onComplete:^(LynxTemplateResource* _Nullable data, NSError* _Nullable error) {
@@ -304,7 +304,8 @@ void LynxResourceLoaderDarwin::LoadResource(
         };
     auto copyable_wrapper_callback = fml::MakeCopyable(std::move(callback_wrapper));
     // 1. try to use LynxTemplateResourceFetcher
-    if (FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback)) {
+    if (FetchTemplateByGenericFetcher(request.url, LynxResourceTypeDynamicComponent,
+                                      copyable_wrapper_callback)) {
       return;
     }
 
@@ -334,7 +335,8 @@ void LynxResourceLoaderDarwin::LoadResource(
         };
     auto copyable_wrapper_callback = fml::MakeCopyable(std::move(callback_wrapper));
     // 1. try to use LynxTemplateResourceFetcher
-    if (FetchTemplateByGenericFetcher(request.url, copyable_wrapper_callback)) {
+    if (FetchTemplateByGenericFetcher(request.url, LynxResourceTypeTemplate,
+                                      copyable_wrapper_callback)) {
       return;
     }
     // invoke callback directly if no provider or fetcher set;

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/LynxResourceLoader.java
@@ -17,13 +17,12 @@ import com.lynx.tasm.base.CalledByNative;
 import com.lynx.tasm.base.LLog;
 import com.lynx.tasm.component.DynamicComponentFetcher;
 import com.lynx.tasm.core.LynxThreadPool;
-import com.lynx.tasm.core.resource.LynxResourceType;
 import com.lynx.tasm.provider.LynxExternalResourceFetcherWrapper;
 import com.lynx.tasm.provider.LynxProviderRegistry;
 import com.lynx.tasm.provider.LynxResourceCallback;
 import com.lynx.tasm.provider.LynxResourceProvider;
-import com.lynx.tasm.provider.LynxResourceRequest;
 import com.lynx.tasm.provider.LynxResourceResponse;
+import com.lynx.tasm.resourceprovider.LynxResourceRequest;
 import com.lynx.tasm.resourceprovider.generic.LynxGenericResourceFetcher;
 import com.lynx.tasm.resourceprovider.template.LynxTemplateResourceFetcher;
 import com.lynx.tasm.utils.UIThreadUtils;
@@ -92,18 +91,18 @@ public class LynxResourceLoader {
 
   void loadResource(long responseHandler, String url, int type) {
     switch (type) {
-      case LynxResourceType.LYNX_RESOURCE_TYPE_ASSETS:
+      case LynxResourceType.LYNX_RESOURCE_TYPE_ASSETS: {
         byte[] data = loadJSSource(url);
         InvokeNativeCallbackWithBytes(responseHandler, data, RESOURCE_LOADER_SUCCESS, null);
-        break;
-      case LynxResourceType.LYNX_RESOURCE_TYPE_EXTERNAL_BYTE_CODE:
+      } break;
+      case LynxResourceType.LYNX_RESOURCE_TYPE_EXTERNAL_BYTE_CODE: {
         if (fetchExternalByteCodeByGenericFetcher(responseHandler, url)) {
           break;
         }
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
-        break;
-      case LynxResourceType.LYNX_RESOURCE_TYPE_EXTERNAL_JS:
+      } break;
+      case LynxResourceType.LYNX_RESOURCE_TYPE_EXTERNAL_JS: {
         // 1. try to use GenericResourceFetcher
         if (fetchScriptByGenericFetcher(responseHandler, url)) {
           break;
@@ -115,37 +114,41 @@ public class LynxResourceLoader {
         // invoke callback directly if no provider or fetcher set;
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
-        break;
-      case LynxResourceType.LYNX_RESOURCE_TYPE_JS_LAZY_BUNDLE:
+      } break;
+      case LynxResourceType.LYNX_RESOURCE_TYPE_JS_LAZY_BUNDLE: {
+        LynxResourceRequest.LynxResourceType resourceType =
+            LynxResourceRequest.LynxResourceType.LynxResourceTypeDynamicComponent;
         // 1. try to use LynxTemplateResourceFetcher
-        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
+        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, resourceType)) {
           break;
         }
         // 2. try to use LynxExternalResourceFetcherWrapper
-        if (fetchTemplateByFetcherWrapper(responseHandler, url, type)) {
+        if (fetchTemplateByFetcherWrapper(responseHandler, url, resourceType)) {
           break;
         }
         // 3. try to use LynxResourceProvider
-        if (fetchTemplateByProvider(responseHandler, url, type)) {
+        if (fetchTemplateByProvider(responseHandler, url, resourceType)) {
           break;
         }
         // invoke callback directly if no provider or fetcher set;
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
-        break;
-      case LynxResourceType.LYNX_RESOURCE_TYPE_FRAME:
+      } break;
+      case LynxResourceType.LYNX_RESOURCE_TYPE_FRAME: {
         // 1. frame only support LynxTemplateResourceFetcher
-        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, type)) {
+        LynxResourceRequest.LynxResourceType resourceType =
+            LynxResourceRequest.LynxResourceType.LynxResourceTypeTemplate;
+        if (fetchTemplateByGenericTemplateFetcher(responseHandler, url, resourceType)) {
           break;
         }
         // invoke callback directly if no provider or fetcher set;
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "No available provider or fetcher.");
-        break;
-      default:
+      } break;
+      default: {
         InvokeNativeCallbackWithBytes(
             responseHandler, null, RESOURCE_LOADER_FAILED, "Unsupported type" + type);
-        break;
+      } break;
     }
   }
 
@@ -308,7 +311,7 @@ public class LynxResourceLoader {
    * fetch lazy bundle template by LynxExternalResourceFetcherWrapper
    */
   private boolean fetchTemplateByFetcherWrapper(
-      long responseHandler, String url, int resourceType) {
+      long responseHandler, String url, LynxResourceRequest.LynxResourceType resourceType) {
     return mFetcherWrapper.fetchResourceWithDynamicComponentFetcher(
         url, new LynxExternalResourceFetcherWrapper.LoadedHandler() {
           private final TemplateResourceCallback mCallback =
@@ -326,13 +329,15 @@ public class LynxResourceLoader {
    * fetch lazy bundle template by LynxResourceProvider
    * @return whether the request has been sent, to determine whether using another loader
    */
-  private boolean fetchTemplateByProvider(long responseHandler, String url, int resourceType) {
+  private boolean fetchTemplateByProvider(
+      long responseHandler, String url, LynxResourceRequest.LynxResourceType resourceType) {
     LynxResourceProvider provider =
         getResourceProviderByType(LynxResourceType.LYNX_RESOURCE_TYPE_JS_LAZY_BUNDLE);
     if (provider == null) {
       return false;
     }
-    final LynxResourceRequest request = new LynxResourceRequest(url);
+    final com.lynx.tasm.provider.LynxResourceRequest request =
+        new com.lynx.tasm.provider.LynxResourceRequest(url);
     provider.request(request, new LynxResourceCallback<byte[]>() {
       private final TemplateResourceCallback mCallback =
           new TemplateResourceCallback(url, responseHandler, mReportHelper, resourceType);
@@ -352,7 +357,7 @@ public class LynxResourceLoader {
    * @return whether the request has been sent, to determine whether using another loader
    */
   private boolean fetchTemplateByGenericTemplateFetcher(
-      long responseHandler, String url, int resourceType) {
+      long responseHandler, String url, LynxResourceRequest.LynxResourceType resourceType) {
     boolean hasTemplateFetcher = mTemplateLoaderHelper.hasTemplateFetcher();
     LLog.i(TAG, "Generic template fetcher existed: " + hasTemplateFetcher);
     if (!hasTemplateFetcher) {
@@ -429,7 +434,8 @@ public class LynxResourceLoader {
     if (provider == null) {
       return false;
     }
-    final LynxResourceRequest request = new LynxResourceRequest(url);
+    final com.lynx.tasm.provider.LynxResourceRequest request =
+        new com.lynx.tasm.provider.LynxResourceRequest(url);
     provider.request(request, new LynxResourceCallback<byte[]>() {
       private final ExternalScriptResourceCallback callback =
           new ExternalScriptResourceCallback(LynxResourceLoader.this, url, responseHandler);

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/TemplateLoaderHelper.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/TemplateLoaderHelper.java
@@ -36,7 +36,7 @@ class TemplateLoaderHelper {
   }
 
   public void fetchTemplateByGenericTemplateFetcher(String url, TemplateResourceCallback callback) {
-    mTemplateFetcher.fetchTemplate(new LynxResourceRequest(url, LynxResourceTypeTemplate),
+    mTemplateFetcher.fetchTemplate(new LynxResourceRequest(url, callback.getResourceType()),
         new LynxResourceCallback<TemplateProviderResult>() {
           @Override
           public void onResponse(LynxResourceResponse<TemplateProviderResult> response) {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/TemplateResourceCallback.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/core/resource/TemplateResourceCallback.java
@@ -6,7 +6,7 @@ package com.lynx.tasm.core.resource;
 
 import com.lynx.tasm.LynxInfoReportHelper;
 import com.lynx.tasm.TemplateBundle;
-import com.lynx.tasm.core.resource.LynxResourceType;
+import com.lynx.tasm.resourceprovider.LynxResourceRequest;
 import com.lynx.tasm.service.LynxServiceCenter;
 import com.lynx.tasm.service.security.ILynxSecurityService;
 import com.lynx.tasm.service.security.SecurityResult;
@@ -20,14 +20,18 @@ import com.lynx.tasm.service.security.SecurityResult;
 class TemplateResourceCallback extends GuardedResourceCallback {
   private final long mResponseHandler;
   private final LynxInfoReportHelper mReportHelper;
-  private final int mResourceType;
+  private final LynxResourceRequest.LynxResourceType mResourceType;
 
-  public TemplateResourceCallback(
-      String url, long responseHandler, LynxInfoReportHelper reportHelper, int resourceType) {
+  public TemplateResourceCallback(String url, long responseHandler,
+      LynxInfoReportHelper reportHelper, LynxResourceRequest.LynxResourceType resourceType) {
     super(url);
     mResponseHandler = responseHandler;
     mReportHelper = reportHelper;
     mResourceType = resourceType;
+  }
+
+  public LynxResourceRequest.LynxResourceType getResourceType() {
+    return this.mResourceType;
   }
 
   public void onTemplateLoaded(
@@ -50,7 +54,7 @@ class TemplateResourceCallback extends GuardedResourceCallback {
       if (securityService != null) {
         // TODO(zhoupeng.z): add new TASM type for frame
         final ILynxSecurityService.LynxTasmType tasmType =
-            mResourceType == LynxResourceType.LYNX_RESOURCE_TYPE_FRAME
+            mResourceType == LynxResourceRequest.LynxResourceType.LynxResourceTypeTemplate
             ? ILynxSecurityService.LynxTasmType.TYPE_TEMPLATE
             : ILynxSecurityService.LynxTasmType.TYPE_DYNAMIC_COMPONENT;
         SecurityResult result = securityService.verifyTASM(null, data, mUrl, tasmType);


### PR DESCRIPTION
- Update resource type handling in resource loader
- Fix template resource callback parameter usage
- Ensure consistent resource type across platforms

issue: f-028375767
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
