### PR TITLE
[Infra][BugFix] Fix an issue in generate_and_register_jni_files.py

### DIFF
--- a/tools/build_jni/generate_and_register_jni_files.py
+++ b/tools/build_jni/generate_and_register_jni_files.py
@@ -460,9 +460,9 @@ def generate_files(root_path, jni_configs_file, use_base_jni_utils_header):
     print(f"Warning: so load file path is empty, you can input the path by `jni_register_configs.output_path` in {jni_configs_file}.")
   else:
     include_headers.extend(special_headers)
-    register_methods.extend(special_methods)
-    include_headers.sort()
     register_methods.sort()
+    register_methods = special_methods + register_methods
+    include_headers.sort()
     jni_register_configs['output_path'] = os.path.join(root_path, so_load_file_path)
     append_content_to_so_registry(jni_register_configs, include_headers, register_methods)
     gn_files.append(convert_to_relative_path(root_path, gn_file_path, so_load_file_path))


### PR DESCRIPTION
When generating the `JNI_Load` function, if methods are defined in `special_cases`, these methods should be called in the order they are defined to ensure that the calling order of functions is controlled in the YAML configuration file.

AutoSubmit:true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
