### PR TITLE
[BugFix][Part2] suppot lynxViewGroup in Darwin

### DIFF
--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -570,16 +570,12 @@ public class LynxBaseConfigurator : NSObject {
   public BOOL LynxBaseConfigurator::enableJSRuntime enableJSRuntime;
   public BOOL LynxBaseConfigurator::enableAirStrictMode enableAirStrictMode;
   public BOOL LynxBaseConfigurator::enableAsyncCreateRender enableAsyncCreateRender;
-  public BOOL LynxBaseConfigurator::enableRadonCompatible enableRadonCompatible;
   public BOOL LynxBaseConfigurator::enableSyncFlush enableSyncFlush;
   public BOOL LynxBaseConfigurator::enableMultiAsyncThread enableMultiAsyncThread;
   public BOOL LynxBaseConfigurator::enableVSyncAlignedMessageLoop enableVSyncAlignedMessageLoop;
   public BOOL LynxBaseConfigurator::enableAsyncHydration enableAsyncHydration;
   public BOOL LynxBaseConfigurator::enableMTSModule enableMTSModule;
-  public CGRect LynxBaseConfigurator::frame frame;
-  public id<LynxDynamicComponentFetcher> LynxBaseConfigurator::fetcher fetcher;
   public CGFloat LynxBaseConfigurator::fontScale fontScale;
-  public NSMutableDictionary<NSString*, id>* LynxBaseConfigurator::lynxViewConfig lynxViewConfig;
   public LynxBooleanOption LynxBaseConfigurator::enableGenericResourceFetcher enableGenericResourceFetcher;
   public id<LynxGenericResourceFetcher> LynxBaseConfigurator::genericResourceFetcher genericResourceFetcher;
   public id<LynxMediaResourceFetcher> LynxBaseConfigurator::mediaResourceFetcher mediaResourceFetcher;
@@ -587,15 +583,12 @@ public class LynxBaseConfigurator : NSObject {
   public CGSize LynxBaseConfigurator::screenSize screenSize;
   public BOOL LynxBaseConfigurator::debuggable debuggable;
   public BOOL LynxBaseConfigurator::enablePreUpdateData enablePreUpdateData;
-  public BOOL LynxBaseConfigurator::enableLynxResourceServiceLoaderInjection enableLynxResourceServiceLoaderInjection;
   public LynxBackgroundJsRuntimeType LynxBaseConfigurator::backgroundJsRuntimeType backgroundJsRuntimeType;
   public BOOL LynxBaseConfigurator::enableBytecode enableBytecode;
   public BOOL LynxBaseConfigurator::enableUnifiedPipeline enableUnifiedPipeline;
   public NSString* LynxBaseConfigurator::bytecodeUrl bytecodeUrl;
-  public NSURL* LynxBaseConfigurator::uri uri;
   public id<LynxUIRendererCreatorProtocol> LynxBaseConfigurator::uiRendererCreator uiRendererCreator;
   public LynxBackgroundRuntimeOptions* LynxBaseConfigurator()::lynxBackgroundRuntimeOptions lynxBackgroundRuntimeOptions;
-  public BOOL isUIRunningMode LynxBaseConfigurator::__attribute__((deprecated("try to set 'threadStrategy' variable if you want to change the thread strategy for rendering")));
   public void LynxBaseConfigurator::setThreadStrategyForRender:(LynxThreadStrategyForRender threadStrategy);
   public LynxThreadStrategyForRender LynxBaseConfigurator::getThreadStrategyForRender();
   public void LynxBaseConfigurator::setEmbeddedMode:(LynxEmbeddedMode embeddedMode);
@@ -603,7 +596,6 @@ public class LynxBaseConfigurator : NSObject {
   public void LynxBaseConfigurator::addLynxResourceProvider:provider:(NSString *_Nonnull resType,[provider] id< LynxResourceProvider > _Nonnull provider);
   public void LynxBaseConfigurator::registerFont:forName:(UIFont *_Nonnull font,[forName] NSString *_Nonnull name);
   public void LynxBaseConfigurator::registerFamilyName:withAliasName:(NSString *_Nonnull fontFamilyName,[withAliasName] NSString *_Nonnull aliasName);
-  public void LynxBaseConfigurator::insertLynxViewConfig:forKey:(id _Nonnull config,[forKey] NSString *_Nonnull key);
   public NSDictionary *_Nonnull LynxBaseConfigurator()::getLynxResourceProviders();
   public NSDictionary *_Nonnull LynxBaseConfigurator()::getBuilderRegisteredAliasFontMap();
 }
@@ -5116,9 +5108,17 @@ public protocol LynxViewBaseLifecycle-p : <NSObjectNSObject> {
 }
 
 public class LynxViewBuilder : LynxBaseConfigurator {
+  public BOOL LynxViewBuilder::enableRadonCompatible enableRadonCompatible;
+  public id<LynxDynamicComponentFetcher> LynxViewBuilder::fetcher fetcher;
+  public BOOL LynxViewBuilder::enableLynxResourceServiceLoaderInjection enableLynxResourceServiceLoaderInjection;
+  public CGRect LynxViewBuilder::frame frame;
   public LynxBackgroundRuntime* LynxViewBuilder::lynxBackgroundRuntime lynxBackgroundRuntime;
   public LynxViewGroup* LynxViewBuilder::lynxViewGroup lynxViewGroup;
+  public NSMutableDictionary<NSString*, id>* LynxViewBuilder::lynxViewConfig lynxViewConfig;
   public id LynxViewBuilder::lynxModuleExtraData lynxModuleExtraData;
+  public NSURL* LynxViewBuilder::uri uri;
+  public BOOL isUIRunningMode LynxViewBuilder::__attribute__((deprecated("try to set 'threadStrategy' variable if you want to change the thread strategy for rendering")));
+  public void LynxViewBuilder::insertLynxViewConfig:forKey:(id _Nonnull config,[forKey] NSString *_Nonnull key);
 }
 
 public class LynxViewGroup : LynxBaseConfigurator {

--- a/platform/darwin/ios/lynx/LynxBaseConfigurator.mm
+++ b/platform/darwin/ios/lynx/LynxBaseConfigurator.mm
@@ -177,17 +177,4 @@
   self.lynxBackgroundRuntimeOptions.templateResourceFetcher = templateResourceFetcher;
 }
 
-- (void)insertLynxViewConfig:(id)config forKey:(NSString*)key {
-  if (!key || !config) {
-    return;
-  }
-  if (!self.lynxViewConfig) {
-    self.lynxViewConfig = [[NSMutableDictionary alloc] initWithObjectsAndKeys:config, key, nil];
-  } else {
-    if (![self.lynxViewConfig objectForKey:key]) {
-      [self.lynxViewConfig setObject:config forKey:key];
-    }
-  }
-}
-
 @end

--- a/platform/darwin/ios/lynx/LynxTemplateRender+Protected.h
+++ b/platform/darwin/ios/lynx/LynxTemplateRender+Protected.h
@@ -34,6 +34,7 @@
 @class LynxView;
 @class LynxViewBuilder;
 @class LynxLifecycleDispatcher;
+@class LynxViewGroup;
 typedef NS_ENUM(NSInteger, LynxBooleanOption);
 
 @protocol LynxDynamicComponentFetcher;
@@ -79,6 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
   LynxSSRHelper* _lynxSSRHelper;
   LynxPerformanceController* _performanceController;
   LynxEngine* _lynxEngine;
+  LynxViewGroup* _lynxViewGroup;
   CGFloat _fontScale;
   CGSize _intrinsicContentSize;
   std::unique_ptr<lynx::shell::LynxShell> shell_;

--- a/platform/darwin/ios/lynx/LynxTemplateRender.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRender.mm
@@ -117,6 +117,7 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
       }
     }
 
+    _lynxViewGroup = builder.lynxViewGroup;
     /// Runtime Options
     _runtime = builder.lynxBackgroundRuntime;
     // Avoid unexpected changes
@@ -473,7 +474,11 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
     [_lynxSSRHelper onHydrateStart];
   }
 
-  if (meta.templateBundle) {
+  // bundle in meta is considered before bundle in lynxViewGroup.
+  LynxTemplateBundle* templateBundle =
+      meta.templateBundle ? meta.templateBundle : _lynxViewGroup.templateBundle;
+
+  if (templateBundle) {
     [self loadTemplateBundle:meta.templateBundle withURL:meta.url initData:meta.initialData];
   } else if (meta.binaryData) {
     [self loadTemplate:meta.binaryData withURL:meta.url initData:meta.initialData];

--- a/platform/darwin/ios/lynx/LynxViewBuilder.mm
+++ b/platform/darwin/ios/lynx/LynxViewBuilder.mm
@@ -9,9 +9,241 @@
 #import <Lynx/LynxTraceEvent.h>
 #import <Lynx/LynxTraceEventDef.h>
 #import <Lynx/LynxViewBuilder.h>
+#import <Lynx/LynxViewGroup.h>
 #import "LynxUIRenderer.h"
 #import "LynxUIRendererCreator.h"
 
 @implementation LynxViewBuilder
+
+- (LynxConfig*)config {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.config;
+  }
+  return [super config];
+}
+
+- (LynxGroup*)group {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.group;
+  }
+  return [super group];
+}
+
+- (BOOL)enableLayoutSafepoint {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableLayoutSafepoint;
+  }
+  return [super enableLayoutSafepoint];
+}
+
+- (BOOL)enableAutoExpose {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableAutoExpose;
+  }
+  return [super enableAutoExpose];
+}
+
+- (BOOL)enableTextNonContiguousLayout {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableTextNonContiguousLayout;
+  }
+  return [super enableTextNonContiguousLayout];
+}
+
+- (BOOL)enableLayoutOnly {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableLayoutOnly;
+  }
+  return [super enableLayoutOnly];
+}
+
+- (BOOL)enableUIOperationQueue {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableUIOperationQueue;
+  }
+  return [super enableUIOperationQueue];
+}
+
+- (BOOL)enablePendingJSTaskOnLayout {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enablePendingJSTaskOnLayout;
+  }
+  return [super enablePendingJSTaskOnLayout];
+}
+
+- (BOOL)enableJSRuntime {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableJSRuntime;
+  }
+
+  return [super enableJSRuntime];
+}
+
+- (BOOL)enableAirStrictMode {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableAirStrictMode;
+  }
+  return [super enableAirStrictMode];
+}
+
+- (BOOL)enableAsyncCreateRender {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableAsyncCreateRender;
+  }
+  return [super enableAsyncCreateRender];
+}
+
+- (BOOL)enableSyncFlush {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableSyncFlush;
+  }
+  return [super enableSyncFlush];
+}
+
+- (BOOL)enableMultiAsyncThread {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableMultiAsyncThread;
+  }
+  return [super enableMultiAsyncThread];
+}
+
+- (BOOL)enableVSyncAlignedMessageLoop {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableVSyncAlignedMessageLoop;
+  }
+  return [super enableVSyncAlignedMessageLoop];
+}
+
+- (BOOL)enableAsyncHydration {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableAsyncHydration;
+  }
+  return [super enableAsyncHydration];
+}
+
+- (BOOL)enableMTSModule {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableMTSModule;
+  }
+  return [super enableMTSModule];
+}
+
+- (CGFloat)fontScale {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.fontScale;
+  }
+  return [super fontScale];
+}
+
+- (LynxBooleanOption)enableGenericResourceFetcher {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableGenericResourceFetcher;
+  }
+  return [super enableGenericResourceFetcher];
+}
+
+- (id<LynxGenericResourceFetcher>)genericResourceFetcher {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.genericResourceFetcher;
+  }
+  return [super genericResourceFetcher];
+}
+
+- (id<LynxMediaResourceFetcher>)mediaResourceFetcher {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.mediaResourceFetcher;
+  }
+  return [super mediaResourceFetcher];
+}
+
+- (id<LynxTemplateResourceFetcher>)templateResourceFetcher {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.templateResourceFetcher;
+  }
+  return [super templateResourceFetcher];
+}
+
+- (CGSize)screenSize {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.screenSize;
+  }
+  return [super screenSize];
+}
+
+- (BOOL)debuggable {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.debuggable;
+  }
+  return [super debuggable];
+}
+
+- (BOOL)enablePreUpdateData {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enablePreUpdateData;
+  }
+  return [super enablePreUpdateData];
+}
+
+- (LynxBackgroundJsRuntimeType)backgroundJsRuntimeType {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.backgroundJsRuntimeType;
+  }
+  return [super backgroundJsRuntimeType];
+}
+
+- (BOOL)enableBytecode {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableBytecode;
+  }
+  return [super enableBytecode];
+}
+
+- (BOOL)enableUnifiedPipeline {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.enableUnifiedPipeline;
+  }
+  return [super enableUnifiedPipeline];
+}
+
+- (NSString*)bytecodeUrl {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.bytecodeUrl;
+  }
+  return [super bytecodeUrl];
+}
+
+- (id<LynxUIRendererCreatorProtocol>)uiRendererCreator {
+  if (_lynxViewGroup) {
+    return _lynxViewGroup.uiRendererCreator;
+  }
+  return [super uiRendererCreator];
+}
+
+- (LynxThreadStrategyForRender)getThreadStrategyForRender {
+  if (_lynxViewGroup) {
+    return [_lynxViewGroup getThreadStrategyForRender];
+  }
+  return [super getThreadStrategyForRender];
+}
+
+- (LynxEmbeddedMode)getEmbeddedMode {
+  if (_lynxViewGroup) {
+    return [_lynxViewGroup getEmbeddedMode];
+  }
+  return [super getEmbeddedMode];
+}
+
+- (void)insertLynxViewConfig:(id)config forKey:(NSString*)key {
+  if (!key || !config) {
+    return;
+  }
+  if (!self.lynxViewConfig) {
+    self.lynxViewConfig = [[NSMutableDictionary alloc] initWithObjectsAndKeys:config, key, nil];
+  } else {
+    if (![self.lynxViewConfig objectForKey:key]) {
+      [self.lynxViewConfig setObject:config forKey:key];
+    }
+  }
+}
 
 @end

--- a/platform/darwin/ios/lynx/public/LynxBaseConfigurator.h
+++ b/platform/darwin/ios/lynx/public/LynxBaseConfigurator.h
@@ -30,17 +30,13 @@
 @property(nonatomic, assign) BOOL enableJSRuntime;
 @property(nonatomic, assign) BOOL enableAirStrictMode;
 @property(nonatomic, assign) BOOL enableAsyncCreateRender;
-@property(nonatomic, assign) BOOL enableRadonCompatible;
 @property(nonatomic, assign) BOOL enableSyncFlush;
 @property(nonatomic, assign) BOOL enableMultiAsyncThread;
 @property(nonatomic, assign) BOOL enableVSyncAlignedMessageLoop;
 // Run the hydration process in a async thread.
 @property(nonatomic, assign) BOOL enableAsyncHydration;
 @property(nonatomic, assign) BOOL enableMTSModule;
-@property(nonatomic, assign) CGRect frame;
-@property(nonatomic, nullable) id<LynxDynamicComponentFetcher> fetcher;
 @property(nonatomic, assign) CGFloat fontScale;
-@property(nonatomic, nullable, strong) NSMutableDictionary<NSString*, id>* lynxViewConfig;
 @property(nonatomic, assign) LynxBooleanOption enableGenericResourceFetcher;
 
 // generic resource fetcher api.
@@ -71,11 +67,6 @@
 @property(nonatomic, assign) BOOL enablePreUpdateData;
 
 /**
- * enable LynxResourceService loader injection
- */
-@property(nonatomic, assign) BOOL enableLynxResourceServiceLoaderInjection;
-
-/**
  * Set backgroundJSRuntime js engine type.
  */
 @property(nonatomic, assign) LynxBackgroundJsRuntimeType backgroundJsRuntimeType;
@@ -96,15 +87,6 @@
  * Set bytecode key for current lynxview.
  */
 @property(nonatomic, strong, nullable) NSString* bytecodeUrl;
-
-@property(nonatomic, assign) BOOL isUIRunningMode __attribute__((deprecated(
-    "try to set 'threadStrategy' variable if you want to change the thread strategy for rendering"))
-);
-
-/**
- * URL for LynxView, which will be parsed by LynxServiceTrailProtocol in building LynxView.
- */
-@property(nonatomic, strong, nullable) NSURL* uri;
 
 @property(nonatomic, nullable) id<LynxUIRendererCreatorProtocol> uiRendererCreator;
 
@@ -133,11 +115,6 @@
 - (void)registerFont:(UIFont* _Nonnull)font forName:(NSString* _Nonnull)name;
 - (void)registerFamilyName:(NSString* _Nonnull)fontFamilyName
              withAliasName:(NSString* _Nonnull)aliasName;
-
-/**
- * insert a key-value pair into lynxViewConfig if the key does not exist, otherwise ignored.
- */
-- (void)insertLynxViewConfig:(id _Nonnull)config forKey:(NSString* _Nonnull)key;
 
 @end
 

--- a/platform/darwin/ios/lynx/public/LynxViewBuilder.h
+++ b/platform/darwin/ios/lynx/public/LynxViewBuilder.h
@@ -17,13 +17,38 @@ static NSString* _Nonnull const KEY_LYNX_PLATFORM_CONFIG = @"platform_config";
 
 @interface LynxViewBuilder : LynxBaseConfigurator
 
+// legacy props that needs to be removed.
+@property(nonatomic, assign) BOOL enableRadonCompatible;
+@property(nonatomic, nullable) id<LynxDynamicComponentFetcher> fetcher;
+
+/**
+ * enable LynxResourceService loader injection
+ */
+@property(nonatomic, assign) BOOL enableLynxResourceServiceLoaderInjection;
+
+@property(nonatomic, assign) BOOL isUIRunningMode __attribute__((deprecated(
+    "try to set 'threadStrategy' variable if you want to change the thread strategy for rendering"))
+);
+
+@property(nonatomic, assign) CGRect frame;
 @property(nonatomic, nullable) LynxBackgroundRuntime* lynxBackgroundRuntime;
 @property(nonatomic, nullable) LynxViewGroup* lynxViewGroup;
+@property(nonatomic, nullable, strong) NSMutableDictionary<NSString*, id>* lynxViewConfig;
 
 /**
  * Pass extra data to LynxModule, the usage of data depends on module's implementation
  */
 @property(nonatomic, nullable) id lynxModuleExtraData;
+
+/**
+ * URL for LynxView, which will be parsed by LynxServiceTrailProtocol in building LynxView.
+ */
+@property(nonatomic, strong, nullable) NSURL* uri;
+
+/**
+ * insert a key-value pair into lynxViewConfig if the key does not exist, otherwise ignored.
+ */
+- (void)insertLynxViewConfig:(id _Nonnull)config forKey:(NSString* _Nonnull)key;
 
 @end
 


### PR DESCRIPTION
- Add substantial implementation to LynxViewBuilder.mm, providing custom getters that consider lynxViewGroup first.
- Remove legacy props in LynxBaseConfigurator to LynxViewBuilder, lynxViewGroup should not considering it any more.
- optimize loadTemplate with meta, if bundle is provided with metaData or lynxViewGroup, it should be considered to optimize the performance.

issue: f-6578369019
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
