### PR TITLE
[BugFix] Make LynxRuntime Initialization If LogicExecutor is not Prov…

### DIFF
--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -137,6 +137,7 @@ public class LynxTemplateRender
   private TemplateBundle mTemplateBundle;
   private ILynxViewConfigProvider mLynxViewConfigProvider;
   private ILynxViewRuntimeCacheManager mRuntimeCacheManager;
+  private ILynxLogicExecutor mLogicExecutor;
 
   private LynxBackgroundRuntimeOptions mLynxRuntimeOptions;
   protected LynxModuleFactory mModuleFactory;
@@ -297,6 +298,7 @@ public class LynxTemplateRender
     mContext = context;
     mBodyView = bodyView;
     mLynxViewConfigProvider = builder;
+    mLogicExecutor = builder.getLogicExecutor();
     if (builder.lynxViewGroup instanceof ILynxViewRuntimeCacheManager) {
       mRuntimeCacheManager = ((ILynxViewRuntimeCacheManager) builder.lynxViewGroup);
     }
@@ -914,7 +916,8 @@ public class LynxTemplateRender
     }
 
     if (!"none".equals(BuildConfig.JS_ENGINE_TYPE)) {
-      if (null != mLynxContext && !mLynxContext.isEmbeddedModeOn()) {
+      if (null != mLynxContext && mLogicExecutor == null) {
+        // init LynxRuntime If LogicExecutor is not provided.
         setUpBackgroundThreadModuleFactory();
         mResourceLoader = new LynxResourceLoader(mLynxRuntimeOptions, mLynxViewBuilder.fetcher,
             this, mLynxContext.getTemplateResourceFetcher(),
@@ -1622,7 +1625,7 @@ public class LynxTemplateRender
       return;
     }
 
-    if (mLynxContext.isEmbeddedModeOn() && metaData.getInitialData() != null) {
+    if (mLogicExecutor != null && metaData.getInitialData() != null) {
       metaData.getInitialData().setEnableJSData(false);
       mTemplateData.updateWithTemplateData(metaData.getInitialData());
     }
@@ -1817,7 +1820,7 @@ public class LynxTemplateRender
     onTraceEventBegin(TraceEventDef.TEMPLATE_RENDER_UPDATE_META_DATE);
 
     TemplateData data = meta.getUpdatedData();
-    if (mLynxContext != null && mLynxContext.isEmbeddedModeOn() && data != null) {
+    if (mLynxContext != null && mLogicExecutor != null && data != null) {
       data.setEnableJSData(false);
       mTemplateData.updateWithTemplateData(data);
     }
@@ -3229,15 +3232,15 @@ public class LynxTemplateRender
 
     @Override
     public void onLynxEvent(ReadableMap event) {
-      if (mLynxViewConfigProvider.getLogicExecutor() != null) {
-        mLynxViewConfigProvider.getLogicExecutor().onLynxEvent(getLynxView(), event);
+      if (mLogicExecutor != null) {
+        mLogicExecutor.onLynxEvent(getLynxView(), event);
       }
     }
   }
 
   public void onLynxEvent(ReadableMap event) {
-    if (mLynxViewConfigProvider.getLogicExecutor() != null) {
-      mLynxViewConfigProvider.getLogicExecutor().onLynxEvent(getLynxView(), event);
+    if (mLogicExecutor != null) {
+      mLogicExecutor.onLynxEvent(getLynxView(), event);
     }
   }
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/group/LynxViewGroup.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/group/LynxViewGroup.java
@@ -142,7 +142,7 @@ class LynxViewGroup implements ILynxViewGroup, ILynxViewRuntimeCacheManager {
     }
     if (templateBundle == null) {
       this.fetchTemplate();
-    } else if (this.logicExecutor == null) {
+    } else if (this.logicExecutor == null && EmbeddedMode.isEnginePoolEnable(embeddedMode)) {
       this.logicExecutor = new DefaultLogicExecutor(
           templateBundle, lynxRuntimeOptions, mContext, LynxViewGroup.this, debuggable);
     }


### PR DESCRIPTION
…ided

LogicExecutor is a replacement of LynxRuntime in embeddedMode, It's needed to make LynxRuntime Initiazation if Users has not provide the implementation of LogicExecutor.

while, if the EnginePool is enabled, we will provided a DefaultLogicExecutor as default Implementation, but not in Base EmbeddedMode.

issue: f-9823765
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
