### PR TITLE
[Infra] Support passing globalProps via url query

### DIFF
--- a/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
+++ b/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         android:usesCleartextTraffic="true">
         <activity
             android:name=".LynxViewShellActivity"
-            android:screenOrientation="portrait"
             android:windowSoftInputMode="adjustNothing"
             android:exported="true"
             android:theme="@style/LynxShellTheme">

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -6,6 +6,7 @@ package com.lynx.explorer;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ActivityInfo;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.graphics.Color;
@@ -53,7 +54,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
   private static final String URL_PREFIX = "file://lynx?local://";
   private static final String TAG = "LynxViewShellActivity";
   private static final String HOME_PAGE_URL =
-      "file://lynx?local://homepage.lynx.bundle?fullscreen=true";
+      "file://lynx?local://homepage.lynx.bundle?fullscreen=true&orientation=portrait";
   private static final String DEFAULT_TOP_BAR_COLOR = "#F0F2F5";
   private static final String DEFAULT_TOP_BAR_TITLE_COLOR = "#000000";
   private static final String DEFAULT_TOP_BAR_BACK_BUTTON_STYLE = "light";
@@ -233,7 +234,12 @@ public class LynxViewShellActivity extends AppCompatActivity {
     // Parse the URL parameters and specify the LynxView width, height, and density according to the
     // parameters.
     QueryMapUtils queryMap = new QueryMapUtils();
-    queryMap.parse(url);
+    if (isAssetFilename(url)) {
+      queryMap.parse(getAssetFilename(url));
+    } else {
+      queryMap.parse(url);
+    }
+
     if (queryMap.contains("width") && queryMap.contains("height")) {
       builder.setPresetMeasuredSpec(
           View.MeasureSpec.makeMeasureSpec(queryMap.getInt("width", 720), View.MeasureSpec.EXACTLY),
@@ -243,8 +249,23 @@ public class LynxViewShellActivity extends AppCompatActivity {
     if (queryMap.contains("density")) {
       builder.setDensity(queryMap.getFloat("density", 320) / 160.f);
     }
+
+    if (queryMap.contains("orientation")) {
+      switch (queryMap.getString("orientation")) {
+        case "portrait":
+          setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+          break;
+        case "landscape":
+          setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+          break;
+        default:
+          setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+          break;
+      }
+    }
+
     LynxView lynxView = builder.build(this);
-    lynxView.updateGlobalProps(getGlobalProps(this));
+    lynxView.updateGlobalProps(getGlobalProps(this, queryMap));
     extraTimingInfo.mPrepareTemplateStart = System.currentTimeMillis();
 
     renderLynxViewWithUrl(lynxView, url);
@@ -289,7 +310,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
       Log.i(TAG, "openTargetUrl failed: not supported url.");
     }
   }
-  private TemplateData getGlobalProps(Context context) {
+  private TemplateData getGlobalProps(Context context, QueryMapUtils queryMap) {
     DisplayMetrics displayMetrics = DisplayMetricsHolder.getRealScreenDisplayMetrics(context);
     Map globalProps = new HashMap();
     globalProps.put("isNotchScreen", isNotchScreen());
@@ -311,6 +332,24 @@ public class LynxViewShellActivity extends AppCompatActivity {
     } else {
       globalProps.put("frontendTheme", "light");
     }
+
+    queryMap.toMap().forEach((key, value) -> {
+      int leadingUnderline = 0;
+      while (leadingUnderline < key.length() && key.charAt(leadingUnderline) == '_') {
+        leadingUnderline++;
+      }
+      key = key.substring(leadingUnderline);
+
+      String[] parts = key.split("_");
+      String propsKey = parts[0];
+      for (int i = 1; i < parts.length; i++) {
+        if (parts[i].isEmpty()) {
+          continue;
+        }
+        propsKey += parts[i].substring(0, 1).toUpperCase() + parts[i].substring(1);
+      }
+      globalProps.put(propsKey, value);
+    });
 
     return TemplateData.fromMap(globalProps);
   }

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
@@ -57,4 +57,14 @@ public class ExplorerModule extends LynxModule {
   public void saveThemePreferences(String theme, String value) {
     LynxModuleAdapter.getInstance().saveThemePreferences(theme, value);
   }
+
+  @LynxMethod
+  public void saveToLocalStorage(String key, String value) {
+    LynxModuleAdapter.getInstance().saveToLocalStorage(key, value);
+  }
+
+  @LynxMethod
+  public String readFromLocalStorage(String key) {
+    return LynxModuleAdapter.getInstance().readFromLocalStorage(key);
+  }
 }

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
@@ -11,6 +11,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import com.lynx.devtoolwrapper.LynxDevtoolCardListener;
 import com.lynx.devtoolwrapper.LynxDevtoolGlobalHelper;
 import com.lynx.explorer.LynxViewShellActivity;
@@ -114,6 +115,23 @@ public class LynxModuleAdapter {
     SharedPreferences p =
         mContext.getSharedPreferences(LynxViewShellActivity.PREFERENCES, Context.MODE_PRIVATE);
     p.edit().putString(theme, value).apply();
+  }
+
+  public void saveToLocalStorage(String key, String value) {
+    if (key == null) {
+      return;
+    }
+    SharedPreferences p =
+        mContext.getSharedPreferences(LynxViewShellActivity.PREFERENCES, Context.MODE_PRIVATE);
+    p.edit().putString(key, value).apply();
+  }
+
+  @Nullable
+  public String readFromLocalStorage(String key) {
+    SharedPreferences p =
+        mContext.getSharedPreferences(LynxViewShellActivity.PREFERENCES, Context.MODE_PRIVATE);
+    String value = p.getString(key, null);
+    return value;
   }
 
   private LynxModuleAdapter() {}

--- a/testing/integration_test/test_script/lib/test_runner/case_set.py
+++ b/testing/integration_test/test_script/lib/test_runner/case_set.py
@@ -86,8 +86,8 @@ class CaseSet:
             url = f"file://lynx?local://{config['path']}.lynx.bundle"
             if enable_scale :
                 if platform == 'android':
-                    config['width'] = config['width'] if 'width' in config else 720
-                    config['height'] = config['height'] if 'height' in config else 1280
+                    config['width'] = config['width'] if 'width' in config else 1080
+                    config['height'] = config['height'] if 'height' in config else 1664
                     config['density'] = config['density'] if 'density' in config else 320
                     url = utils.append_query_to_url(url, f'width={config["width"]}&height={config["height"]}&density={config["density"]}')
                 elif platform == 'ios':


### PR DESCRIPTION
Given a url with queries "?query_one=hello&query_two=world", two globalProps "queryOne=hello" and "queryTwo=world" will be put to the card.

other changes:
1. Add a new query orientation to specify the card's orientation.
2. Add a local storage native module.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
