### PR TITLE
Support passing globalProps via url query

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
@@ -669,7 +669,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -703,7 +703,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
@@ -9,7 +9,8 @@
 #import "TasmDispatcher.h"
 
 NSString *const LOCAL_URL_PREFIX = @"file://lynx?local://";
-NSString *const HOMEPAGE_URL = @"file://lynx?local://homepage.lynx.bundle?fullscreen=true";
+NSString *const HOMEPAGE_URL =
+    @"file://lynx?local://homepage.lynx.bundle?fullscreen=true&orientation=portrait";
 
 @interface AppDelegate ()
 

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
@@ -73,6 +73,43 @@ NSString *const kBackButtonImageDark = @"back_dark";
   [self.navigationController setNavigationBarHidden:YES animated:NO];
 }
 
+- (LynxTemplateData *)getGlobalPropsFromParams {
+  NSMutableDictionary *params = [NSMutableDictionary dictionary];
+  for (NSString *key in self.params) {
+    id value = self.params[key];
+
+    // 1. remove redundant '_'
+    NSUInteger leadingUnderline = 0;
+    while (leadingUnderline < key.length && [key characterAtIndex:leadingUnderline] == '_') {
+      leadingUnderline++;
+    }
+    NSString *trimmedKey = [key substringFromIndex:leadingUnderline];
+    if (trimmedKey.length == 0) {
+      [params setObject:value forKey:key];
+      continue;
+    }
+
+    // 2. split by underscores and convert to camel case
+    NSArray<NSString *> *parts = [trimmedKey componentsSeparatedByString:@"_"];
+    NSMutableString *propsKey = [NSMutableString stringWithString:parts[0]];
+
+    for (NSUInteger i = 1; i < parts.count; i++) {
+      NSString *part = parts[i];
+      if (part.length == 0) {
+        continue;
+      }
+      NSString *capitalizedPart =
+          [part stringByReplacingCharactersInRange:NSMakeRange(0, 1)
+                                        withString:[part substringToIndex:1].uppercaseString];
+      [propsKey appendString:capitalizedPart];
+    }
+    [params setObject:value forKey:propsKey];
+  }
+
+  LynxTemplateData *globalProps = [[LynxTemplateData alloc] initWithDictionary:params];
+  return globalProps;
+}
+
 - (void)loadLynxViewWithUrl:(NSString *)url templateData:(NSData *)data {
   CGRect screenFrame = self.view.frame;
   CGRect statusRect = [[UIApplication sharedApplication] statusBarFrame];
@@ -124,7 +161,7 @@ NSString *const kBackButtonImageDark = @"back_dark";
   CGRect screenRect = [[UIScreen mainScreen] bounds];
   CGFloat screenWidth = screenRect.size.width;
   CGFloat screenHeight = screenRect.size.height;
-  LynxTemplateData *globalProps = [[LynxTemplateData alloc] initWithDictionary:nil];
+  LynxTemplateData *globalProps = [self getGlobalPropsFromParams];
   [globalProps updateBool:[self isNotchScreen] forKey:@"isNotchScreen"];
   [globalProps updateDouble:screenHeight forKey:@"screenHeight"];
   [globalProps updateDouble:screenWidth forKey:@"screenWidth"];
@@ -250,6 +287,22 @@ NSString *const kBackButtonImageDark = @"back_dark";
   [barView addSubview:goBackButton];
   [barView addSubview:titleLabel];
   [self.view addSubview:barView];
+}
+
+- (BOOL)shouldAutorotate {
+  return NO;
+}
+
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+  if ([self.params.allKeys containsObject:@"orientation"]) {
+    NSString *orientation = self.params[@"orientation"];
+    if ([orientation isEqualToString:@"portrait"]) {
+      return UIInterfaceOrientationMaskPortrait;
+    } else if ([orientation isEqualToString:@"landscape"]) {
+      return UIInterfaceOrientationMaskLandscape;
+    }
+  }
+  return UIInterfaceOrientationMaskAllButUpsideDown;
 }
 
 - (void)viewWillLayoutSubviews {

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/ExplorerModule.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/modules/ExplorerModule.m
@@ -40,6 +40,8 @@ NSString *const DEVTOOL_SWITCH_URL __attribute__((deprecated)) =
     @"openDevtoolSwitchPage" : NSStringFromSelector(@selector(openDevToolSwitchPage)),
     @"navigateBack" : NSStringFromSelector(@selector(navigateBack)),
     @"saveThemePreferences" : NSStringFromSelector(@selector(saveThemePreferences:value:)),
+    @"saveToLocalStorage" : NSStringFromSelector(@selector(saveToLocalStorage:value:)),
+    @"readFromLocalStorage" : NSStringFromSelector(@selector(readFromLocalStorage:)),
   };
 }
 
@@ -97,6 +99,17 @@ NSString *const DEVTOOL_SWITCH_URL __attribute__((deprecated)) =
   NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
   [defaults setObject:value forKey:theme];
   [defaults synchronize];
+}
+
+- (void)saveToLocalStorage:(NSString *)key value:(NSString *)value {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  [defaults setObject:value forKey:key];
+  [defaults synchronize];
+}
+
+- (NSString *)readFromLocalStorage:(NSString *)key {
+  NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+  return [defaults objectForKey:key];
 }
 
 @end


### PR DESCRIPTION
Given a URL with queries "?query_one=hello&query_two=world", two globalProps "queryOne=hello" and "queryTwo=world" will be put to the card. other changes:
1. Add a new query orientation to specify the card's orientation.
2. Add a local storage native module.
3. Adjust case sets' default resolution so that they won't break after the adjustment of query parsing.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
