### PR TITLE
Fix: Update SDWebImage to comply with Apple's privacy manifest requirement (ITMS-91061)

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/Podfile
+++ b/explorer/darwin/ios/lynx_explorer/Podfile
@@ -50,8 +50,8 @@ target 'LynxExplorer' do
 
   pod 'PrimJS', :subspecs => ['quickjs', 'napi']
 
-  pod 'SDWebImage','5.15.5'
-  pod 'SDWebImageWebPCoder', '0.11.0'
+  pod 'SDWebImage', '~> 5.19'
+  pod 'SDWebImageWebPCoder', '~> 0.14'
 
   pod 'DebugRouter', '5.0.13'
 end

--- a/platform/darwin/ios/lynx_service/BUILD.gn
+++ b/platform/darwin/ios/lynx_service/BUILD.gn
@@ -68,11 +68,11 @@ subspec_target("Image") {
   dependency = lynx_dependency
   dependency += [ [
         "SDWebImage",
-        "5.15.5",
+        "~> 5.19",
       ] ]
   dependency += [ [
         "SDWebImageWebPCoder",
-        "0.11.0",
+        "~> 0.14",
       ] ]
   dependency += [ [
         "LynxServiceAPI",


### PR DESCRIPTION
  Apple now requires SDWebImage to include a privacy manifest (PrivacyInfo.xcprivacy). SDWebImage added this in version 5.18.7.

  This PR updates:
  - SDWebImage: 5.15.5 → ~> 5.19
  - SDWebImageWebPCoder: 0.11.0 → ~> 0.14

  Tested: Verified that pod install resolves correctly and the project builds with SDWebImage 5.21.4 and SDWebImageWebPCoder 0.15.0.

  References:
  - https://github.com/SDWebImage/SDWebImage/releases/tag/5.18.7
  - https://developer.apple.com/support/third-party-SDK-requirements