### PR TITLE
[Optimize] Unify renderTemplate api to lynxLoadMeta

### DIFF
--- a/core/shell/android/lynx_template_render_android.cc
+++ b/core/shell/android/lynx_template_render_android.cc
@@ -523,7 +523,7 @@ void LoadSSRDataByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
 
 void LoadTemplateByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
                                  jlong lifecycle, jstring j_url,
-                                 jbyteArray j_binary, jint is_pre_painting,
+                                 jbyteArray j_binary, jboolean is_pre_painting,
                                  jboolean enable_recycle_template_bundle,
                                  jlong data, jboolean readOnly, jstring name,
                                  jobject template_data, jint options,
@@ -532,19 +532,17 @@ void LoadTemplateByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
   std::vector<uint8_t> vec = JNIConvertHelper::ConvertJavaBinary(env, j_binary);
   InternalLoadTemplate(env, ptr, lifecycle, j_url, std::move(vec),
                        data ? *(reinterpret_cast<Value*>(data)) : Value(),
-                       readOnly, is_pre_painting == 1, processor_name,
-                       template_data, enable_recycle_template_bundle,
-                       j_timing_option, options);
+                       readOnly, is_pre_painting, processor_name, template_data,
+                       enable_recycle_template_bundle, j_timing_option,
+                       options);
 }
 
-void LoadTemplateBufferByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
-                                       jlong lifecycle, jstring url,
-                                       jobject bufferPtr, jint is_pre_painting,
-                                       jboolean enable_recycle_template_bundle,
-                                       jlong data, jboolean read_only,
-                                       jstring j_processor_name,
-                                       jobject template_data, jint options,
-                                       jobject timing_option) {
+void LoadTemplateBufferByPreParsedData(
+    JNIEnv* env, jclass jcaller, jlong ptr, jlong lifecycle, jstring url,
+    jobject bufferPtr, jboolean is_pre_painting,
+    jboolean enable_recycle_template_bundle, jlong data, jboolean read_only,
+    jstring j_processor_name, jobject template_data, jint options,
+    jobject timing_option) {
   std::string processor_name =
       JNIConvertHelper::ConvertToString(env, j_processor_name);
   auto* buffer_ptr =
@@ -562,16 +560,16 @@ void LoadTemplateBufferByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
   std::vector<uint8_t> vec(buffer_ptr, buffer_ptr + capacity);
   InternalLoadTemplate(env, ptr, lifecycle, url, std::move(vec),
                        data ? *(reinterpret_cast<Value*>(data)) : Value(),
-                       read_only, is_pre_painting == 1, processor_name,
+                       read_only, is_pre_painting, processor_name,
                        template_data, enable_recycle_template_bundle,
                        timing_option, options);
 }
 
 void LoadTemplateBundleByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
                                        jlong lifecycle, jstring j_url,
-                                       jlong bundlePtr, jint is_pre_painting,
-                                       jlong data, jboolean readOnly,
-                                       jstring processorName,
+                                       jlong bundlePtr,
+                                       jboolean is_pre_painting, jlong data,
+                                       jboolean readOnly, jstring processorName,
                                        jobject android_template_data,
                                        jint options, jobject j_timing_option) {
   // TODO(songshourui.null): add a method to get template_data with
@@ -609,7 +607,7 @@ void LoadTemplateBundleByPreParsedData(JNIEnv* env, jclass jcaller, jlong ptr,
   }
   auto pipeline_options =
       ProcessLoadTemplateTimingOption(env, ptr, j_timing_option, options);
-  pipeline_options->enable_pre_painting = (is_pre_painting == 1);
+  pipeline_options->enable_pre_painting = is_pre_painting;
 
   reinterpret_cast<LynxShell*>(ptr)->LoadTemplateBundle(
       url, std::move(copied_bundle), pipeline_options, template_data);

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -1303,36 +1303,26 @@ public class LynxTemplateRender
    */
   public void renderTemplateWithBaseUrl(
       byte[] template, TemplateData templateData, String baseUrl) {
-    if (mDevTool != null) {
-      mDevTool.onLoadFromLocalFile(template, templateData, baseUrl);
-    }
-
-    setUrl(baseUrl);
-    renderTemplate(template, templateData);
+    LynxLoadMeta.Builder metaBuilder = new LynxLoadMeta.Builder();
+    metaBuilder.setBinaryData(template);
+    metaBuilder.setInitialData(templateData);
+    metaBuilder.setUrl(baseUrl);
+    loadTemplate(metaBuilder.build());
     LLog.i(TAG, formatLynxMessage("renderTemplate"));
   }
 
   public void renderTemplateWithBaseUrl(byte[] template, Map<String, Object> data, String baseUrl) {
     TemplateData templateData = TemplateData.fromMap(data);
     templateData.markReadOnly();
-    if (mDevTool != null) {
-      mDevTool.onLoadFromLocalFile(template, templateData, baseUrl);
-    }
-
-    setUrl(baseUrl);
-    renderTemplate(template, templateData);
+    renderTemplateWithBaseUrl(template, templateData, baseUrl);
     LLog.i(TAG, formatLynxMessage("renderTemplate"));
   }
 
   public void renderTemplateWithBaseUrl(byte[] template, String stringData, String baseUrl) {
     TemplateData templateData = TemplateData.fromString(stringData);
     templateData.markReadOnly();
-    if (mDevTool != null) {
-      mDevTool.onLoadFromLocalFile(template, templateData, baseUrl);
-    }
-
     setUrl(baseUrl);
-    renderTemplate(template, templateData);
+    renderTemplateWithBaseUrl(template, templateData, baseUrl);
     LLog.i(TAG, formatLynxMessage("renderTemplate"));
   }
 
@@ -1414,75 +1404,19 @@ public class LynxTemplateRender
   }
 
   public void renderTemplate(final byte[] template, final Map<String, Object> initData) {
-    if (mHasDestroy) {
-      return;
-    }
-    if ((!mAsyncRender || reload) && !UIThreadUtils.isOnUiThread()) {
-      UIThreadUtils.runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          renderTemplate(template, initData);
-        }
-      });
-      return;
-    }
-
-    TimingOption timingOption = TimingOption.createTimingOption(
-        TimingConstants.LOAD_BUNDLE, TimingConstants.LOAD_BUNDLE_START);
-    if (mPerformanceController.isEmbeddedMode()) {
-      mPerformanceController.markTiming(TimingConstants.LOAD_BUNDLE_START, null);
-    }
-    this.prepareLynxEngineIfNeeded();
-    if (mNativePtr != 0) {
-      loadTemplate(template, initData, getTemplateUrl(), new TASMCallback(), timingOption);
-    }
+    LynxLoadMeta.Builder metaBuilder = new LynxLoadMeta.Builder();
+    metaBuilder.setBinaryData(template);
+    TemplateData initialData = TemplateData.fromMap(initData);
+    initialData.markReadOnly();
+    metaBuilder.setInitialData(initialData);
+    loadTemplate(metaBuilder.build());
   }
 
   public void renderTemplate(final byte[] template, final TemplateData templateData) {
-    if (mHasDestroy) {
-      return;
-    }
-    if ((!mAsyncRender || reload) && !UIThreadUtils.isOnUiThread()) {
-      UIThreadUtils.runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          renderTemplate(template, templateData);
-        }
-      });
-      return;
-    }
-
-    TimingOption timingOption = TimingOption.createTimingOption(
-        TimingConstants.LOAD_BUNDLE, TimingConstants.LOAD_BUNDLE_START);
-    if (mPerformanceController.isEmbeddedMode()) {
-      mPerformanceController.markTiming(TimingConstants.LOAD_BUNDLE_START, null);
-    }
-    this.prepareLynxEngineIfNeeded();
-    if (mNativePtr != 0) {
-      loadTemplate(template, templateData, getTemplateUrl(), new TASMCallback(), timingOption);
-    }
-    postRenderOrUpdateData(templateData);
-  }
-
-  private void renderTemplate(
-      final byte[] template, final String initData, TimingOption timingOption) {
-    if (mHasDestroy) {
-      return;
-    }
-    if ((!mAsyncRender || reload) && !UIThreadUtils.isOnUiThread()) {
-      UIThreadUtils.runOnUiThread(new Runnable() {
-        @Override
-        public void run() {
-          renderTemplate(template, initData, timingOption);
-        }
-      });
-      return;
-    }
-
-    this.prepareLynxEngineIfNeeded();
-    if (mNativePtr != 0) {
-      loadTemplate(template, initData, getTemplateUrl(), new TASMCallback(), timingOption);
-    }
+    LynxLoadMeta.Builder metaBuilder = new LynxLoadMeta.Builder();
+    metaBuilder.setBinaryData(template);
+    metaBuilder.setInitialData(templateData);
+    loadTemplate(metaBuilder.build());
   }
 
   @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -3524,44 +3458,16 @@ public class LynxTemplateRender
     }
   }
 
-  private void loadTemplate(byte[] template, TemplateData initData, String url,
-      NativeFacade.Callback callback, TimingOption timingOption) {
-    this.loadTemplate(template, initData, url, false, false, callback, timingOption);
-  }
-
-  private void loadTemplateByteBuffer(ByteBuffer template, TemplateData initData, String url,
+  private void loadTemplateByteBuffer(ByteBuffer buffer, TemplateData initData, String url,
       boolean isPrePainting, int options, boolean enableRecycleTemplateBundle,
       NativeFacade.Callback callback, TimingOption timingOption) {
-    if (template == null) {
+    if (buffer == null) {
       LLog.e(TAG, "Load Template with null template");
       return;
     }
-    if ((mNativeFacade == null) || (mNativePtr == 0)) {
-      LLog.e(TAG, "Load Template before inited");
-      return;
-    }
-    long nativePtr = 0;
-    String processorName = null;
-    boolean read_only = false;
-    if (initData != null) {
-      initData.flush();
-      nativePtr = initData.getNativePtr();
-      processorName = initData.processorName();
-      read_only = initData.isReadOnly();
-      initData.markConsumed();
-    }
-    if (nativePtr == 0) {
-      LLog.e(TAG, "Load Template with zero template data");
-    }
-    mNativeFacade.setUrl(url);
-    mNativeFacade.setCallback(callback);
-    //    mNativeFacade.setSize(template.length);
-    if (mDevTool != null) {
-      mDevTool.attachToDebugBridge(url);
-    }
 
-    nativeLoadTemplate(url, null, template, isPrePainting ? 1 : 0, enableRecycleTemplateBundle,
-        read_only, processorName, initData, options, timingOption);
+    nativeLoadTemplate(url, null, buffer, isPrePainting, enableRecycleTemplateBundle, initData,
+        options, timingOption, callback);
   }
 
   private void loadTemplate(byte[] template, TemplateData initData, String url,
@@ -3571,31 +3477,9 @@ public class LynxTemplateRender
       LLog.e(TAG, "Load Template with null template");
       return;
     }
-    if ((mNativeFacade == null) || (mNativePtr == 0)) {
-      LLog.e(TAG, "Load Template before inited");
-      return;
-    }
-    long nativePtr = 0;
-    String processorName = null;
-    boolean read_only = false;
-    if (initData != null) {
-      initData.flush();
-      nativePtr = initData.getNativePtr();
-      processorName = initData.processorName();
-      read_only = initData.isReadOnly();
-      initData.markConsumed();
-    }
-    if (nativePtr == 0) {
-      LLog.e(TAG, "Load Template with zero template data");
-    }
-    mNativeFacade.setUrl(url);
-    mNativeFacade.setCallback(callback);
-    mNativeFacade.setSize(template.length);
-    if (mDevTool != null) {
-      mDevTool.attachToDebugBridge(url);
-    }
-    nativeLoadTemplate(url, template, null, isPrePainting ? 1 : 0, enableRecycleTemplateBundle,
-        read_only, processorName, initData, 0, timingOption);
+
+    nativeLoadTemplate(url, template, null, isPrePainting, enableRecycleTemplateBundle, initData, 0,
+        timingOption, callback);
   }
 
   private void loadTemplateBundle(TemplateBundle bundle, String url, TemplateData initData,
@@ -3638,7 +3522,7 @@ public class LynxTemplateRender
     PageConfig.attachPageConfig(bundle.getPageConfig(), mLynxContext, mLynxUIRender);
     timingOption.markTiming(TimingConstants.FFI_START);
     nativeLoadTemplateBundleByPreParsedData(mNativePtr, mNativeLifecycle, url,
-        bundle.getNativePtr(), isPrePainting ? 1 : 0, nativePtr, read_only, processorName, initData,
+        bundle.getNativePtr(), isPrePainting, nativePtr, read_only, processorName, initData,
         options, timingOption.toJavaOnlyMap());
   }
 
@@ -3665,49 +3549,14 @@ public class LynxTemplateRender
         mNativePtr, mNativeLifecycle, ssr, nativePtr, readOnly, processorName, templateData);
   }
 
-  private void loadTemplate(byte[] template, String initData, String url,
-      NativeFacade.Callback callback, TimingOption timingOption) {
-    if ((mNativeFacade == null) || (mNativePtr == 0)) {
+  private void nativeLoadTemplate(String url, byte[] template, ByteBuffer buffer,
+      boolean isPrePainting, boolean enableRecycleTemplateBundle, TemplateData templateData,
+      int option, TimingOption timingOption, NativeFacade.Callback callback) {
+    if (mNativeFacade == null || mNativePtr == 0) {
       LLog.e(TAG, "Load Template before inited");
       return;
     }
-    if (template == null) {
-      LLog.e(TAG, "Load Template with null template");
-      return;
-    }
-    mNativeFacade.setUrl(url);
-    mNativeFacade.setCallback(callback);
-    mNativeFacade.setSize(template.length);
-    TemplateData templateData = TemplateData.fromString(initData);
-    templateData.flush();
-    templateData.markConsumed();
 
-    nativeLoadTemplate(url, template, null, 0, false, true, "", templateData, 0, timingOption);
-  }
-
-  private void loadTemplate(byte[] template, Map<String, Object> initData, String url,
-      NativeFacade.Callback callback, TimingOption timingOption) {
-    if ((mNativeFacade == null) || (mNativePtr == 0)) {
-      LLog.e(TAG, "Load Template before inited");
-      return;
-    }
-    if (template == null) {
-      LLog.e(TAG, "Load Template with null template");
-      return;
-    }
-    mNativeFacade.setUrl(url);
-    mNativeFacade.setCallback(callback);
-    mNativeFacade.setSize(template.length);
-    TemplateData templateData = TemplateData.fromMap(initData);
-    templateData.flush();
-    templateData.markConsumed();
-
-    nativeLoadTemplate(url, template, null, 0, false, true, "", templateData, 0, timingOption);
-  }
-
-  private void nativeLoadTemplate(String url, byte[] template, ByteBuffer buffer, int isPrePainting,
-      boolean enableRecycleTemplateBundle, boolean readOnly, String processorName,
-      TemplateData templateData, int options, TimingOption timingOption) {
     ILynxSecurityService securityService =
         LynxServiceCenter.inst().getService(ILynxSecurityService.class);
     if (securityService != null) {
@@ -3723,17 +3572,35 @@ public class LynxTemplateRender
       }
     }
 
+    if (mDevTool != null) {
+      mDevTool.attachToDebugBridge(url);
+    }
+    mNativeFacade.setUrl(url);
+    mNativeFacade.setCallback(callback);
+
+    long nativePtr = 0;
+    String processorName = null;
+    boolean readOnly = false;
+    if (templateData != null) {
+      templateData.flush();
+      nativePtr = templateData.getNativePtr();
+      processorName = templateData.processorName();
+      readOnly = templateData.isReadOnly();
+      templateData.markConsumed();
+    }
+
     // SecurityService is null, or Verified;
     timingOption.markTiming(TimingConstants.FFI_START);
-    long nativePtr = templateData == null ? 0 : templateData.getNativePtr();
 
     if (buffer != null) {
+      mNativeFacade.setSize(buffer.position());
       nativeLoadTemplateBufferByPreParsedData(mNativePtr, mNativeLifecycle, url, buffer,
           isPrePainting, enableRecycleTemplateBundle, nativePtr, readOnly, processorName,
-          templateData, options, timingOption.toJavaOnlyMap());
+          templateData, option, timingOption.toJavaOnlyMap());
     } else if (template != null) {
+      mNativeFacade.setSize(template.length);
       nativeLoadTemplateByPreParsedData(mNativePtr, mNativeLifecycle, url, template, isPrePainting,
-          enableRecycleTemplateBundle, nativePtr, readOnly, processorName, templateData, options,
+          enableRecycleTemplateBundle, nativePtr, readOnly, processorName, templateData, option,
           timingOption.toJavaOnlyMap());
     } else {
       LLog.e(TAG, "loadTemplate with empty template or buffer.");
@@ -4285,17 +4152,17 @@ public class LynxTemplateRender
 
   // FIXME(songshourui.null): only use templateData later
   private static native void nativeLoadTemplateByPreParsedData(long ptr, long lifecycle, String url,
-      byte[] temp, int isPrePainting, boolean enableRecycleTemplateBundle, long data,
+      byte[] temp, boolean isPrePainting, boolean enableRecycleTemplateBundle, long data,
       boolean readOnly, String processorName, TemplateData templateData, int options,
       ReadableMap timingOption);
 
   // FIXME(songshourui.null): only use templateData later
   private static native void nativeLoadTemplateBundleByPreParsedData(long ptr, long lifecycle,
-      String url, long bundlePtr, int isPrePainting, long data, boolean readOnly,
+      String url, long bundlePtr, boolean isPrePainting, long data, boolean readOnly,
       String processorName, TemplateData templateData, int options, ReadableMap timingOption);
 
   private static native void nativeLoadTemplateBufferByPreParsedData(long ptr, long lifecycle,
-      String url, ByteBuffer temp, int isPrePainting, boolean enableRecycleTemplateBundle,
+      String url, ByteBuffer temp, boolean isPrePainting, boolean enableRecycleTemplateBundle,
       long data, boolean readOnly, String processorName, TemplateData templateData, int options,
       ReadableMap timingOption);
 


### PR DESCRIPTION
Unify renderTemplate serias api to `loadTemplate(LynxLoadMeta)` making LynxTemplateRender clear.

- Unify renderTemplate serias api to `loadTemplate(LynxLoadMeta)`
- Move template data extraction (getNativePtr, processorName, isReadOnly) to just before native call to avoid unnecessary processing when template data is null.
- Defer template data processing until needed in nativeLoadTemplate
- Simplify nativeLoadTemplate method signatures by removing redundant parameters
- Ensure flush() is only called when template data will be used
- passing `isPrePainting` params as jboolean to C++, it's int before.

issue: f-97826365
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
