### PR TITLE
[BugFix] ensure ResponseHandler listener safe with weakRef.

### DIFF
--- a/core/runtime/bindings/jsi/resource/response_handler_in_js.cc
+++ b/core/runtime/bindings/jsi/resource/response_handler_in_js.cc
@@ -99,16 +99,22 @@ Value ResponseHandlerInJS::AddListenerForResponse(Runtime& rt) {
           }
 
           piper::Function func = args[0].getObject(rt).getFunction(rt);
-          AddResourceListener([this, func = std::move(func)](
-                                  tasm::BundleResourceInfo info) mutable {
-            auto ptr = native_app_.lock();
-            if (ptr && !ptr->IsDestroying()) {
-              auto rt = ptr->GetRuntime();
-              if (rt != nullptr) {
-                func.call(*rt, ConvertBundleInfoToPiperValue(info));
-              }
-            }
-          });
+          AddResourceListener(
+              [weak_self = weak_from_this(),
+               func = std::move(func)](tasm::BundleResourceInfo info) mutable {
+                auto self = weak_self.lock();
+                if (self) {
+                  auto ptr = self->native_app_.lock();
+                  if (ptr && !ptr->IsDestroying()) {
+                    auto rt = ptr->GetRuntime();
+                    if (rt != nullptr) {
+                      func.call(
+                          *ptr->GetRuntime(),
+                          self->ConvertBundleInfoToPiperValue(std::move(info)));
+                    }
+                  }
+                }
+              });
         }
         return piper::Value::undefined();
       });

--- a/core/runtime/bindings/lepus/renderer_functions.cc
+++ b/core/runtime/bindings/lepus/renderer_functions.cc
@@ -771,11 +771,12 @@ RENDERER_FUNCTION_CC(AddListenerForResponse) {
   ResponseHandlerInLepus* response_handler =
       ResponseHandlerInLepus::GetResponseHandlerFromLepusValue(binding_proxy);
   response_handler->AddResourceListener(
-      [ctx = LEPUS_CONTEXT(), &arg0](tasm::BundleResourceInfo bundle_info) {
+      [ctx = LEPUS_CONTEXT(),
+       arg = *arg0](tasm::BundleResourceInfo bundle_info) {
         auto value = bundle_info.ConvertToLepusValue();
         std::vector<lepus::Value> param;
         param.push_back(value);
-        ctx->CallClosureArgs(*arg0, param);
+        ctx->CallClosureArgs(arg, param);
       });
   RETURN_UNDEFINED()
 }


### PR DESCRIPTION
to ensure ResponseHandler safe with weakRef to avoid danling pointer issues.

issue: f-89723756
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
