### PR TITLE
[Optimize][DevTool][Android] Introduce DevToolLifecycle state machine…

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -1432,11 +1432,34 @@ public class com::lynx::tasm::utils::DeviceUtils :  {
   public static float com.lynx.tasm.utils.DeviceUtils.getRefreshRate(Context context);
 }
 
+public class com::lynx::devtoolwrapper::DevToolLifecycle :  {
+  public static DevToolLifecycle com.lynx.devtoolwrapper.DevToolLifecycle.getInstance();
+  public DevToolState com.lynx.devtoolwrapper.DevToolLifecycle.getState();
+  public boolean com.lynx.devtoolwrapper.DevToolLifecycle.isAttached();
+  public boolean com.lynx.devtoolwrapper.DevToolLifecycle.isInitialized();
+  public boolean com.lynx.devtoolwrapper.DevToolLifecycle.isEnabled();
+  public boolean com.lynx.devtoolwrapper.DevToolLifecycle.isConnected();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onAttached();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onEnabled();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onDisabled();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onInitialized();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onConnected();
+  public synchronized void com.lynx.devtoolwrapper.DevToolLifecycle.onDisconnected();
+}
+
 public class com::lynx::devtoolwrapper::DevToolOverlayDelegate :  {
   public static DevToolOverlayDelegate com.lynx.devtoolwrapper.DevToolOverlayDelegate.getInstance();
   public ArrayList< Dialog > com.lynx.devtoolwrapper.DevToolOverlayDelegate.getGlobalOverlayView();
   public ArrayList< Integer > com.lynx.devtoolwrapper.DevToolOverlayDelegate.getAllVisibleOverlaySign();
   public void com.lynx.devtoolwrapper.DevToolOverlayDelegate.init(OverlayService service);
+}
+
+public enum com::lynx::devtoolwrapper::DevToolState {
+  public com.lynx.devtoolwrapper.DevToolState.UNAVAILABLE UNAVAILABLE;
+  public com.lynx.devtoolwrapper.DevToolState.ATTACHED ATTACHED;
+  public com.lynx.devtoolwrapper.DevToolState.ENABLED ENABLED;
+  public com.lynx.devtoolwrapper.DevToolState.INITIALIZED INITIALIZED;
+  public com.lynx.devtoolwrapper.DevToolState.CONNECTED CONNECTED;
 }
 
 public interface com::lynx::tasm::image::model::DiskCacheChoice {

--- a/platform/android/lynx_android/src/android_test/java/com/lynx/devtoolwrapper/DevToolLifecycleTest.java
+++ b/platform/android/lynx_android/src/android_test/java/com/lynx/devtoolwrapper/DevToolLifecycleTest.java
@@ -1,0 +1,114 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.devtoolwrapper;
+
+import static org.junit.Assert.*;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class DevToolLifecycleTest {
+  private DevToolLifecycle mLifecycle;
+
+  @Before
+  public void setUp() {
+    mLifecycle = DevToolLifecycle.getInstance();
+    mLifecycle.reset();
+  }
+
+  @Test
+  public void testInitialState() {
+    assertEquals(DevToolState.UNAVAILABLE, mLifecycle.getState());
+    assertFalse(mLifecycle.isAttached());
+    assertFalse(mLifecycle.isEnabled());
+    assertFalse(mLifecycle.isInitialized());
+    assertFalse(mLifecycle.isConnected());
+  }
+
+  @Test
+  public void testOnAttached() {
+    mLifecycle.onAttached();
+    assertEquals(DevToolState.ATTACHED, mLifecycle.getState());
+    assertTrue(mLifecycle.isAttached());
+    assertFalse(mLifecycle.isEnabled());
+  }
+
+  @Test
+  public void testOnEnabled() {
+    mLifecycle.onAttached();
+    mLifecycle.onEnabled();
+    assertEquals(DevToolState.ENABLED, mLifecycle.getState());
+    assertTrue(mLifecycle.isEnabled());
+    assertFalse(mLifecycle.isInitialized());
+  }
+
+  @Test
+  public void testOnInitialized() {
+    mLifecycle.onAttached();
+    mLifecycle.onEnabled();
+    mLifecycle.onInitialized();
+    assertEquals(DevToolState.INITIALIZED, mLifecycle.getState());
+    assertTrue(mLifecycle.isInitialized());
+    assertFalse(mLifecycle.isConnected());
+  }
+
+  @Test
+  public void testOnConnected() {
+    mLifecycle.onAttached();
+    mLifecycle.onEnabled();
+    mLifecycle.onInitialized();
+    mLifecycle.onConnected();
+    assertEquals(DevToolState.CONNECTED, mLifecycle.getState());
+    assertTrue(mLifecycle.isConnected());
+  }
+
+  @Test
+  public void testOnDisconnected() {
+    mLifecycle.onAttached();
+    mLifecycle.onEnabled();
+    mLifecycle.onInitialized();
+    mLifecycle.onConnected();
+
+    mLifecycle.onDisconnected();
+    assertEquals(DevToolState.INITIALIZED, mLifecycle.getState());
+  }
+
+  @Test
+  public void testOnDisabled() {
+    mLifecycle.onAttached();
+    mLifecycle.onEnabled();
+    mLifecycle.onInitialized();
+
+    mLifecycle.onDisabled();
+    assertEquals(DevToolState.ATTACHED, mLifecycle.getState());
+
+    // Re-enable to check if we can go back
+    mLifecycle.onEnabled();
+    mLifecycle.onInitialized();
+    mLifecycle.onConnected();
+    mLifecycle.onDisabled();
+    assertEquals(DevToolState.ATTACHED, mLifecycle.getState());
+  }
+
+  @Test
+  public void testInvalidTransitions() {
+    // Cannot go UNAVAILABLE -> ENABLED directly
+    mLifecycle.onEnabled();
+    assertEquals(DevToolState.UNAVAILABLE, mLifecycle.getState());
+
+    // Cannot go ATTACHED -> INITIALIZED directly (need ENABLED first)
+    mLifecycle.onAttached();
+    mLifecycle.onInitialized();
+    assertEquals(DevToolState.ATTACHED, mLifecycle.getState());
+
+    // Cannot go ENABLED -> CONNECTED directly (need INITIALIZED first)
+    mLifecycle.onEnabled();
+    mLifecycle.onConnected();
+    assertEquals(DevToolState.ENABLED, mLifecycle.getState());
+  }
+}

--- a/platform/android/lynx_android/src/android_test/java/com/lynx/devtoolwrapper/DevToolStateTest.java
+++ b/platform/android/lynx_android/src/android_test/java/com/lynx/devtoolwrapper/DevToolStateTest.java
@@ -1,0 +1,36 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.devtoolwrapper;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class DevToolStateTest {
+  /**
+   * DevToolLifecycle uses Enum.ordinal() to compare states
+   * (e.g. isAttached() checks state >= ATTACHED).
+   * This test ensures that the order of constants in DevToolState enum
+   * remains correct for those comparisons.
+   * <p>
+   * Expected order:
+   * 1. UNAVAILABLE
+   * 2. ATTACHED
+   * 3. ENABLED
+   * 4. INITIALIZED
+   * 5. CONNECTED
+   */
+  @Test
+  public void testStateOrdinality() {
+    assertTrue("ATTACHED should be after UNAVAILABLE",
+        DevToolState.ATTACHED.ordinal() > DevToolState.UNAVAILABLE.ordinal());
+    assertTrue("ENABLED should be after ATTACHED",
+        DevToolState.ENABLED.ordinal() > DevToolState.ATTACHED.ordinal());
+    assertTrue("INITIALIZED should be after ENABLED",
+        DevToolState.INITIALIZED.ordinal() > DevToolState.ENABLED.ordinal());
+    assertTrue("CONNECTED should be after INITIALIZED",
+        DevToolState.CONNECTED.ordinal() > DevToolState.INITIALIZED.ordinal());
+  }
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolLifecycle.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolLifecycle.java
@@ -1,0 +1,139 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.devtoolwrapper;
+
+import androidx.annotation.RestrictTo;
+import com.lynx.tasm.base.LLog;
+
+/**
+ * Manages the state transitions for the DevTool.
+ * Ensures valid transitions between states like UNAVAILABLE, ATTACHED, INITIALIZED, etc.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+public class DevToolLifecycle {
+  private static final String TAG = "DevToolLifecycle";
+  private volatile DevToolState mState = DevToolState.UNAVAILABLE;
+
+  private static volatile DevToolLifecycle sInstance;
+
+  private DevToolLifecycle() {}
+
+  public static DevToolLifecycle getInstance() {
+    if (sInstance == null) {
+      synchronized (DevToolLifecycle.class) {
+        if (sInstance == null) {
+          sInstance = new DevToolLifecycle();
+        }
+      }
+    }
+    return sInstance;
+  }
+
+  public DevToolState getState() {
+    return mState;
+  }
+
+  public boolean isAttached() {
+    return mState.ordinal() >= DevToolState.ATTACHED.ordinal();
+  }
+
+  public boolean isInitialized() {
+    return mState.ordinal() >= DevToolState.INITIALIZED.ordinal();
+  }
+
+  public boolean isEnabled() {
+    return mState.ordinal() >= DevToolState.ENABLED.ordinal();
+  }
+
+  public boolean isConnected() {
+    return mState.ordinal() >= DevToolState.CONNECTED.ordinal();
+  }
+
+  /**
+   * Called when the DevTool component is detected (e.g., via reflection).
+   * Transition: UNAVAILABLE -> ATTACHED
+   */
+  public synchronized void onAttached() {
+    if (mState == DevToolState.UNAVAILABLE) {
+      LLog.i(TAG, "DevTool attached. Transitioning to ATTACHED.");
+      mState = DevToolState.ATTACHED;
+    } else {
+      LLog.w(TAG, "onAttached() called but state is " + mState);
+    }
+  }
+
+  /**
+   * Called when DevTool is enabled (by policy or user switch).
+   * Transition: ATTACHED -> ENABLED
+   */
+  public synchronized void onEnabled() {
+    if (mState == DevToolState.ATTACHED) {
+      LLog.i(TAG, "DevTool enabled. Transitioning to ENABLED.");
+      mState = DevToolState.ENABLED;
+    } else if (mState == DevToolState.UNAVAILABLE) {
+      LLog.w(TAG, "Cannot enable DevTool because it is " + mState);
+    } else {
+      // Already enabled or further along
+      LLog.d(TAG, "onEnabled() called but state is " + mState);
+    }
+  }
+
+  /**
+   * Called when DevTool is disabled (by policy or user switch).
+   * Transition: ENABLED/INITIALIZED/CONNECTED -> ATTACHED
+   */
+  public synchronized void onDisabled() {
+    if (mState == DevToolState.ENABLED || mState == DevToolState.INITIALIZED
+        || mState == DevToolState.CONNECTED) {
+      LLog.i(TAG, "DevTool disabled. Transitioning to ATTACHED.");
+      mState = DevToolState.ATTACHED;
+    }
+  }
+
+  /**
+   * Called when the DevTool env is initialized, i.e. native library is loaded.
+   * Transition: ENABLED -> INITIALIZED
+   */
+  public synchronized void onInitialized() {
+    if (mState == DevToolState.ENABLED) {
+      LLog.i(TAG, "DevTool env initialized. Transitioning to INITIALIZED.");
+      mState = DevToolState.INITIALIZED;
+    }
+  }
+
+  /**
+   * Called when a DevTool client connects.
+   * Transition: INITIALIZED -> CONNECTED
+   */
+  public synchronized void onConnected() {
+    if (mState == DevToolState.INITIALIZED) {
+      LLog.i(TAG, "DevTool client connected. Transitioning to CONNECTED.");
+      mState = DevToolState.CONNECTED;
+    }
+  }
+
+  /**
+   * Called when a DevTool client disconnects.
+   * Transition: CONNECTED -> INITIALIZED
+   */
+  public synchronized void onDisconnected() {
+    if (mState == DevToolState.CONNECTED) {
+      LLog.i(TAG, "DevTool client disconnected. Transitioning to INITIALIZED.");
+      mState = DevToolState.INITIALIZED;
+    }
+  }
+
+  private synchronized void syncStateWithNative() {
+    // TODO(mitchilling): Implement the logic to sync the DevTool state with the native side.
+    // This method should be called each time the state changes.
+  }
+
+  /**
+   * Stay default (package-private) accessibility for testing purpose.
+   */
+  void reset() {
+    mState = DevToolState.UNAVAILABLE;
+  }
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolState.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/devtoolwrapper/DevToolState.java
@@ -1,0 +1,60 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.devtoolwrapper;
+
+/**
+ * Represents the lifecycle states of the DevTool.
+ *
+ * <pre>
+ * State Transition Graph:
+ *
+ * [UNAVAILABLE]
+ *      |
+ *      | (onAttached)
+ *      v
+ *   [ATTACHED] <------------------------------------+
+ *      |                                            |
+ *      | (onEnabled)                                |
+ *      v                                            |
+ *    [ENABLED]                                      |
+ *      |                                            |
+ *      | (onInitialized)                            |
+ *      v                                            |
+ *   [INITIALIZED] <----------+                      | (onDisabled)
+ *      |                     |                      |
+ *      | (onConnected)       | (onDisconnected)     |
+ *      v                     |                      |
+ *  [CONNECTED]  -------------+                      |
+ *      |                                            |
+ *      +--------------------------------------------+
+ * </pre>
+ */
+public enum DevToolState {
+  /**
+   * DevTool is not integrated into the application.
+   */
+  UNAVAILABLE,
+
+  /**
+   * DevTool is present, but disabled by app policy or user switch.
+   */
+  ATTACHED,
+
+  /**
+   * DevTool is enabled by app policy or user switch, waiting for initialization.
+   */
+  ENABLED,
+
+  /**
+   * DevTool environment is initialized (e.g. all necessary native libraries loaded)
+   * and ready to connect.
+   */
+  INITIALIZED,
+
+  /**
+   * Active inspection or debugging session in progress.
+   */
+  CONNECTED
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnv.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnv.java
@@ -23,6 +23,7 @@ import com.lynx.BuildConfig;
 import com.lynx.base.IBaseNativeLibraryLoader;
 import com.lynx.base.LynxBaseEnv;
 import com.lynx.config.LynxLiteConfigs;
+import com.lynx.devtoolwrapper.DevToolLifecycle;
 import com.lynx.devtoolwrapper.LynxDevToolUtils;
 import com.lynx.jsbridge.LynxBytecodeCallback;
 import com.lynx.jsbridge.LynxModule;
@@ -95,6 +96,7 @@ public class LynxEnv {
   protected BehaviorBundle mViewManagerBundle;
   protected final AtomicBoolean hasInit = new AtomicBoolean(false);
   /**
+   * TODO(mitchilling): Remove this comment block after DevToolLifecycle is refactored.
    * mDevToolComponentAttach: indicates whether DevTool Component is attached to
    * the host.
    * mDevToolEnabled: control whether to enable DevTool Debug
@@ -115,7 +117,6 @@ public class LynxEnv {
    * enable/disable
    * DevTool Debug, and useless is host doesn't attach DevTool
    */
-  protected boolean mDevToolComponentAttach = false;
   protected boolean mDebugModeEnabled = false;
   protected boolean mLayoutOnlyEnabled = true;
   protected boolean mRecordEnable = false;
@@ -189,6 +190,7 @@ public class LynxEnv {
 
   protected final Object mLazyInitLock = new Object();
 
+  // FIXME(mitchilling): devtoolService is retrieved every time when it's about to be used.
   private static ILynxDevToolService devtoolService = null;
 
   private Boolean mHasV8BridgeLoadSuccess = false;
@@ -751,13 +753,14 @@ public class LynxEnv {
   // otherwise will cause endless loop.
   // Because this method used by LLog.
   //------------warning----------------
+  /*
+   * Deprecated. Use `DevToolLifecycle.getInstance().isEnabled()` instead.
+   */
+  @Deprecated
   public boolean isLynxDebugEnabled() {
     // Return true only if the DevTool Component is attached and the `lynxDebugPresetValue` is true.
     // It avoids unnecessary reflection calls.
-    ILynxDevToolService devtoolService =
-        LynxServiceCenter.inst().getService(ILynxDevToolService.class);
-    return mDevToolComponentAttach
-        && (devtoolService != null && devtoolService.getLynxDebugPresetValue());
+    return DevToolLifecycle.getInstance().isEnabled();
   }
 
   // Provided for hosts that load the DevTool component after initializing
@@ -774,14 +777,35 @@ public class LynxEnv {
     syncDevtoolComponentAttachSwitch();
   }
 
+  /*
+   * This method could be called before or after `LynxEnv.init()`
+   * In order to make it work as expected in both usages:
+   * - if before, we preset value for later use;
+   * - if after, we change the state of `DevToolLifecycle` directly,
+   *     and call `initDevtoolEnv()` if the parameter is true.
+   */
   public void enableLynxDebug(boolean enableLynxDebug) {
     LLog.i(TAG, enableLynxDebug ? "enable lynx debug" : "disable lynx debug");
-    ILynxDevToolService devtoolService =
-        LynxServiceCenter.inst().getService(ILynxDevToolService.class);
-    if (devtoolService != null) {
-      devtoolService.setLynxDebugPresetValue(enableLynxDebug);
+    if (!DevToolLifecycle.getInstance().isAttached()) {
+      // DevTool is UNAVAILABLE (i.e. before ATTACHED)
+      // We need to take advantage of preset value.
+      ILynxDevToolService devtoolService =
+          LynxServiceCenter.inst().getService(ILynxDevToolService.class);
+      if (devtoolService != null) {
+        devtoolService.setLynxDebugPresetValue(enableLynxDebug);
+      }
+      // No further action required
+      return;
     }
-    initDevtoolEnv();
+
+    // DevTool is at least ATTACHED
+    if (enableLynxDebug) {
+      DevToolLifecycle.getInstance().onEnabled();
+      initDevtoolEnv();
+    } else {
+      DevToolLifecycle.getInstance().onDisabled();
+    }
+
     if (mIsNativeLibraryLoaded) {
       setBooleanLocalEnv(LynxEnvKey.LYNX_DEBUG_ENABLED, isLynxDebugEnabled());
     }
@@ -789,27 +813,54 @@ public class LynxEnv {
 
   protected void initDevtoolComponentAttachSwitch() {
     devtoolService = LynxServiceCenter.inst().getService(ILynxDevToolService.class);
+    boolean attached = false;
     if (devtoolService != null) {
-      mDevToolComponentAttach = devtoolService.isDevtoolAttached();
-    } else {
-      mDevToolComponentAttach = false;
+      attached = devtoolService.isDevtoolAttached();
     }
-    LLog.i(TAG,
-        "The current application has embedded the DevTool Component: " + mDevToolComponentAttach);
+    if (attached) {
+      DevToolLifecycle.getInstance().onAttached();
+      enableDevToolIfPreset();
+    }
+    LLog.i(TAG, "The current application has embedded the DevTool Component: " + attached);
   }
 
+  /*
+   * In some cases, e.g. DevTool working as a plugin,
+   * callers would enable DevTool via presetting before attaching.
+   * So we ought to check the preset value and change to state `ENABLED`.
+   */
+  private void enableDevToolIfPreset() {
+    if (!DevToolLifecycle.getInstance().isAttached()) {
+      // Wrong state, shortcut.
+      return;
+    }
+    if (devtoolService == null) {
+      devtoolService = LynxServiceCenter.inst().getService(ILynxDevToolService.class);
+    }
+    if (devtoolService == null) {
+      // service not registered, thus there won't be preset value. We'll just ignore it.
+      return;
+    }
+    if (devtoolService.getLynxDebugPresetValue()) {
+      DevToolLifecycle.getInstance().onEnabled();
+    }
+  }
+
+  // TODO(mitchilling): Remove this method after DevToolLifecycle is refactored.
   protected void syncDevtoolComponentAttachSwitch() {
     // Since the default value in native is false, we only sync to native when the
     // value is true,
     // which can reduce native calls.
-    if (isNativeLibraryLoaded() && mDevToolComponentAttach) {
+    if (isNativeLibraryLoaded() && isDevtoolComponentAttach()) {
       setBooleanLocalEnv(LynxEnvKey.DEVTOOL_COMPONENT_ATTACH, true);
       setBooleanLocalEnv(LynxEnvKey.LYNX_DEBUG_ENABLED, isLynxDebugEnabled());
     }
   }
 
+  // TODO(mitchilling): Remove this method after DevToolLifecycle is refactored.
+  @Deprecated
   public boolean isDevtoolComponentAttach() {
-    return mDevToolComponentAttach;
+    return DevToolLifecycle.getInstance().isAttached();
   }
 
   public boolean isDevtoolEnabled() {

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnvKey.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxEnvKey.java
@@ -19,7 +19,8 @@ public enum LynxEnvKey {
   ENABLE_IMAGE_MEMORY_REPORT("enable_image_memory_report"),
   ENABLE_COMPONENT_STATISTIC_REPORT("enable_component_statistic_report"),
   ENABLE_TRANSFORM_FOR_POSITION_CALCULATION("enable_transform_for_position_calculation"),
-  DEVTOOL_COMPONENT_ATTACH("devtool_component_attach"),
+  // TODO(mitchilling): Remove deprecated keys after setting up state machine in native
+  @Deprecated DEVTOOL_COMPONENT_ATTACH("devtool_component_attach"),
   ENABLE_GENERIC_LYNX_RESOURCE_FETCHER_FONT_KEY("enable_generic_lynx_resource_fetcher_font"),
   ENABLE_VSYNC_ALIGNED_MESSAGE_LOOP_GLOBAL("enable_vsync_aligned_message_loop_global"),
   FORCE_LAYOUT_ON_BACKGROUND_THREAD("force_layout_on_background_thread"),
@@ -46,7 +47,7 @@ public enum LynxEnvKey {
   ENABLE_DATA_LIST_FIX("enable_data_list_fix"),
   FSP_ENABLE("enable_fsp"),
   FSP_CONFIG_JSON_STRING("fsp_config_json_string"),
-  LYNX_DEBUG_ENABLED("lynx_debug_enabled"),
+  @Deprecated LYNX_DEBUG_ENABLED("lynx_debug_enabled"),
   INIT_DISPLAY_METRICS_IN_ENV("init_display_metrics_in_env");
 
   private final String description;
@@ -68,7 +69,8 @@ public enum LynxEnvKey {
       ENABLE_VSYNC_ALIGNED_FLUSH.getDescription();
 
   // Keys for devtool.
-  public static final String KEY_LYNX_DEBUG_ENABLED = "lynx_debug_enabled";
+  @Deprecated public static final String KEY_LYNX_DEBUG_ENABLED = "lynx_debug_enabled";
+  @Deprecated
   public static final String KEY_DEVTOOL_COMPONENT_ATTACH =
       DEVTOOL_COMPONENT_ATTACH.getDescription();
   public static final String SP_KEY_ENABLE_DEVTOOL = "enable_devtool";
@@ -83,7 +85,7 @@ public enum LynxEnvKey {
   public static final String SP_KEY_IGNORE_ERROR_TYPES = "ignore_error_types";
   public static final String SP_KEY_ENABLE_IGNORE_ERROR_CSS = "error_code_css";
   public static final String SP_KEY_ENABLE_PIXEL_COPY = "enable_pixel_copy";
-  public static final String SP_KEY_DEVTOOL_CONNECTED = "devtool_connected";
+  @Deprecated public static final String SP_KEY_DEVTOOL_CONNECTED = "devtool_connected";
   public static final String SP_KEY_ENABLE_QUICKJS_DEBUG = "enable_quickjs_debug";
   public static final String SP_KEY_ENABLE_PREVIEW_SCREEN_SHOT = "enable_preview_screen_shot";
   public static final String SP_KEY_ACTIVATED_CDP_DOMAINS = "activated_cdp_domains";

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxDevtoolEnv.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxDevtoolEnv.java
@@ -11,6 +11,7 @@ import androidx.annotation.Keep;
 import com.example.lynxdevtool.BuildConfig;
 import com.lynx.config.LynxLiteConfigs;
 import com.lynx.devtool.memory.MemoryController;
+import com.lynx.devtoolwrapper.DevToolLifecycle;
 import com.lynx.tasm.INativeLibraryLoader;
 import com.lynx.tasm.LynxEnv;
 import com.lynx.tasm.LynxEnvKey;
@@ -108,6 +109,11 @@ public class LynxDevtoolEnv {
     } catch (Throwable t) {
       LLog.e(TAG, t.toString());
       throw t;
+    }
+    // All initializations are done. Let's notify DevToolLifecycle.
+    DevToolLifecycle.getInstance().onInitialized();
+    if (LynxGlobalDebugBridge.getInstance().isEnabled()) {
+      DevToolLifecycle.getInstance().onConnected();
     }
   }
 

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxGlobalDebugBridge.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/LynxGlobalDebugBridge.java
@@ -15,6 +15,7 @@ import com.lynx.debugrouter.ConnectionType;
 import com.lynx.debugrouter.DebugRouter;
 import com.lynx.debugrouter.DebugRouterGlobalHandler;
 import com.lynx.debugrouter.StateListener;
+import com.lynx.devtoolwrapper.DevToolLifecycle;
 import com.lynx.devtoolwrapper.LynxDevtoolCardListener;
 import com.lynx.tasm.LynxEnv;
 import com.lynx.tasm.LynxEnvKey;
@@ -131,6 +132,11 @@ public class LynxGlobalDebugBridge
   @Override
   public void onClose(int code, String reason) {
     enableTraceMode(false);
+    // FIXME(mitchilling): Theoretically, we should notify the DevToolLifecycle
+    // to update the state to DISCONNECTED.
+    // However, at the moment onClose() and onOpen() are called multiple times back and forth.
+    // I need to look into debug router to find out the root cause.
+    // For now, let's not update the state yet.
   }
 
   private void enableTraceMode(boolean enable) {
@@ -149,6 +155,7 @@ public class LynxGlobalDebugBridge
   @Override
   public void onOpen(ConnectionType type) {
     LynxDevtoolEnv.inst().setDevtoolEnv(LynxEnvKey.SP_KEY_DEVTOOL_CONNECTED, true);
+    DevToolLifecycle.getInstance().onConnected();
   }
 
   @Override


### PR DESCRIPTION
… to simplify switches

This commit refactors the complex DevTool switch logic in `LynxEnv` by introducing a `DevToolLifecycle` state machine. Key changes include:
- Defined states in `DevToolState` Enum.
- In `DevToolLifecycle` managed state transitions with validation and provided helper methods like `isAttached()` to abstract state comparisons.
- Updated some usage of switches in `LynxEnv`. 
We still have a lot to do like the implementation in native and iOS, updating the usage of other switches. Those will come in the following changes.
