### PR TITLE
[BugFix] add missing property to LoadLepusChunk options

### DIFF
--- a/js_libraries/type-element-api/types/element-api.d.ts
+++ b/js_libraries/type-element-api/types/element-api.d.ts
@@ -316,7 +316,7 @@ declare global {
 
   function __InvokeUIMethod(e: ElementRef, method: string, params: Record<string, unknown>, callback: (res: { code: number; data: unknown }) => void): ElementRef[];
 
-  function __LoadLepusChunk(name: string, cfg: { chunkType: number }): void;
+  function __LoadLepusChunk(name: string, cfg: { chunkType: number; dynamicComponentEntry?: string }): boolean;
 
   function __CreateGestureDetector(
     node: ElementRef,


### PR DESCRIPTION
the dynamicComponentEntry key does exist in the c++ backend and it is used while the type doesn't. This change adds it.

reactLynx does define it here: https://github.com/lynx-family/lynx-stack/blob/d66886574e11c4d17dfa1643ccad5c6e82b6abbb/packages/react/worklet-runtime/src/types/elementApi.d.ts#L31

but i want to use the types package provided by this repo rather than redefining it.

EDIT: also update the return type

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
