### PR TITLE
[BugFix] Make decode_wasm async and remove duplicate definition

### DIFF
--- a/oliver/lynx-tasm/CHANGELOG.md
+++ b/oliver/lynx-tasm/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-# 0.0.25
+# 0.0.26
 * fix `Module.__malloc` not found issue. #5150
 
 # 0.0.24

--- a/oliver/lynx-tasm/index.js
+++ b/oliver/lynx-tasm/index.js
@@ -101,8 +101,8 @@ function decode_napi(templateJS) {
   return JSON.parse(res.result);
 }
 
-function decode_wasm(buffer) {
-  const Module = loadModule();
+async function decode_wasm(buffer) {
+  const Module = await loadModule();
   // console.log(templateJs);
   // const uint8array = new Uint8Array(templateJs.size());
   // const res = m._decode(uint8array);
@@ -120,27 +120,6 @@ function decode_wasm(buffer) {
     throw new Error(`decode error: ${res.result}`);
   }
   return JSON.parse(res.result);
-}
-
-function decode_wasm(buffer) {
-  const Module = loadModule();
-  // console.log(templateJs);
-  // const uint8array = new Uint8Array(templateJs.size());
-  // const res = m._decode(uint8array);
-  const byteArray = new Uint8Array(buffer);
-  const byteArrayLength = byteArray.length;
-  // Allocate memory in the Emscripten heap
-  const byteArrayPtr = Module._malloc(byteArrayLength);
-  // Copy the data to the Emscripten heap
-  Module.HEAPU8.set(byteArray, byteArrayPtr);
-  // Call the C++ function
-  const res = Module._decode(byteArrayPtr, byteArrayLength);
-  // Free the allocated memory
-  Module._free(byteArrayPtr);
-  if (res.status !== 0) {
-    throw new Error(`decode error: ${res.result}`);
-  }
-  return res;
 }
 
 let encode = encode_napi;

--- a/oliver/lynx-tasm/package.json
+++ b/oliver/lynx-tasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/tasm",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Changes:
- Changed decode_wasm to async function with awaited loadModule()
- Removed duplicate decode_wasm function definition

issue: #5150
AutoSubmit: true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
