### PR TITLE
[Infra] Run E2E task with unobfuscated app in ci pipeline

### DIFF
--- a/.github/actions/android-explorer-build/action.yml
+++ b/.github/actions/android-explorer-build/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Set project properties for gradle when building explorer
     required: false
     default: ''
+  build-type:
+    description: The build type of the explorer apk
+    required: false
+    default: 'release'
 
 runs:
   using: composite
@@ -27,11 +31,13 @@ runs:
         cd $GITHUB_WORKSPACE/lynx
         source tools/envsetup.sh
         pushd explorer/android
-        ./gradlew :LynxExplorer:assembleNoasanRelease -Penable_trace=perfetto -PabiList=${{ inputs.abi-list }} -no-daemon ${{ inputs.build-params }}
+        build_type='${{ inputs.build-type }}'
+        build_type_capitalized="${build_type^}"
+        ./gradlew :LynxExplorer:assembleNoasan${build_type_capitalized} -Penable_trace=perfetto -PabiList=${{ inputs.abi-list }} -no-daemon ${{ inputs.build-params }}
         popd
     - name: upload artifact
       uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
       continue-on-error: true
       with:
         name: android-lynx-explorer
-        path: '${{ github.workspace }}/lynx/explorer/android/lynx_explorer/build/outputs/apk/noasan/release/LynxExplorer-noasan-release.apk'
+        path: '${{ github.workspace }}/lynx/explorer/android/lynx_explorer/build/outputs/apk/noasan/${{ inputs.build-type }}/LynxExplorer-noasan-${{ inputs.build-type }}.apk'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,7 @@ jobs:
         with:
           abi-list: x86,arm64-v8a
           build-params: -PIntegrationTest
+          build-type: e2e
 
   windows-explorer-build:
     # Disable temporarily due to flakiness
@@ -428,7 +429,7 @@ jobs:
               exit 1
           fi
           APK_PATH=${{ github.workspace }}/lynx/explorer/android/lynx_explorer/build_temp
-          java -jar $ANDROID_HOME/build-tools/$LATEST_VERSION/lib/apksigner.jar sign --key $ESPRESSO_SIGN_KEYS_DIR/testkey.pk8 --cert $ESPRESSO_SIGN_KEYS_DIR/testkey.x509.pem  --out $APK_PATH/LynxExplorer-noasan-release-signed.apk $APK_PATH/LynxExplorer-noasan-release.apk
+          java -jar $ANDROID_HOME/build-tools/$LATEST_VERSION/lib/apksigner.jar sign --key $ESPRESSO_SIGN_KEYS_DIR/testkey.pk8 --cert $ESPRESSO_SIGN_KEYS_DIR/testkey.x509.pem  --out $APK_PATH/LynxExplorer-noasan-release-signed.apk $APK_PATH/LynxExplorer-noasan-e2e.apk
           adb install $APK_PATH/LynxExplorer-noasan-release-signed.apk
       - name: Start Appium server
         run: |

--- a/explorer/android/build.gradle
+++ b/explorer/android/build.gradle
@@ -87,7 +87,7 @@ ext.getFlavorNamesAndBuildTypes = { Project project ->
     // To reduce the generation of cmake scripts, the following types that will
     // not be used are excluded.
     // Notice: We can't exclude flavorNames because not all the flavors are the same in all projects.
-    if (!(runTasks.contains("release") || runTasks.contains("publish"))) {
+    if (!(runTasks.contains("release") || runTasks.contains("publish") || runTasks.contains("e2e"))) {
         buildTypes -= "release"
     }
     if (!runTasks.contains("debug")) {

--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -42,6 +42,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
         }
+        e2e {
+            initWith release
+            minifyEnabled false
+            signingConfig signingConfigs.release
+            matchingFallbacks = ["release"]
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
1. Add a new build type 'e2e' in android explorer with minifyEnabled false.

2. Run android E2E task with unobfuscated app in ci pipeline.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
