### PR TITLE
[BugFix][Explorer] Pass safe area insets for proper notch and home indicator handling

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -316,6 +316,27 @@ public class LynxViewShellActivity extends AppCompatActivity {
     globalProps.put("isNotchScreen", isNotchScreen());
     globalProps.put("screenWidth", displayMetrics.widthPixels / displayMetrics.density);
     globalProps.put("screenHeight", displayMetrics.heightPixels / displayMetrics.density);
+    // Pass safe area insets for notch and navigation bar
+    double safeAreaTop = 0;
+    double safeAreaBottom = 0;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      DisplayCutout cutout = getWindow().getDecorView().getRootWindowInsets() != null
+          ? getWindow().getDecorView().getRootWindowInsets().getDisplayCutout()
+          : null;
+      if (cutout != null) {
+        safeAreaTop = cutout.getSafeInsetTop() / displayMetrics.density;
+      }
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      android.view.WindowInsets insets = getWindow().getDecorView().getRootWindowInsets();
+      if (insets != null) {
+        android.graphics.Insets navInsets =
+            insets.getInsets(android.view.WindowInsets.Type.navigationBars());
+        safeAreaBottom = navInsets.bottom / displayMetrics.density;
+      }
+    }
+    globalProps.put("safeAreaTop", safeAreaTop);
+    globalProps.put("safeAreaBottom", safeAreaBottom);
 
     String theme = "Light";
     if ((context.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK)

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
@@ -165,6 +165,15 @@ NSString *const kBackButtonImageDark = @"back_dark";
   [globalProps updateBool:[self isNotchScreen] forKey:@"isNotchScreen"];
   [globalProps updateDouble:screenHeight forKey:@"screenHeight"];
   [globalProps updateDouble:screenWidth forKey:@"screenWidth"];
+  if (@available(iOS 11.0, *)) {
+    UIWindow *window = UIApplication.sharedApplication.keyWindow;
+    UIEdgeInsets safeAreaInsets = window.safeAreaInsets;
+    [globalProps updateDouble:safeAreaInsets.top forKey:@"safeAreaTop"];
+    [globalProps updateDouble:safeAreaInsets.bottom forKey:@"safeAreaBottom"];
+  } else {
+    [globalProps updateDouble:0 forKey:@"safeAreaTop"];
+    [globalProps updateDouble:0 forKey:@"safeAreaBottom"];
+  }
   NSString *theme = @"Light";
   if ([UIScreen mainScreen].traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
     theme = @"Dark";

--- a/explorer/homepage/components/homepage/index.tsx
+++ b/explorer/homepage/components/homepage/index.tsx
@@ -19,6 +19,7 @@ interface HomePageProps {
   currentTheme: string;
   withTheme: (className: string) => string;
   withNotchScreen: (className: string) => string;
+  safeAreaBottom: number;
 }
 
 export default function HomePage(props: HomePageProps) {
@@ -96,9 +97,19 @@ export default function HomePage(props: HomePageProps) {
     return <></>;
   }
 
+  const safeAreaTop = lynx.__globalProps.safeAreaTop || 0;
+  const navigatorHeight = 48 + props.safeAreaBottom;
+
   return (
-    <view clip-radius="true" className={withTheme('page')}>
-      <view className={withNotchScreen('page-header')}>
+    <view
+      clip-radius="true"
+      className={withTheme('page')}
+      style={{ height: `calc(100% - ${navigatorHeight}px)` }}
+    >
+      <view
+        className="page-header"
+        style={{ marginTop: `${Math.max(safeAreaTop, 10)}px` }}
+      >
         <image src={getIcon('Explorer')} className="logo" mode="aspectFit" />
         <text className={withTheme('home-title')}>Lynx Explorer</text>
         <view className="scan">

--- a/explorer/homepage/components/navigator/index.scss
+++ b/explorer/homepage/components/navigator/index.scss
@@ -5,7 +5,6 @@
 @mixin navigator {
   display: flex;
   margin-top: auto;
-  height: 48px;
 }
 .navigator__light {
   @include navigator;
@@ -20,6 +19,7 @@
 }
 .button {
   flex-grow: 1;
+  height: 48px;
   align-items: center;
   justify-content: center;
 }

--- a/explorer/homepage/components/navigator/index.tsx
+++ b/explorer/homepage/components/navigator/index.tsx
@@ -20,6 +20,7 @@ interface NavigatorProps {
   withTheme: (className: string) => string;
   openHomePage: () => void;
   openSettingsPage: () => void;
+  safeAreaBottom: number;
 }
 
 type IconName = 'home' | 'settings';
@@ -62,7 +63,11 @@ export default function Navigator(props: NavigatorProps) {
   };
 
   return (
-    <view clip-radius="true" className={props.withTheme('navigator')}>
+    <view
+      clip-radius="true"
+      className={props.withTheme('navigator')}
+      style={{ paddingBottom: `${props.safeAreaBottom}px` }}
+    >
       <view
         className="button"
         bindtap={props.openHomePage}

--- a/explorer/homepage/components/settingspage/index.tsx
+++ b/explorer/homepage/components/settingspage/index.tsx
@@ -21,6 +21,7 @@ interface SettingsPageProps {
   setTheme: (theme: string) => void;
   withTheme: (className: string) => string;
   withNotchScreen: (className: string) => string;
+  safeAreaBottom: number;
 }
 
 export default function SettingsPage(props: SettingsPageProps) {
@@ -66,9 +67,19 @@ export default function SettingsPage(props: SettingsPageProps) {
     return <></>;
   }
 
+  const safeAreaTop = lynx.__globalProps.safeAreaTop || 0;
+  const navigatorHeight = 48 + props.safeAreaBottom;
+
   return (
-    <view clip-radius="true" className={withTheme('page')}>
-      <view className={withNotchScreen('page-header')}>
+    <view
+      clip-radius="true"
+      className={withTheme('page')}
+      style={{ height: `calc(100% - ${navigatorHeight}px)` }}
+    >
+      <view
+        className="page-header"
+        style={{ marginTop: `${Math.max(safeAreaTop, 10)}px` }}
+      >
         <text className={withTheme('title')}>Settings</text>
       </view>
 

--- a/explorer/homepage/index.tsx
+++ b/explorer/homepage/index.tsx
@@ -70,6 +70,8 @@ export default function Explorer() {
     return lynx.__globalProps.isNotchScreen ? `${className}__notch` : className;
   };
 
+  const safeAreaBottom = lynx.__globalProps.safeAreaBottom || 0;
+
   return (
     <view clip-radius="true" style={{ height: '100%' }}>
       <HomePage
@@ -77,6 +79,7 @@ export default function Explorer() {
         withNotchScreen={withNotchScreen}
         withTheme={withTheme}
         showPage={state.showHomePage}
+        safeAreaBottom={safeAreaBottom}
       />
       <SettingsPage
         themes={state.themes}
@@ -85,12 +88,14 @@ export default function Explorer() {
         withTheme={withTheme}
         setTheme={setTheme}
         showPage={state.showSettingsPage}
+        safeAreaBottom={safeAreaBottom}
       />
       <Navigator
         {...state}
         withTheme={withTheme}
         openHomePage={openHomePage}
         openSettingsPage={openSettingsPage}
+        safeAreaBottom={safeAreaBottom}
       />
     </view>
   );

--- a/explorer/homepage/typing.d.ts
+++ b/explorer/homepage/typing.d.ts
@@ -34,6 +34,8 @@ declare module '@lynx-js/types' {
     preferredTheme?: string;
     theme: string;
     isNotchScreen: boolean;
+    safeAreaTop?: number;
+    safeAreaBottom?: number;
   }
 
   interface IntrinsicElements extends Lynx.IntrinsicElements {


### PR DESCRIPTION
## Summary

- **Native (iOS/Android)**: Pass actual `safeAreaTop` and `safeAreaBottom` values (in pt/dp) as global props to the Lynx frontend, instead of relying only on a boolean `isNotchScreen` flag.
- **Frontend (homepage)**: Use precise safe area inset values for the page header margin-top and the navigator tab bar padding-bottom, ensuring content doesn't overlap with the Dynamic Island/notch or home indicator on modern devices.
- **Navigator**: Move `height: 48px` from the navigator mixin to the `.button` class, so `paddingBottom` on the navigator extends beyond the button area to fill the home indicator region with the tab bar background.

## Test plan

- [ ] Build and run on iOS simulator (iPhone with Dynamic Island) — verify header clears the notch and tab bar clears the home indicator
- [ ] Build and run on Android device with display cutout — verify same safe area behavior
- [ ] Verify non-notch devices (e.g. iPhone SE, older Android) still display correctly with zero insets
- [ ] Verify dark mode still works correctly on both pages (home + settings)