### PR TITLE
[Doc][Agents] Add coding style and Explorer app guides

### DIFF
--- a/agents/code_review/coding_style.md
+++ b/agents/code_review/coding_style.md
@@ -1,0 +1,71 @@
+# Coding Style & Formatting
+
+CI runs `coding-style` checks on every PR. All changed files must pass `clang-format` or `prettier` formatting before merge.
+
+## Formatting Tools by File Type
+
+| File Extension | Formatter | Config |
+|---|---|---|
+| `.java`, `.h`, `.hpp`, `.c`, `.cc`, `.cpp`, `.m`, `.mm` | `clang-format` | `.clang-format` (`BasedOnStyle: Google`) |
+| `.ts`, `.tsx`, `.yml`, `.yaml` | `prettier@2.2.1` | `.prettierrc` |
+| `.gn`, `.gni` | `gn format` | — |
+
+## How to Format
+
+Run **before committing**:
+
+```bash
+# Format all changed files (requires tools/envsetup.sh to be sourced first)
+source tools/envsetup.sh
+python3 tools_shared/git_lynx.py format
+
+# Or format a single file manually:
+# C++/ObjC/Java:
+buildtools/llvm/bin/clang-format -i <file>
+# TypeScript/YAML:
+npx prettier@2.2.1 -w <file>
+```
+
+## Key Details
+
+- **Java files use `clang-format` with Google style**, not a Java-specific formatter. Pay attention to:
+  - Ternary operator line breaks: `? value\n: fallback` (each on its own line)
+  - Method chain wrapping: assignment on one line, call indented on the next
+  - 100-character line limit (Google style default)
+
+- **TypeScript/TSX files use `prettier@2.2.1`** (pinned version). The `.prettierrc` config enforces:
+  - `printWidth: 80`, `singleQuote: true`, `tabWidth: 2`, `trailingComma: "es5"`
+
+- **`.d.ts` files are excluded** from prettier checks (see `.prettierignore`)
+
+## CI Checks
+
+CI runs these static checks (see `.github/workflows/ci.yml`):
+
+| Check | What it does |
+|---|---|
+| `coding-style` | Verifies `clang-format` / `prettier` formatting compliance |
+| `cpplint` | C++ lint (Google style) |
+| `java-lint` | PMD-based Java static analysis |
+| `android-check-style` | Checkstyle (UnusedImports, etc.) |
+| `commit-message` | Validates commit message format (see `commit_message_format.md`) |
+
+## Running All Checks Locally
+
+```bash
+source tools/envsetup.sh
+python3 tools_shared/git_lynx.py check
+```
+
+Or run specific checkers:
+
+```bash
+python3 tools_shared/git_lynx.py check --checkers coding-style
+python3 tools_shared/git_lynx.py check --checkers java-lint
+```
+
+## Common Pitfalls
+
+1. **Forgetting to format Java files**: Java uses `clang-format` (Google style), which has different conventions from standard Java IDEs. Always run `clang-format -i` on Java files.
+2. **Wrong prettier version**: CI uses `prettier@2.2.1` specifically. Using a different version may produce different output.
+3. **Missing trailing newline**: The format script ensures files end with a newline. Some editors strip trailing newlines.

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -1,0 +1,69 @@
+# Explorer App
+
+The Explorer app is the demo/development app for Lynx, available on iOS, Android, macOS, and Windows. It hosts a Lynx-rendered homepage and provides navigation to showcase pages.
+
+## Architecture
+
+### Homepage (Lynx Frontend)
+
+- **Source**: `explorer/homepage/` (TypeScript + SCSS, built with `@lynx-js/rspeedy`)
+- **Build**: `cd explorer/homepage && npx rspeedy build` produces `dist/main.lynx.bundle`
+- **Bundle must be copied** to platform-specific resource directories after build:
+  - iOS: `explorer/darwin/ios/lynx_explorer/LynxExplorer/Resource/homepage.lynx.bundle`
+  - The full setup script `explorer/darwin/ios/lynx_explorer/bundle_install.sh` handles build + copy + pod install
+
+### iOS Shell (`LynxViewShellViewController`)
+
+- **Path**: `explorer/darwin/ios/lynx_explorer/LynxExplorer/`
+- The shell creates a `LynxView` and passes **global props** to the frontend:
+  - `isNotchScreen`, `safeAreaTop`, `safeAreaBottom`, `screenWidth`, `screenHeight`
+  - `theme` (Light/Dark from system), `preferredTheme` (user preference)
+  - Query parameters from the URL are converted to camelCase global props
+- **Layout modes**: `fullscreen`, `hiddenNav`, or standard (with nav bar)
+- The homepage loads with `fullscreen=true`
+
+### Android Shell (`LynxViewShellActivity`)
+
+- **Path**: `explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/`
+- Same global props as iOS
+
+### Global Props (Native → Frontend)
+
+| Prop | Type | Description |
+|---|---|---|
+| `isNotchScreen` | `boolean` | Whether the device has a notch/cutout |
+| `safeAreaTop` | `number` | Top safe area inset in pt/dp |
+| `safeAreaBottom` | `number` | Bottom safe area inset in pt/dp |
+| `screenWidth` | `number` | Screen width in pt/dp |
+| `screenHeight` | `number` | Screen height in pt/dp |
+| `theme` | `string` | System theme: `"Light"` or `"Dark"` |
+| `preferredTheme` | `string?` | User-selected theme preference |
+| `frontendTheme` | `string` | `"light"` or `"dark"` |
+
+Type declarations: `explorer/homepage/typing.d.ts`
+
+## iOS Build
+
+```bash
+cd explorer/darwin/ios/lynx_explorer
+
+# Full setup (builds homepage, generates podspecs, pod install):
+bash bundle_install.sh
+
+# Or manually:
+# 1. Build homepage
+cd ../../homepage && npx rspeedy build
+cp dist/main.lynx.bundle ../darwin/ios/lynx_explorer/LynxExplorer/Resource/homepage.lynx.bundle
+
+# 2. Build Xcode project
+xcodebuild -workspace LynxExplorer.xcworkspace -scheme LynxExplorer \
+  -sdk iphonesimulator -destination 'id=<SIMULATOR_UDID>' build
+
+# 3. Install & launch on simulator
+xcrun simctl install <UDID> build/Build/Products/Debug-iphonesimulator/LynxExplorer.app
+xcrun simctl launch <UDID> com.lynx.LynxExplorer
+```
+
+## Pod Dependencies
+
+The iOS project uses CocoaPods with local pods from the monorepo root (`pod 'Lynx', :path => '../../../..'`). Run `bundle exec pod install` from the `lynx_explorer/` directory. Some pods (like `Sparkling`) are private and may not be available in all environments.


### PR DESCRIPTION
## Summary

- Add `agents/code_review/coding_style.md`: Documents the CI formatting pipeline — which formatters are used for which file types (clang-format for C++/ObjC/Java, prettier@2.2.1 for TS/YAML), how to run checks locally, and common pitfalls (e.g. Java files using clang-format Google style, not a Java-specific formatter).
- Add `agents/explorer.md`: Documents the Explorer app architecture, the native→frontend global props contract, iOS/Android build workflow, and pod dependency notes.

## Test plan

- [ ] Verify the docs render correctly on GitHub
- [ ] Confirm the information matches the actual CI pipeline in `.github/workflows/ci.yml` and `tools_shared/`