### PR TITLE
[Infra] Update espressoConfig to adapt androidx deps

### DIFF
--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.4.0'
     implementation 'com.squareup.retrofit2:retrofit:2.7.0'
     implementation 'org.lynxsdk.lynx:v8so:11.1.277.4'
+    implementation 'com.google.android.material:material:1.1.0'
 
     implementation project(':LynxAndroid')
     implementation project(':LynxBase')

--- a/testing/integration_test/test_script/requirements.txt
+++ b/testing/integration_test/test_script/requirements.txt
@@ -10,7 +10,7 @@ h11==0.16.0
     # via wsproto
 idna==3.11
     # via trio
-lynx-e2e-appium==0.0.8
+lynx-e2e-appium==0.0.9-alpha.4
     # via -r testing/integration_test/test_script/requirements.in
 numpy==2.2.6
     # via opencv-python


### PR DESCRIPTION
Use a switch to isolate accessability-label and lynx-test-tag to avoid being unable to run UI automation with lynx-test-tag after enabling accessibility on the page.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
