### PR TITLE
[Optimize][JSVM] Enable memory-sensitive JSVM initialization configur…

### DIFF
--- a/core/runtime/js/jsi/jsvm/jsvm_runtime_wrapper.cc
+++ b/core/runtime/js/jsi/jsvm/jsvm_runtime_wrapper.cc
@@ -21,8 +21,30 @@ void JSVMRuntimeInstance::InitInstance() {
   static std::once_flag flag;
   std::call_once(flag, [this]() {
     LOGI("lynx JSVMRuntimeInstance::InitInstance");
+    enum class JSVMInitMode {
+      kDefault,
+      kMemorySensitive,
+    };
+
+    JSVMInitMode init_mode = JSVMInitMode::kDefault;
     JSVM_InitOptions initOptions;
-    memset(&initOptions, 0, sizeof(initOptions));
+    int argc = 0;
+    const char* argv[2];
+
+    switch (init_mode) {
+      case JSVMInitMode::kMemorySensitive:
+        argc = 2;
+        argv[0] = "--jsvm";
+        argv[1] = "--optimize-for-size";
+        initOptions.argc = &argc;
+        initOptions.argv = const_cast<char**>(argv);
+        break;
+      case JSVMInitMode::kDefault:
+      default:
+        memset(&initOptions, 0, sizeof(initOptions));
+        break;
+    }
+
     JSVM_CALL_NO_ENV(OH_JSVM_Init, &initOptions);
 
     JSVM_CreateVMOptions options;


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

Reasoning for the Change
The Openharmony JSVM in Lynx previously lacked granular initialization options for memory optimization strategies. In scenarios where Lynx is deployed on resource-constrained devices (e.g., low-end mobile phones, embedded devices), the default JSVM memory configuration prioritized execution speed over memory footprint, leading to excessive memory usage and potential OOM (Out of Memory) issues. This change introduces a dedicated initialization option to address this gap by enabling memory-centric optimization for JSVM.

Problem/Issue Resolved
This pull request resolves the problem of high baseline memory consumption of JSVM in Lynx, particularly for use cases that require minimal memory overhead. We allow JSVM to prioritize memory usage optimization over raw performance, making Lynx more suitable for resource-limited deployment environments.

Relevant Context
Optimized JSVM memory management logic under this option:

Adjusted GC (Garbage Collection) scheduling frequency to reclaim unused memory more proactively;
Enhanced memory block reuse mechanisms to reduce fragmented memory allocation;
Reduced the minimum size of the JSVM young generation semi-space to half of the original baseline


- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
