### PR TITLE
fix: wrong number of arguments in a class instantiation

### DIFF
--- a/tools/rtf/plugins/android_ut_plugin.py
+++ b/tools/rtf/plugins/android_ut_plugin.py
@@ -66,7 +66,7 @@ class AndroidUTPlugin(Plugin):
             elif args.command == "list":
                 return self.__handle_list_command(template_name, template)
             else:
-                return Err(f"Unsupported command: {args.command}")
+                return Err("UNSUPPORTED_COMMAND", f"Unsupported command: {args.command}")
 
     def __handle_run_command(self, local_env, args):
         container = AndroidUTContainer(local_env["builder"], local_env["coverage"])


### PR DESCRIPTION
The problem is that `Err` is being constructed with only one argument, while its `__init__` requires at least two. To fix this without changing existing functionality, we should add an additional argument that matches how `Err` is used elsewhere in the codebase (commonly an error code plus a message, or a value plus an error). Since we don’t see other usages here, a safe pattern is to treat the human-readable message as the second argument and supply a simple, descriptive error-code or category as the first.

Concretely, in `AndroidUTPlugin.accept`, for the `else` branch where `args.command` is unsupported, change the `Err` construction to pass two arguments. For example, use a short error code or tag such as `"UNSUPPORTED_COMMAND"` as the first argument, and keep the existing formatted string as the second argument. This preserves the semantics (still reports the same message) while satisfying the required arity of `Err.__init__`.