### PR TITLE
[BugFix][Clay] Implement missing PaintingContextClay bridge methods

### DIFF
--- a/clay/lynx_adaptor/painting_context_clay.cc
+++ b/clay/lynx_adaptor/painting_context_clay.cc
@@ -13,7 +13,10 @@
 #include "clay/lynx_adaptor/prop_bundle_impl.h"
 #include "clay/lynx_adaptor/value_converter.h"
 #include "clay/public/value.h"
+#include "clay/ui/component/base_view.h"
+#include "clay/ui/component/intersection_observer_manager.h"
 #include "clay/ui/component/list/lynx_list_data.h"
+#include "clay/ui/component/page_view.h"
 #include "clay/ui/lynx_module/type_utils.h"
 #include "clay/ui/shadow/text_render.h"
 #include "core/renderer/css/css_property_id.h"
@@ -137,7 +140,11 @@ void PaintingContextClay::FinishLayoutOperation(
 }
 
 void PaintingContextClay::FinishTasmOperation(
-    const std::shared_ptr<PipelineOptions>& options) {}
+    const std::shared_ptr<PipelineOptions>& options) {
+  (void)options;
+  // Trigger queued UI operations for this tasm batch.
+  Flush();
+}
 
 // Invoked by BTS
 void PaintingContextClay::InvokeUIMethod(int32_t view_id,
@@ -449,9 +456,70 @@ std::unique_ptr<lynx::pub::Value> PaintingContextClay::GetTextInfo(
   return std::make_unique<ClayValue>(std::move(result));
 }
 
-void PaintingContextClay::StopExposure(const pub::Value& options) {}
+std::vector<float> PaintingContextClay::getWindowSize(int id) {
+  (void)id;
+  if (!view_context_ || !view_context_->GetPageView()) {
+    return floats_;
+  }
+  auto size = view_context_->GetPageView()->logical_size();
+  return std::vector<float>{size.width(), size.height()};
+}
 
-void PaintingContextClay::ResumeExposure() {}
+std::vector<float> PaintingContextClay::GetRectToWindow(int id) {
+  if (!view_context_) {
+    return floats_;
+  }
+
+  auto* view = view_context_->FindViewByViewId(id);
+  if (!view) {
+    return floats_;
+  }
+
+  float position[2] = {0.0f, 0.0f};
+  getAbsolutePosition(id, position);
+  return std::vector<float>{position[1], position[0], view->Width(),
+                            view->Height()};
+}
+
+std::vector<float> PaintingContextClay::GetRectToLynxView(int64_t id) {
+  return GetRectToWindow(static_cast<int>(id));
+}
+
+void PaintingContextClay::StopExposure(const pub::Value& options) {
+  bool send_event = true;
+  if (options.IsMap() && options.Contains("sendEvent")) {
+    auto send_event_value = options.GetValueForKey("sendEvent");
+    if (send_event_value && send_event_value->IsBool()) {
+      send_event = send_event_value->Bool();
+    }
+  }
+
+  Enqueue([view_context = view_context_, send_event]() {
+    if (!view_context || !view_context->GetPageView()) {
+      return;
+    }
+    auto* intersection_manager =
+        view_context->GetPageView()->intersection_observer_manager();
+    if (!intersection_manager) {
+      return;
+    }
+    intersection_manager->StopExposure(send_event);
+  });
+}
+
+void PaintingContextClay::ResumeExposure() {
+  Enqueue([view_context = view_context_]() {
+    if (!view_context || !view_context->GetPageView()) {
+      return;
+    }
+    auto* intersection_manager =
+        view_context->GetPageView()->intersection_observer_manager();
+    if (!intersection_manager) {
+      return;
+    }
+    intersection_manager->ResumeExposure();
+  });
+}
 
 std::list<int32_t> PaintingContextClay::GetAncestorElements(int32_t tag) {
   return engine_proxy_->GetAncestorElements(tag);

--- a/clay/lynx_adaptor/painting_context_clay.h
+++ b/clay/lynx_adaptor/painting_context_clay.h
@@ -117,14 +117,13 @@ class PaintingContextClay : public PaintingCtxPlatformImpl,
   bool EnableParallelElement() override { return true; }
   bool EnableUIOperationQueue() override { return true; }
 
-  // TODO(chenhyouhui): Use default implementations
-  std::vector<float> getWindowSize(int id) override { return floats_; }
-  std::vector<float> GetRectToWindow(int id) override { return floats_; }
+  std::vector<float> getWindowSize(int id) override;
+  std::vector<float> GetRectToWindow(int id) override;
   std::unique_ptr<pub::Value> GetTextInfo(const std::string& content,
                                           const pub::Value& info) override;
   void StopExposure(const pub::Value& options) override;
   void ResumeExposure() override;
-  std::vector<float> GetRectToLynxView(int64_t id) override { return floats_; }
+  std::vector<float> GetRectToLynxView(int64_t id) override;
   std::vector<float> ScrollBy(int64_t id, float width, float height) override {
     return floats_;
   }


### PR DESCRIPTION
- Implemented previously stubbed platform bridge methods for window/rect queries and exposure control in PaintingContextClay.
- Wired FinishTasmOperation to flush queued UI operations so TASM-to-UI execution flow is completed.
- Reused existing ViewContext/PageView/IntersectionObserverManager pathways to keep behavior aligned with Clay native module and other platforms.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
