### PR TITLE
[Feature][DevTool] Support DOM.getDocument depth

### DIFF
--- a/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
@@ -544,6 +544,14 @@ void InspectorTasmExecutor::GetDocument(
     const Json::Value& message) {
   Json::Value response(Json::ValueType::objectValue);
   Json::Value content = Json::Value(Json::ValueType::objectValue);
+  Json::Value params = message["params"];
+  int depth = -1;
+  if (params.isMember("depth")) {
+    depth = params["depth"].asInt();
+  }
+  if (depth < -1) {
+    depth = -1;
+  }
   if (element_root_ == nullptr) {
     response["result"] = content;
     response["id"] = message["id"].asInt64();
@@ -551,7 +559,8 @@ void InspectorTasmExecutor::GetDocument(
     return;
   }
 
-  content["root"] = ElementHelper::GetDocumentBodyFromNode(element_root_);
+  content["root"] =
+      ElementHelper::GetDocumentBodyFromNode(element_root_, depth);
   content["compress"] = false;
 
   response["result"] = content;

--- a/devtool/lynx_devtool/agent/inspector_tasm_executor_unittest.cc
+++ b/devtool/lynx_devtool/agent/inspector_tasm_executor_unittest.cc
@@ -60,6 +60,13 @@ class InspectorTasmExecutorTest : public ::testing::Test {
     devtool_mediator_->ui_task_runner_ = ui_thread_->GetTaskRunner();
   }
 
+  void FlushDevtoolTasks() {
+    std::promise<void> p;
+    auto f = p.get_future();
+    devtool_mediator_->RunOnDevToolThread([&p]() { p.set_value(); }, true);
+    f.wait();
+  }
+
  private:
   std::shared_ptr<devtool::InspectorTasmExecutor> element_executor_;
   std::shared_ptr<devtool::LynxDevToolMediator> devtool_mediator_;
@@ -254,6 +261,77 @@ TEST_F(InspectorTasmExecutorTest, GetLayerContentFromElementCase) {
   EXPECT_EQ(layer, res);
 }
 
+TEST_F(InspectorTasmExecutorTest, GetDocumentWithDepthCase) {
+  auto root = manager_->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(root.get()));
+
+  auto child = manager_->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(child.get()));
+  auto grandchild = manager_->CreateFiberElement("text");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(grandchild.get()));
+
+  root->AddChildAt(child, 0);
+  child->AddChildAt(grandchild, 0);
+  element_executor_->element_root_ = root.get();
+
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 7;
+  message["params"]["depth"] = 1;
+  element_executor_->GetDocument(message_sender_, message);
+  FlushDevtoolTasks();
+
+  Json::Value res;
+  Json::Reader reader;
+  ASSERT_TRUE(reader.parse(
+      devtool::MockReceiver::GetInstance().received_message_.second, res));
+  EXPECT_EQ(res["id"], 7);
+  EXPECT_TRUE(res["error"].isNull());
+  EXPECT_EQ(res["result"]["root"]["nodeId"],
+            devtool::ElementInspector::NodeId(root.get()));
+  ASSERT_TRUE(res["result"]["root"]["children"].isArray());
+  ASSERT_EQ(res["result"]["root"]["children"].size(), 1U);
+  EXPECT_EQ(res["result"]["root"]["children"][0]["nodeId"],
+            devtool::ElementInspector::NodeId(child.get()));
+  EXPECT_TRUE(res["result"]["root"]["children"][0]["children"].isNull());
+}
+
+TEST_F(InspectorTasmExecutorTest, GetDocumentDefaultDepthReturnsFullTreeCase) {
+  auto root = manager_->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(root.get()));
+
+  auto child = manager_->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(child.get()));
+  auto grandchild = manager_->CreateFiberElement("text");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(grandchild.get()));
+
+  root->AddChildAt(child, 0);
+  child->AddChildAt(grandchild, 0);
+  element_executor_->element_root_ = root.get();
+
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 8;
+  element_executor_->GetDocument(message_sender_, message);
+  FlushDevtoolTasks();
+
+  Json::Value res;
+  Json::Reader reader;
+  ASSERT_TRUE(reader.parse(
+      devtool::MockReceiver::GetInstance().received_message_.second, res));
+  EXPECT_EQ(res["id"], 8);
+  ASSERT_TRUE(res["result"]["root"]["children"].isArray());
+  ASSERT_EQ(res["result"]["root"]["children"].size(), 1U);
+  ASSERT_TRUE(res["result"]["root"]["children"][0]["children"].isArray());
+  ASSERT_EQ(res["result"]["root"]["children"][0]["children"].size(), 1U);
+  EXPECT_EQ(res["result"]["root"]["children"][0]["children"][0]["nodeId"],
+            devtool::ElementInspector::NodeId(grandchild.get()));
+}
+
 TEST_F(InspectorTasmExecutorTest, SendDOMEventMsgCase) {
   auto element = manager_->CreateFiberElement("view");
   lynx::devtool::ElementInspector::InitForInspector(
@@ -263,17 +341,10 @@ TEST_F(InspectorTasmExecutorTest, SendDOMEventMsgCase) {
   element_executor_->element_root_ = element.get();
   devtool_mediator_->default_task_runner_ = ui_thread_->GetTaskRunner();
 
-  auto flush_devtool_tasks = [this]() {
-    std::promise<void> p;
-    auto f = p.get_future();
-    devtool_mediator_->RunOnDevToolThread([&p]() { p.set_value(); }, true);
-    f.wait();
-  };
-
   element_executor_->SendDOMEventMsg(
       devtool::InspectorTasmExecutor::DomCdpEvent::ATTRIBUTE_MODIFIED, node_id,
       "style", -1);
-  flush_devtool_tasks();
+  FlushDevtoolTasks();
 
   Json::Value res;
   Json::Reader reader;
@@ -290,14 +361,14 @@ TEST_F(InspectorTasmExecutorTest, SendDOMEventMsgCase) {
   element_executor_->SendDOMEventMsg(
       devtool::InspectorTasmExecutor::DomCdpEvent::ATTRIBUTE_MODIFIED, -1,
       "style", -1);
-  flush_devtool_tasks();
+  FlushDevtoolTasks();
   EXPECT_EQ(devtool::MockReceiver::GetInstance().received_message_.second,
             prev);
 
   element_executor_->SendDOMEventMsg(
       devtool::InspectorTasmExecutor::DomCdpEvent::CHILD_NODE_REMOVED, node_id,
       "", node_id);
-  flush_devtool_tasks();
+  FlushDevtoolTasks();
   is_valid = reader.parse(
       devtool::MockReceiver::GetInstance().received_message_.second, res);
   EXPECT_TRUE(is_valid);
@@ -308,7 +379,7 @@ TEST_F(InspectorTasmExecutorTest, SendDOMEventMsgCase) {
   element_executor_->SendDOMEventMsg(
       devtool::InspectorTasmExecutor::DomCdpEvent::DOCUMENT_UPDATED, -1, "",
       -1);
-  flush_devtool_tasks();
+  FlushDevtoolTasks();
   is_valid = reader.parse(
       devtool::MockReceiver::GetInstance().received_message_.second, res);
   EXPECT_TRUE(is_valid);

--- a/devtool/lynx_devtool/element/element_helper.cc
+++ b/devtool/lynx_devtool/element/element_helper.cc
@@ -83,18 +83,32 @@ Element* ElementHelper::GetPreviousNode(Element* ptr) {
   return nullptr;
 }
 
-Json::Value ElementHelper::GetDocumentBodyFromNode(Element* ptr) {
+namespace {
+
+void SetDocumentChildren(Json::Value& res, Element* ptr, int depth) {
+  res["childNodeCount"] = static_cast<int>(ptr->GetChildren().size());
+  if (depth == 0) {
+    return;
+  }
+
+  int next_depth = depth == -1 ? -1 : depth - 1;
+  res["children"] = Json::Value(Json::ValueType::arrayValue);
+  for (Element* child : ptr->GetChildren()) {
+    res["children"].append(
+        ElementHelper::GetDocumentBodyFromNode(child, next_depth));
+  }
+}
+
+}  // namespace
+
+Json::Value ElementHelper::GetDocumentBodyFromNode(Element* ptr, int depth) {
   Json::Value res = Json::Value(Json::ValueType::objectValue);
 
   CHECK_NULL_AND_LOG_RETURN_VALUE(ptr, "ptr is null", res);
 
-  auto set_node_func = [](Json::Value& res, Element* ptr) {
+  auto set_node_func = [depth](Json::Value& res, Element* ptr) {
     SetJsonValueOfNode(ptr, res);
-    res["childNodeCount"] = static_cast<int>(ptr->GetChildren().size());
-    res["children"] = Json::Value(Json::ValueType::arrayValue);
-    for (Element* child : ptr->GetChildren()) {
-      res["children"].append(GetDocumentBodyFromNode(child));
-    }
+    SetDocumentChildren(res, ptr, depth);
   };
 
   Element* comp_ptr =

--- a/devtool/lynx_devtool/element/element_helper.h
+++ b/devtool/lynx_devtool/element/element_helper.h
@@ -29,7 +29,7 @@ class ElementHelper {
  public:
   static Element* GetPreviousNode(Element* ptr);
 
-  static Json::Value GetDocumentBodyFromNode(Element* ptr);
+  static Json::Value GetDocumentBodyFromNode(Element* ptr, int depth = -1);
   static void SetJsonValueOfNode(Element* ptr, Json::Value& value);
   static Json::Value GetMatchedStylesForNode(Element* ptr);
   static Json::Value GetKeyframesRulesForNode(Element* ptr);

--- a/devtool/lynx_devtool/element/element_helper_unittest.cc
+++ b/devtool/lynx_devtool/element/element_helper_unittest.cc
@@ -155,6 +155,55 @@ TEST_F(ElementHelperTest, GetDocumentBodyFromNodeTest) {
   child_container->RemoveSelf(true);
 }
 
+TEST_F(ElementHelperTest, GetDocumentBodyFromNodeWithDepthTest) {
+  auto root = manager->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(root.get()));
+  root->CreateElementContainer(false);
+
+  auto child = manager->CreateFiberElement("view");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(child.get()));
+  root->AddChildAt(child, 0);
+  child->CreateElementContainer(false);
+  child->element_container_impl()->InsertSelf();
+
+  auto grandchild = manager->CreateFiberElement("text");
+  lynx::devtool::ElementInspector::InitForInspector(
+      std::make_tuple(grandchild.get()));
+  child->AddChildAt(grandchild, 0);
+  grandchild->CreateElementContainer(false);
+  grandchild->element_container_impl()->InsertSelf();
+
+  auto depth_zero =
+      lynx::devtool::ElementHelper::GetDocumentBodyFromNode(root.get(), 0);
+  EXPECT_EQ(depth_zero["nodeId"],
+            lynx::devtool::ElementInspector::NodeId(root.get()));
+  EXPECT_EQ(depth_zero["childNodeCount"], 1);
+  EXPECT_TRUE(depth_zero["children"].isNull());
+
+  auto depth_one =
+      lynx::devtool::ElementHelper::GetDocumentBodyFromNode(root.get(), 1);
+  ASSERT_TRUE(depth_one["children"].isArray());
+  ASSERT_EQ(depth_one["children"].size(), 1U);
+  EXPECT_EQ(depth_one["children"][0]["nodeId"],
+            lynx::devtool::ElementInspector::NodeId(child.get()));
+  EXPECT_EQ(depth_one["children"][0]["childNodeCount"], 1);
+  EXPECT_TRUE(depth_one["children"][0]["children"].isNull());
+
+  auto full_depth =
+      lynx::devtool::ElementHelper::GetDocumentBodyFromNode(root.get(), -1);
+  ASSERT_TRUE(full_depth["children"].isArray());
+  ASSERT_EQ(full_depth["children"].size(), 1U);
+  ASSERT_TRUE(full_depth["children"][0]["children"].isArray());
+  ASSERT_EQ(full_depth["children"][0]["children"].size(), 1U);
+  EXPECT_EQ(full_depth["children"][0]["children"][0]["nodeId"],
+            lynx::devtool::ElementInspector::NodeId(grandchild.get()));
+
+  grandchild->element_container_impl()->RemoveSelf(true);
+  child->element_container_impl()->RemoveSelf(true);
+}
+
 TEST_F(ElementHelperTest, GetElementContentTest) {
   auto element = manager->CreateFiberElement("view");
   lynx::devtool::ElementInspector::InitForInspector(std::make_tuple(element));


### PR DESCRIPTION
## Summary
- add depth-aware DOM tree serialization to ElementHelper::GetDocumentBodyFromNode
- make DOM.getDocument honor the CDP depth parameter while preserving compression behavior
- add unit tests for helper-level depth serialization and DOM.getDocument(depth)

## Verification
- ./out/codex_noflutter/devtool_element_exec --gtest_filter='*GetDocumentBodyFromNodeWithDepthTest'
- ./out/codex_noflutter/devtool_agent_unittest_exec --gtest_filter='*GetDocumentWithDepthCase'

close: #5613