### PR TITLE
[Feature][Explorer][Android] Add DebugRouter App page handlers

### DIFF
--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.9.0"
     implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.4.0'
     implementation 'com.squareup.retrofit2:retrofit:2.7.0'
+    implementation 'org.lynxsdk.lynx:debug-router:0.0.20'
     implementation 'org.lynxsdk.lynx:v8so:11.1.277.4'
     implementation 'com.google.android.material:material:1.4.0'
 

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
@@ -3,12 +3,16 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.explorer;
 
+import android.app.Activity;
 import android.app.Application;
+import android.os.Bundle;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.imagepipeline.core.ImagePipelineConfig;
 import com.facebook.imagepipeline.memory.PoolConfig;
 import com.facebook.imagepipeline.memory.PoolFactory;
+import com.lynx.debugrouter.DebugRouter;
 import com.lynx.devtool.recorder.LynxRecorderPageManager;
+import com.lynx.explorer.modules.ExplorerAppMessageHandler;
 import com.lynx.explorer.modules.LynxModuleAdapter;
 import com.lynx.explorer.provider.DemoTemplateProvider;
 import com.lynx.explorer.shell.LynxRecorderDefaultActionCallback;
@@ -28,6 +32,8 @@ public class ExplorerApplication extends Application {
     initLynxService();
     initLynxEnv();
     installLynxJSModule(); // register native module.
+    initDebugRouterHandlers();
+    initActivityTracker();
     initFresco();
     initLynxRecorder();
   }
@@ -54,6 +60,40 @@ public class ExplorerApplication extends Application {
     LynxDevToolService.getINSTANCE().setLogBoxPresetValue(true);
     LynxDevToolService.getINSTANCE().setLoadQJSBridge(true);
     LynxDevToolService.getINSTANCE().setLoadV8Bridge(true);
+  }
+
+  private void initDebugRouterHandlers() {
+    DebugRouter.getInstance().addMessageHandler(ExplorerAppMessageHandler.createOpenPageHandler());
+    DebugRouter.getInstance().addMessageHandler(ExplorerAppMessageHandler.createClosePageHandler());
+  }
+
+  private void initActivityTracker() {
+    registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
+      @Override
+      public void onActivityCreated(Activity activity, Bundle savedInstanceState) {}
+
+      @Override
+      public void onActivityStarted(Activity activity) {}
+
+      @Override
+      public void onActivityResumed(Activity activity) {
+        LynxModuleAdapter.getInstance().onActivityResumed(activity);
+      }
+
+      @Override
+      public void onActivityPaused(Activity activity) {
+        LynxModuleAdapter.getInstance().onActivityPaused(activity);
+      }
+
+      @Override
+      public void onActivityStopped(Activity activity) {}
+
+      @Override
+      public void onActivitySaveInstanceState(Activity activity, Bundle outState) {}
+
+      @Override
+      public void onActivityDestroyed(Activity activity) {}
+    });
   }
 
   // merge it into InitProcessor later.

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerAppMessageHandler.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerAppMessageHandler.java
@@ -1,0 +1,69 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.explorer.modules;
+
+import androidx.annotation.Nullable;
+import com.lynx.debugrouter.app.MessageHandleResult;
+import com.lynx.debugrouter.app.MessageHandler;
+import java.util.Map;
+
+public class ExplorerAppMessageHandler implements MessageHandler {
+  private static final String ACTION_OPEN_PAGE = "App.openPage";
+  private static final String ACTION_CLOSE_PAGE = "App.closePage";
+
+  private final String mActionName;
+
+  private ExplorerAppMessageHandler(String actionName) {
+    mActionName = actionName;
+  }
+
+  public static MessageHandler createOpenPageHandler() {
+    return new ExplorerAppMessageHandler(ACTION_OPEN_PAGE);
+  }
+
+  public static MessageHandler createClosePageHandler() {
+    return new ExplorerAppMessageHandler(ACTION_CLOSE_PAGE);
+  }
+
+  @Override
+  public MessageHandleResult handle(Map<String, String> params) {
+    try {
+      if (ACTION_OPEN_PAGE.equals(mActionName)) {
+        String url = params == null ? null : params.get("url");
+        if (url == null || url.trim().isEmpty()) {
+          return fail("Parameter `url` is required.");
+        }
+        LynxModuleAdapter.getInstance().openSchemaSync(url);
+        return success(null);
+      }
+
+      if (ACTION_CLOSE_PAGE.equals(mActionName)) {
+        if (!LynxModuleAdapter.getInstance().hasClosablePage()) {
+          return fail("No active Explorer page can be closed.");
+        }
+        LynxModuleAdapter.getInstance().closeCurrentPageSync();
+        return success(null);
+      }
+    } catch (RuntimeException e) {
+      return fail(e.getMessage());
+    }
+
+    return new MessageHandleResult(
+        MessageHandleResult.CODE_NOT_IMPLEMENTED, "Unsupported action: " + mActionName);
+  }
+
+  @Override
+  public String getName() {
+    return mActionName;
+  }
+
+  private MessageHandleResult success(@Nullable String message) {
+    return new MessageHandleResult(MessageHandleResult.CODE_HANDLE_SUCCESSFULLY, message);
+  }
+
+  private MessageHandleResult fail(@Nullable String message) {
+    return new MessageHandleResult(
+        MessageHandleResult.CODE_HANDLE_FAILED, message == null ? "Unknown error." : message);
+  }
+}

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
@@ -3,15 +3,16 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.explorer.modules;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.util.Log;
 import androidx.annotation.Nullable;
+import com.lynx.devtool.recorder.LynxRecorderActivity;
 import com.lynx.devtoolwrapper.LynxDevtoolCardListener;
 import com.lynx.devtoolwrapper.LynxDevtoolGlobalHelper;
 import com.lynx.explorer.LynxViewShellActivity;
@@ -20,10 +21,14 @@ import com.lynx.explorer.shell.TemplateDispatcher;
 import com.lynx.react.bridge.JavaOnlyMap;
 import com.lynx.react.bridge.WritableMap;
 import com.lynx.tasm.LynxEnv;
+import java.lang.ref.WeakReference;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 
 public class LynxModuleAdapter {
   private Context mContext;
   private Handler mHandler;
+  private WeakReference<Activity> mTopActivity = new WeakReference<>(null);
 
   private LynxDevtoolCardListener mListener = new LynxDevtoolCardListener() {
     @Override
@@ -72,6 +77,43 @@ public class LynxModuleAdapter {
     mHandler.sendMessage(msg);
   }
 
+  public void onActivityResumed(Activity activity) {
+    mTopActivity = new WeakReference<>(activity);
+  }
+
+  public void onActivityPaused(Activity activity) {
+    Activity topActivity = mTopActivity.get();
+    if (topActivity == activity) {
+      mTopActivity.clear();
+    }
+  }
+
+  public boolean hasClosablePage() {
+    Activity activity = mTopActivity.get();
+    return isClosableExplorerActivity(activity) && !isActivityUnavailable(activity);
+  }
+
+  public void openSchemaSync(String url) {
+    executeOnMainThread(() -> {
+      startFromUrl(url);
+      return null;
+    });
+  }
+
+  public void closeCurrentPageSync() {
+    executeOnMainThread(() -> {
+      Activity activity = mTopActivity.get();
+      if (!isClosableExplorerActivity(activity)) {
+        throw new IllegalStateException("No closable Explorer page is active.");
+      }
+      if (isActivityUnavailable(activity)) {
+        throw new IllegalStateException("Current Explorer page is already closing.");
+      }
+      activity.finish();
+      return null;
+    });
+  }
+
   public void setThreadMode(int threadMode) {
     LynxSettingManager.getInstance().setThreadStrategy(threadMode);
   }
@@ -109,6 +151,45 @@ public class LynxModuleAdapter {
   private void startFromUrlSingleTop(String url) {
     TemplateDispatcher.dispatchUrl(
         mContext, url, Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+  }
+
+  private boolean isClosableExplorerActivity(@Nullable Activity activity) {
+    return activity instanceof LynxViewShellActivity || activity instanceof QRScanActivity
+        || activity instanceof LynxRecorderActivity;
+  }
+
+  private boolean isActivityUnavailable(@Nullable Activity activity) {
+    return activity == null || activity.isFinishing()
+        || (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && activity.isDestroyed());
+  }
+
+  private void executeOnMainThread(ThrowingCallable callable) {
+    if (mHandler == null) {
+      throw new IllegalStateException("LynxModuleAdapter is not initialized.");
+    }
+    if (Looper.myLooper() == Looper.getMainLooper()) {
+      callable.call();
+      return;
+    }
+
+    FutureTask<Void> task = new FutureTask<>(() -> callable.call());
+    mHandler.post(task);
+    try {
+      task.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Interrupted while waiting for main-thread execution.", e);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new IllegalStateException("Main-thread execution failed.", cause);
+    }
+  }
+
+  private interface ThrowingCallable {
+    Void call();
   }
 
   public void saveThemePreferences(String theme, String value) {


### PR DESCRIPTION
## Summary
- add DebugRouter message handlers for `App.openPage` and `App.closePage` in LynxExplorer Android
- register the handlers at app startup and track the top Explorer activity so close requests target the current page
- run page open/close on the main thread and add the explicit `debug-router` dependency required for compilation

## Test Plan
- `export ANDROID_HOME=/Users/colin/Library/Android/sdk && export ANDROID_SDK_ROOT=$ANDROID_HOME && source tools/envsetup.sh && cd explorer/android && ./gradlew :LynxExplorer:compileNoasanDebugJavaWithJavac --no-daemon`
- install `LynxExplorer-noasan-debug.apk` on device with `adb install -r`
- use the devtool skill to verify `App.openPage` opens `https://lynxjs.org/lynx-examples/hello-world/dist/main.lynx.bundle`
- use the devtool skill to verify `App.closePage` returns to the Explorer home page
