### PR TITLE
[Feature][Explorer][iOS] Add DebugRouter App.openPage and App.closePage handlers

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		2B590A452D633F3A0041DE80 /* DemoGenericResourceFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B590A442D633F3A0041DE80 /* DemoGenericResourceFetcher.m */; };
 		2B590A492D635BEB0041DE80 /* DemoMeidaResourceFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B590A482D635BEB0041DE80 /* DemoMeidaResourceFetcher.m */; };
 		2B590A4C2D635CF00041DE80 /* DemoTemplateResourceFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B590A4B2D635CF00041DE80 /* DemoTemplateResourceFetcher.m */; };
+		2B6010012E0010000041DE80 /* AppDelegate+DebugRouter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B6010032E0010000041DE80 /* AppDelegate+DebugRouter.mm */; };
 		2B736B8C2D096F8A000A35F6 /* LynxExplorerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B736B8B2D096F8A000A35F6 /* LynxExplorerTests.m */; };
 		2B948FA22C2D9FD900535C96 /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2B948FA12C2D9FD900535C96 /* AppDelegate.mm */; };
 		2B948FA82C2D9FD900535C96 /* LynxViewShellViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2B948FA72C2D9FD900535C96 /* LynxViewShellViewController.m */; };
@@ -66,6 +67,8 @@
 		2B590A482D635BEB0041DE80 /* DemoMeidaResourceFetcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DemoMeidaResourceFetcher.m; sourceTree = "<group>"; };
 		2B590A4A2D635CD80041DE80 /* DemoTemplateResourceFetcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DemoTemplateResourceFetcher.h; sourceTree = "<group>"; };
 		2B590A4B2D635CF00041DE80 /* DemoTemplateResourceFetcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DemoTemplateResourceFetcher.m; sourceTree = "<group>"; };
+		2B6010022E0010000041DE80 /* AppDelegate+DebugRouter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "AppDelegate+DebugRouter.h"; sourceTree = "<group>"; };
+		2B6010032E0010000041DE80 /* AppDelegate+DebugRouter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = "AppDelegate+DebugRouter.mm"; sourceTree = "<group>"; };
 		2B736B892D096F8A000A35F6 /* LynxExplorerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LynxExplorerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2B736B8B2D096F8A000A35F6 /* LynxExplorerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LynxExplorerTests.m; sourceTree = "<group>"; };
 		2B948F9D2C2D9FD900535C96 /* LynxExplorer.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LynxExplorer.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,7 +216,9 @@
 				2B382D822D17BF9200C67770 /* scan */,
 				2B382D7B2D17BCDC00C67770 /* modules */,
 				2B948FA02C2D9FD900535C96 /* AppDelegate.h */,
+				2B6010022E0010000041DE80 /* AppDelegate+DebugRouter.h */,
 				2B948FA12C2D9FD900535C96 /* AppDelegate.mm */,
+				2B6010032E0010000041DE80 /* AppDelegate+DebugRouter.mm */,
 				2B948FA62C2D9FD900535C96 /* LynxViewShellViewController.h */,
 				2B948FA72C2D9FD900535C96 /* LynxViewShellViewController.m */,
 				2B948FA92C2D9FD900535C96 /* Main.storyboard */,
@@ -437,6 +442,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2B948FA82C2D9FD900535C96 /* LynxViewShellViewController.m in Sources */,
+				2B6010012E0010000041DE80 /* AppDelegate+DebugRouter.mm in Sources */,
 				2B382D862D17C06D00C67770 /* ScanViewController.m in Sources */,
 				2B948FA22C2D9FD900535C96 /* AppDelegate.mm in Sources */,
 				2BB78AD32D1D18FA00060E1C /* LynxSettingManager.m in Sources */,

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.h
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.h
@@ -1,0 +1,13 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import "AppDelegate.h"
+
+@interface AppDelegate (DebugRouter)
+
+- (void)registerDebugRouterMessageHandlers;
+- (NSMutableDictionary<NSString *, id> *)debugRouterOpenPageResponseForURL:(NSString *)url;
+- (NSMutableDictionary<NSString *, id> *)debugRouterClosePageResponse;
+
+@end

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.mm
@@ -1,0 +1,170 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <DebugRouter/DebugRouter.h>
+#import <objc/runtime.h>
+
+#import "AppDelegate+DebugRouter.h"
+#import "DemoTemplateResourceFetcher.h"
+#import "TasmDispatcher.h"
+
+NSString *const DEBUG_ROUTER_APP_OPEN_PAGE = @"App.openPage";
+NSString *const DEBUG_ROUTER_APP_CLOSE_PAGE = @"App.closePage";
+
+static NSInteger const kDebugRouterAppActionSuccessCode = 0;
+static NSInteger const kDebugRouterAppActionFailedCode = -1;
+static const void *kAppOpenPageMessageHandlerKey = &kAppOpenPageMessageHandlerKey;
+static const void *kAppClosePageMessageHandlerKey = &kAppClosePageMessageHandlerKey;
+
+static NSMutableDictionary<NSString *, id> *LynxExplorerDebugRouterResponse(NSInteger code,
+                                                                            NSString *message) {
+  NSMutableDictionary<NSString *, id> *response = [[NSMutableDictionary alloc] initWithDictionary:@{
+    @"code" : @(code)
+  }];
+  if (message.length > 0) {
+    response[@"message"] = message;
+  }
+  return response;
+}
+
+static DebugRouterMessageHandleResult *LynxExplorerDebugRouterHandleResultFromResponse(
+    NSDictionary<NSString *, id> *response) {
+  NSInteger code = [response[@"code"] integerValue];
+  NSString *message = response[@"message"];
+  if (code == kDebugRouterAppActionSuccessCode) {
+    return [[DebugRouterMessageHandleResult alloc] init];
+  }
+  return [[DebugRouterMessageHandleResult alloc] initWithCode:(int)code message:message ?: @""];
+}
+
+static void LynxExplorerRunOnMainThreadSync(dispatch_block_t block) {
+  if (NSThread.isMainThread) {
+    block();
+    return;
+  }
+  dispatch_sync(dispatch_get_main_queue(), block);
+}
+
+@interface LynxExplorerOpenPageMessageHandler : NSObject <DebugRouterMessageHandler>
+
+- (instancetype)initWithAppDelegate:(AppDelegate *)appDelegate;
+
+@end
+
+@interface LynxExplorerClosePageMessageHandler : NSObject <DebugRouterMessageHandler>
+
+- (instancetype)initWithAppDelegate:(AppDelegate *)appDelegate;
+
+@end
+
+@implementation LynxExplorerOpenPageMessageHandler {
+  __weak AppDelegate *_appDelegate;
+}
+
+- (instancetype)initWithAppDelegate:(AppDelegate *)appDelegate {
+  self = [super init];
+  if (self) {
+    _appDelegate = appDelegate;
+  }
+  return self;
+}
+
+- (nonnull NSString *)getName {
+  return DEBUG_ROUTER_APP_OPEN_PAGE;
+}
+
+- (nonnull DebugRouterMessageHandleResult *)handleMessageWithParams:
+    (NSMutableDictionary<NSString *, NSString *> *)params {
+  return LynxExplorerDebugRouterHandleResultFromResponse(
+      [_appDelegate debugRouterOpenPageResponseForURL:params[@"url"]]);
+}
+
+@end
+
+@implementation LynxExplorerClosePageMessageHandler {
+  __weak AppDelegate *_appDelegate;
+}
+
+- (instancetype)initWithAppDelegate:(AppDelegate *)appDelegate {
+  self = [super init];
+  if (self) {
+    _appDelegate = appDelegate;
+  }
+  return self;
+}
+
+- (nonnull NSString *)getName {
+  return DEBUG_ROUTER_APP_CLOSE_PAGE;
+}
+
+- (nonnull DebugRouterMessageHandleResult *)handleMessageWithParams:
+    (NSMutableDictionary<NSString *, NSString *> *)params {
+  return LynxExplorerDebugRouterHandleResultFromResponse(
+      [_appDelegate debugRouterClosePageResponse]);
+}
+
+@end
+
+@implementation AppDelegate (DebugRouter)
+
+- (void)registerDebugRouterMessageHandlers {
+  id<DebugRouterMessageHandler> openPageHandler =
+      [[LynxExplorerOpenPageMessageHandler alloc] initWithAppDelegate:self];
+  id<DebugRouterMessageHandler> closePageHandler =
+      [[LynxExplorerClosePageMessageHandler alloc] initWithAppDelegate:self];
+  objc_setAssociatedObject(self, kAppOpenPageMessageHandlerKey, openPageHandler,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  objc_setAssociatedObject(self, kAppClosePageMessageHandlerKey, closePageHandler,
+                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  [[DebugRouter instance] addMessageHandler:openPageHandler];
+  [[DebugRouter instance] addMessageHandler:closePageHandler];
+}
+
+- (BOOL)isDebugRouterSupportedURL:(NSString *)url {
+  if (url.length == 0) {
+    return NO;
+  }
+
+  LocalBundleResult localResult = [DemoTemplateResourceFetcher readLocalBundleFromResource:url];
+  if (localResult.isLocalScheme || localResult.isLynxRecorderSchema) {
+    return YES;
+  }
+
+  NSString *encodedURL =
+      [url stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet
+                                                                  URLFragmentAllowedCharacterSet]];
+  NSURL *parsedURL = [NSURL URLWithString:encodedURL];
+  NSString *scheme = parsedURL.scheme.lowercaseString;
+  return [scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"];
+}
+
+- (NSMutableDictionary<NSString *, id> *)debugRouterOpenPageResponseForURL:(NSString *)url {
+  if (url.length == 0) {
+    return LynxExplorerDebugRouterResponse(kDebugRouterAppActionFailedCode, @"url is required");
+  }
+  if (![self isDebugRouterSupportedURL:url]) {
+    return LynxExplorerDebugRouterResponse(kDebugRouterAppActionFailedCode, @"unsupported url");
+  }
+
+  LynxExplorerRunOnMainThreadSync(^{
+    [[TasmDispatcher sharedInstance] openTargetUrl:url];
+  });
+  return LynxExplorerDebugRouterResponse(kDebugRouterAppActionSuccessCode, nil);
+}
+
+- (NSMutableDictionary<NSString *, id> *)debugRouterClosePageResponse {
+  __block NSMutableDictionary<NSString *, id> *response = nil;
+  LynxExplorerRunOnMainThreadSync(^{
+    if (self.navigationController.viewControllers.count <= 1) {
+      response =
+          LynxExplorerDebugRouterResponse(kDebugRouterAppActionFailedCode, @"no page to close");
+      return;
+    }
+    [self.navigationController popViewControllerAnimated:YES];
+    response = LynxExplorerDebugRouterResponse(kDebugRouterAppActionSuccessCode, nil);
+  });
+  return response;
+}
+
+@end

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate+DebugRouter.mm
@@ -3,7 +3,6 @@
 // LICENSE file in the root directory of this source tree.
 
 #import <DebugRouter/DebugRouter.h>
-#import <objc/runtime.h>
 
 #import "AppDelegate+DebugRouter.h"
 #import "DemoTemplateResourceFetcher.h"
@@ -14,8 +13,6 @@ NSString *const DEBUG_ROUTER_APP_CLOSE_PAGE = @"App.closePage";
 
 static NSInteger const kDebugRouterAppActionSuccessCode = 0;
 static NSInteger const kDebugRouterAppActionFailedCode = -1;
-static const void *kAppOpenPageMessageHandlerKey = &kAppOpenPageMessageHandlerKey;
-static const void *kAppClosePageMessageHandlerKey = &kAppClosePageMessageHandlerKey;
 
 static NSMutableDictionary<NSString *, id> *LynxExplorerDebugRouterResponse(NSInteger code,
                                                                             NSString *message) {
@@ -113,10 +110,6 @@ static void LynxExplorerRunOnMainThreadSync(dispatch_block_t block) {
       [[LynxExplorerOpenPageMessageHandler alloc] initWithAppDelegate:self];
   id<DebugRouterMessageHandler> closePageHandler =
       [[LynxExplorerClosePageMessageHandler alloc] initWithAppDelegate:self];
-  objc_setAssociatedObject(self, kAppOpenPageMessageHandlerKey, openPageHandler,
-                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-  objc_setAssociatedObject(self, kAppClosePageMessageHandlerKey, closePageHandler,
-                           OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   [[DebugRouter instance] addMessageHandler:openPageHandler];
   [[DebugRouter instance] addMessageHandler:closePageHandler];
 }

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #import "AppDelegate.h"
+#import "AppDelegate+DebugRouter.h"
 #import "LynxDebugger.h"
 #import "LynxInitProcessor.h"
 #import "LynxViewShellViewController.h"
@@ -11,10 +12,6 @@
 NSString *const LOCAL_URL_PREFIX = @"file://lynx?local://";
 NSString *const HOMEPAGE_URL =
     @"file://lynx?local://homepage.lynx.bundle?fullscreen=true&orientation=portrait";
-
-@interface AppDelegate ()
-
-@end
 
 @implementation AppDelegate
 
@@ -30,6 +27,7 @@ NSString *const HOMEPAGE_URL =
   self.window.rootViewController = self.navigationController;
   self.window.backgroundColor = [UIColor whiteColor];
   [self.window makeKeyAndVisible];
+  [self registerDebugRouterMessageHandlers];
 
   [LynxDebugger setOpenCardCallback:^(NSString *url) {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
@@ -29,9 +29,14 @@ NSString *const HOMEPAGE_URL =
   [self.window makeKeyAndVisible];
   [self registerDebugRouterMessageHandlers];
 
+  __weak __typeof__(self) weakSelf = self;
   [LynxDebugger setOpenCardCallback:^(NSString *url) {
     dispatch_async(dispatch_get_main_queue(), ^{
-      [self openCard:url];
+      __strong __typeof__(weakSelf) strongSelf = weakSelf;
+      if (!strongSelf) {
+        return;
+      }
+      [strongSelf openCard:url];
     });
   }];
 

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorerTests/LynxExplorerTests.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorerTests/LynxExplorerTests.m
@@ -3,33 +3,61 @@
 // LICENSE file in the root directory of this source tree.
 
 #import <XCTest/XCTest.h>
+#import "AppDelegate+DebugRouter.h"
+#import "AppDelegate.h"
 
 @interface LynxExplorerTests : XCTestCase
+
+@property(nonatomic, strong) AppDelegate *appDelegate;
 
 @end
 
 @implementation LynxExplorerTests
 
 - (void)setUp {
-  // Put setup code here. This method is called before the invocation of each test method in the
-  // class.
+  [super setUp];
+  self.appDelegate = [[AppDelegate alloc] init];
+  self.appDelegate.navigationController = [[UINavigationController alloc] init];
 }
 
 - (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
+  self.appDelegate = nil;
+  [super tearDown];
 }
 
-- (void)testExample {
-  // This is an example of a functional test case.
-  // Use XCTAssert and related functions to verify your tests produce the correct results.
+- (void)testOpenPageFailsWhenURLIsMissing {
+  NSDictionary<NSString *, id> *result = [self.appDelegate debugRouterOpenPageResponseForURL:nil];
+
+  XCTAssertEqualObjects(result[@"code"], @(-1));
+  XCTAssertEqualObjects(result[@"message"], @"url is required");
 }
 
-- (void)testPerformanceExample {
-  // This is an example of a performance test case.
-  [self measureBlock:^{
-      // Put the code you want to measure the time of here.
-  }];
+- (void)testOpenPageSucceedsWhenURLIsSupported {
+  NSDictionary<NSString *, id> *result =
+      [self.appDelegate debugRouterOpenPageResponseForURL:@"https://example.com/page"];
+
+  XCTAssertEqualObjects(result[@"code"], @(0));
+  XCTAssertNil(result[@"message"]);
+}
+
+- (void)testClosePageFailsWhenNoPageCanBeClosed {
+  NSDictionary<NSString *, id> *result = [self.appDelegate debugRouterClosePageResponse];
+
+  XCTAssertEqualObjects(result[@"code"], @(-1));
+  XCTAssertEqualObjects(result[@"message"], @"no page to close");
+}
+
+- (void)testClosePageSucceedsWhenNavigationStackHasMoreThanOnePage {
+  UIViewController *rootViewController = [[UIViewController alloc] init];
+  UIViewController *detailViewController = [[UIViewController alloc] init];
+  [self.appDelegate.navigationController
+      setViewControllers:@[ rootViewController, detailViewController ]
+                animated:NO];
+
+  NSDictionary<NSString *, id> *result = [self.appDelegate debugRouterClosePageResponse];
+
+  XCTAssertEqualObjects(result[@"code"], @(0));
+  XCTAssertEqual(self.appDelegate.navigationController.viewControllers.count, 1);
 }
 
 @end


### PR DESCRIPTION
## Summary
- add DebugRouter message handlers for `App.openPage` and `App.closePage` in LynxExplorer iOS
- reuse the existing `TasmDispatcher` navigation flow for page opening and pop the current navigation stack page for closing
- add unit coverage for url validation and navigation stack close behavior

## Test Plan
- `xcodebuild test -workspace explorer/darwin/ios/lynx_explorer/LynxExplorer.xcworkspace -scheme LynxExplorerTests -destination 'platform=iOS Simulator,id=766B391E-B520-4A04-AF18-C2906AAA4D77'`
- command currently fails in pre-existing `LynxListLayoutManagerUnitTest::testVerticalLayout`
- `TestPlan/UTTest.xctestplan` has `LynxExplorerTests` disabled by default, so the scheme does not execute the new `LynxExplorerTests` cases yet