### PR TITLE
[Testing] Remove unused import in e2e test case

### DIFF
--- a/testing/integration_test/test_script/lib/android/app.py
+++ b/testing/integration_test/test_script/lib/android/app.py
@@ -2,7 +2,6 @@
 # Copyright 2021 The Lynx Authors. All rights reserved.
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
-import time
 
 from lynx_e2e.api.app import LynxApp as LynxAppBase
 

--- a/testing/integration_test/test_script/lib/common/utils.py
+++ b/testing/integration_test/test_script/lib/common/utils.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import threading
 import queue
+import threading
 
 from urllib.parse import urlparse, urlunparse, parse_qsl
 from lynx_e2e.api.config import settings


### PR DESCRIPTION
Use a switch to isolate accessability-label and lynx-test-tag to avoid being unable to run UI automation with lynx-test-tag after enabling accessibility on the page.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
