### PR TITLE
[Testing] Remove unused import in e2e test case

### DIFF
--- a/testing/integration_test/ENV_SETUP.md
+++ b/testing/integration_test/ENV_SETUP.md
@@ -8,6 +8,7 @@ Integration test uses [Lynx-E2E](https://pypi.org/project/lynx-e2e-appium) as th
 # First execute the environment preparation in the root directory of Lynx
 source tools/envsetup.sh
 tools/hab sync -f .
+
 # Install Appium by npm
 npm install -g appium@2.11.2
 # Install appium-doctor

--- a/testing/integration_test/demo_pages/build_and_copy.py
+++ b/testing/integration_test/demo_pages/build_and_copy.py
@@ -4,7 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 import os
 import shutil
-import subprocess
 import sys
 
 # Get the directory where the current script is located

--- a/testing/integration_test/test_script/lib/android/app.py
+++ b/testing/integration_test/test_script/lib/android/app.py
@@ -2,7 +2,6 @@
 # Copyright 2021 The Lynx Authors. All rights reserved.
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
-import time
 
 from lynx_e2e.api.app import LynxApp as LynxAppBase
 

--- a/testing/integration_test/test_script/lib/common/utils.py
+++ b/testing/integration_test/test_script/lib/common/utils.py
@@ -4,8 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-import threading
 import queue
+import threading
 
 from urllib.parse import urlparse, urlunparse, parse_qsl
 from lynx_e2e.api.config import settings

--- a/testing/integration_test/test_script/lib/test_runner/case_set.py
+++ b/testing/integration_test/test_script/lib/test_runner/case_set.py
@@ -8,7 +8,6 @@
 """
 import importlib
 import os
-from urllib.parse import urlparse
 
 from lib.common import utils
 

--- a/testing/integration_test/test_script/lib/test_runner/mixin/img_diff_mixin.py
+++ b/testing/integration_test/test_script/lib/test_runner/mixin/img_diff_mixin.py
@@ -5,7 +5,6 @@
 
 import os
 import cv2
-import time
 import numpy
 
 from lynx_e2e.api.config import settings

--- a/testing/integration_test/test_script/lib/test_runner/test_runner.py
+++ b/testing/integration_test/test_script/lib/test_runner/test_runner.py
@@ -6,9 +6,9 @@
 import os
 import errno
 import time
-from retrying import retry
 import socket
 import traceback
+from retrying import retry
 from lynx_e2e.api.logger import EnumLogLevel
 from lynx_e2e.api.exception import LynxCDPTimeoutException
 


### PR DESCRIPTION
Use a switch to isolate accessability-label and lynx-test-tag to avoid being unable to run UI automation with lynx-test-tag after enabling accessibility on the page.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
