### PR TITLE
[BugFix][Types] Add mouse enter and leave event typings

### DIFF
--- a/js_libraries/types/CHANGELOG.md
+++ b/js_libraries/types/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.9.2
+
+- Add `bindmouseenter` and `bindmouseleave` typings for mouse events.
+
 ## 3.9.1
 
 - lynx.requestResourcePrefetch support awaitComplete options.

--- a/js_libraries/types/package.json
+++ b/js_libraries/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/types",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "",
   "keywords": [
     "lynx",

--- a/js_libraries/types/test/common/events.test-d.ts
+++ b/js_libraries/types/test/common/events.test-d.ts
@@ -1,5 +1,5 @@
 import { assertType, describe, expect, expectTypeOf, it } from 'vitest';
-import { StandardProps, Target, TouchEvent, MainThread, AnimationEvent } from '../../types';
+import { StandardProps, Target, TouchEvent, MainThread, AnimationEvent, MouseEvent } from '../../types';
 
 describe('Test Basic Event Binding', () => {
   it('Test event bind', () => {
@@ -90,5 +90,21 @@ describe('Test Animation Events', () => {
     expectTypeOf<StandardProps['main-thread:bindtouchstart']>().parameter(0).toEqualTypeOf<MainThread.TouchEvent>();
     expectTypeOf<StandardProps['main-thread:bindtouchmove']>().parameter(0).toEqualTypeOf<MainThread.TouchEvent>();
     expectTypeOf<StandardProps['main-thread:bindtouchend']>().parameter(0).toEqualTypeOf<MainThread.TouchEvent>();
+  });
+});
+
+describe('Test Mouse Events', () => {
+  it('mouse enter and leave bind', () => {
+    expectTypeOf<StandardProps['bindmouseenter']>().exclude(undefined).toExtend<(e: MouseEvent) => void>();
+    expectTypeOf<StandardProps['bindmouseleave']>().exclude(undefined).toExtend<(e: MouseEvent) => void>();
+    expectTypeOf<StandardProps['main-thread:bindmouseenter']>().exclude(undefined).toExtend<(e: MainThread.MouseEvent) => void>();
+    expectTypeOf<StandardProps['main-thread:bindmouseleave']>().exclude(undefined).toExtend<(e: MainThread.MouseEvent) => void>();
+  });
+
+  it('mouse enter and leave event object', () => {
+    expectTypeOf<StandardProps['bindmouseenter']>().parameter(0).toEqualTypeOf<MouseEvent>();
+    expectTypeOf<StandardProps['bindmouseleave']>().parameter(0).toEqualTypeOf<MouseEvent>();
+    expectTypeOf<StandardProps['main-thread:bindmouseenter']>().parameter(0).toEqualTypeOf<MainThread.MouseEvent>();
+    expectTypeOf<StandardProps['main-thread:bindmouseleave']>().parameter(0).toEqualTypeOf<MainThread.MouseEvent>();
   });
 });

--- a/js_libraries/types/types/common/events.d.ts
+++ b/js_libraries/types/types/common/events.d.ts
@@ -764,6 +764,18 @@ export interface LynxEvent<T> {
   MouseMove?: EventHandler<BaseMouseEvent<T>>;
 
   /** 
+   * Indicates that a pointing device is moved onto the element.
+   * @PC
+   */
+  MouseEnter?: EventHandler<BaseMouseEvent<T>>;
+
+  /** 
+   * Indicates that a pointing device is moved off the element.
+   * @PC
+   */
+  MouseLeave?: EventHandler<BaseMouseEvent<T>>;
+
+  /** 
    * Mouse click.
    * @PC
    */
@@ -904,6 +916,8 @@ interface AnimationEndProps<T> { bindanimationend?: LynxEvent<T>['AnimationEnd']
 interface MouseDownProps<T> { bindmousedown?: LynxEvent<T>['MouseDown']; catchmousedown?: LynxEvent<T>['MouseDown']; 'capture-bindmousedown'?: LynxEvent<T>['MouseDown']; 'capture-catchmousedown'?: LynxEvent<T>['MouseDown']; 'global-bindmousedown'?: LynxEvent<T>['MouseDown']; }
 interface MouseUpProps<T> { bindmouseup?: LynxEvent<T>['MouseUp']; catchmouseup?: LynxEvent<T>['MouseUp']; 'capture-bindmouseup'?: LynxEvent<T>['MouseUp']; 'capture-catchmouseup'?: LynxEvent<T>['MouseUp']; 'global-bindmouseup'?: LynxEvent<T>['MouseUp']; }
 interface MouseMoveProps<T> { bindmousemove?: LynxEvent<T>['MouseMove']; catchmousemove?: LynxEvent<T>['MouseMove']; 'capture-bindmousemove'?: LynxEvent<T>['MouseMove']; 'capture-catchmousemove'?: LynxEvent<T>['MouseMove']; 'global-bindmousemove'?: LynxEvent<T>['MouseMove']; }
+interface MouseEnterProps<T> { bindmouseenter?: LynxEvent<T>['MouseEnter']; catchmouseenter?: LynxEvent<T>['MouseEnter']; 'capture-bindmouseenter'?: LynxEvent<T>['MouseEnter']; 'capture-catchmouseenter'?: LynxEvent<T>['MouseEnter']; 'global-bindmouseenter'?: LynxEvent<T>['MouseEnter']; }
+interface MouseLeaveProps<T> { bindmouseleave?: LynxEvent<T>['MouseLeave']; catchmouseleave?: LynxEvent<T>['MouseLeave']; 'capture-bindmouseleave'?: LynxEvent<T>['MouseLeave']; 'capture-catchmouseleave'?: LynxEvent<T>['MouseLeave']; 'global-bindmouseleave'?: LynxEvent<T>['MouseLeave']; }
 interface MouseClickProps<T> { bindmouseclick?: LynxEvent<T>['MouseClick']; catchmouseclick?: LynxEvent<T>['MouseClick']; 'capture-bindmouseclick'?: LynxEvent<T>['MouseClick']; 'capture-catchmouseclick'?: LynxEvent<T>['MouseClick']; 'global-bindmouseclick'?: LynxEvent<T>['MouseClick']; }
 interface MouseDblClickProps<T> { bindmousedblclick?: LynxEvent<T>['MouseDblClick']; catchmousedblclick?: LynxEvent<T>['MouseDblClick']; 'capture-bindmousedblclick'?: LynxEvent<T>['MouseDblClick']; 'capture-catchmousedblclick'?: LynxEvent<T>['MouseDblClick']; 'global-bindmousedblclick'?: LynxEvent<T>['MouseDblClick']; }
 interface MouseLongPressProps<T> { bindmouselongpress?: LynxEvent<T>['MouseLongPress']; catchmouselongpress?: LynxEvent<T>['MouseLongPress']; 'capture-bindmouselongpress'?: LynxEvent<T>['MouseLongPress']; 'capture-catchmouselongpress'?: LynxEvent<T>['MouseLongPress']; 'global-bindmouselongpress'?: LynxEvent<T>['MouseLongPress']; }
@@ -941,6 +955,8 @@ export type LynxEventPropsBase<T> = BGLoadProps<T> &
   MouseDownProps<T> &
   MouseUpProps<T> &
   MouseMoveProps<T> &
+  MouseEnterProps<T> &
+  MouseLeaveProps<T> &
   MouseClickProps<T> &
   MouseDblClickProps<T> &
   MouseLongPressProps<T> &


### PR DESCRIPTION
Summary of change:
- add MouseEnter and MouseLeave to common event declarations
- expose bindmouseenter and bindmouseleave in event props
- add type tests for the new mouse event bindings

TEST: Not run locally (js_libraries/types dependencies are not installed)