### PR TITLE
[Feature][DevTool] Support PerformanceEntry query in CDP Performance domain

### DIFF
--- a/core/services/performance/BUILD.gn
+++ b/core/services/performance/BUILD.gn
@@ -59,5 +59,6 @@ lynx_core_source_set("performance") {
   deps = [
     "../../../base/src:base_log_headers",
     "../../../third_party/rapidjson",
+    "../timing_handler",
   ]
 }

--- a/core/services/performance/performance_controller.cc
+++ b/core/services/performance/performance_controller.cc
@@ -28,6 +28,8 @@ void PerformanceController::SetPlatformImpl(
 void PerformanceController::OnPerformanceEvent(
     std::unique_ptr<pub::Value> entry, EventType type) {
   entry->PushInt32ToMap("instanceId", instance_id_);
+  performance_entries_.emplace_back(
+      pub::ValueUtils::ConvertValueToLepusValue(*entry));
   if ((type & kEventTypePlatform) && platform_impl_) {
     platform_impl_->OnPerformanceEvent(entry);
   }
@@ -35,6 +37,20 @@ void PerformanceController::OnPerformanceEvent(
     js_blocking_monitor_->OnPerformanceEvent(entry);
   }
   delegate_->OnPerformanceEvent(std::move(entry), type);
+}
+
+std::unique_ptr<pub::Value> PerformanceController::GetAllPerformanceEntries()
+    const {
+  auto entries = value_factory_->CreateArray();
+  for (const auto& entry : performance_entries_) {
+    entries->PushValueToArray(pub::ValueImplLepus(entry));
+  }
+  return entries;
+}
+
+void PerformanceController::ResetStateBeforeReload() {
+  timing_handler_.ResetTimingBeforeReload();
+  performance_entries_.clear();
 }
 
 }  // namespace performance

--- a/core/services/performance/performance_controller.h
+++ b/core/services/performance/performance_controller.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "base/include/lynx_actor.h"
 #include "core/public/pub_value.h"
@@ -36,10 +37,10 @@ class PerformanceController : public PerformanceEventSender {
       : PerformanceEventSender(std::make_shared<pub::PubValueFactoryDefault>()),
         instance_id_(instance_id),
         delegate_(std::move(delegate)),
+        js_blocking_monitor_(std::make_shared<JSBlockingMonitor>(this)),
         memory_monitor_(this, instance_id),
         timing_handler_(
-            timing::TimingHandler(std::move(timing_delegate), this)),
-        js_blocking_monitor_(std::make_shared<JSBlockingMonitor>(this)) {}
+            timing::TimingHandler(std::move(timing_delegate), this)) {}
   ~PerformanceController() override;
 
   static fml::RefPtr<fml::TaskRunner> GetTaskRunner();
@@ -71,6 +72,8 @@ class PerformanceController : public PerformanceEventSender {
   std::shared_ptr<JSBlockingMonitor>& GetJSBlockingMonitor() {
     return js_blocking_monitor_;
   }
+  std::unique_ptr<pub::Value> GetAllPerformanceEntries() const;
+  void ResetStateBeforeReload();
 
   void SetInstanceId(int32_t instance_id) { instance_id_ = instance_id; }
 
@@ -85,9 +88,12 @@ class PerformanceController : public PerformanceEventSender {
   int32_t instance_id_ = report::kUninitializedInstanceId;
   std::unique_ptr<PerformanceEventSender> delegate_;
   std::unique_ptr<PerformanceControllerPlatformImpl> platform_impl_;
+  // Keep members touched by OnPerformanceEvent alive until after
+  // MemoryMonitor reports its final teardown event.
+  std::vector<lepus::Value> performance_entries_;
+  std::shared_ptr<JSBlockingMonitor> js_blocking_monitor_;
   MemoryMonitor memory_monitor_;
   timing::TimingHandler timing_handler_;
-  std::shared_ptr<JSBlockingMonitor> js_blocking_monitor_;
 };
 
 }  // namespace performance

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -1535,6 +1535,14 @@ LYNX_EXPORT_FOR_DEVTOOL const lepus::Value LynxShell::GetAllTimingInfo() const {
   });
 }
 
+LYNX_EXPORT_FOR_DEVTOOL const lepus::Value LynxShell::GetAllPerformanceEntries()
+    const {
+  return perf_controller_actor_->ActSync([](auto& performance) {
+    auto all_performance_entries = performance->GetAllPerformanceEntries();
+    return pub::ValueUtils::ConvertValueToLepusValue(*all_performance_entries);
+  });
+}
+
 void LynxShell::SetSSRTimingData(std::string url, uint64_t data_size) const {
   perf_controller_actor_->ActAsync(
       [url = std::move(url), data_size](auto& performance) {
@@ -1571,9 +1579,8 @@ void LynxShell::OnPipelineStart(
 }
 
 void LynxShell::ResetTimingBeforeReload() const {
-  perf_controller_actor_->ActAsync([](auto& performance) {
-    performance->GetTimingHandler().ResetTimingBeforeReload();
-  });
+  perf_controller_actor_->ActAsync(
+      [](auto& performance) { performance->ResetStateBeforeReload(); });
 }
 
 void LynxShell::SetInspectorElementObserver(

--- a/core/shell/lynx_shell.h
+++ b/core/shell/lynx_shell.h
@@ -363,6 +363,7 @@ class LynxShell {
                  tasm::PipelineID pipeline_id) const;
 
   const lepus::Value GetAllTimingInfo() const;
+  const lepus::Value GetAllPerformanceEntries() const;
 
   // TODO(kechenglong): should find a better way to set SSR timing data?
   void SetSSRTimingData(std::string url, uint64_t data_size) const;

--- a/core/shell/lynx_shell_unittest.cc
+++ b/core/shell/lynx_shell_unittest.cc
@@ -13,6 +13,9 @@
 
 #include "base/include/debug/lynx_error.h"
 #include "base/include/value/base_value.h"
+#include "core/public/pub_value.h"
+#include "core/services/performance/memory_monitor/memory_monitor.h"
+#include "core/services/performance/memory_monitor/memory_record.h"
 #include "core/shell/lynx_shell_builder.h"
 #include "core/shell/testing/mock_native_facade.h"
 #include "core/shell/testing/mock_runner_manufactor.h"
@@ -28,6 +31,7 @@ class LynxShellTest : public ::testing::Test {
 
   void SetUp() override {
     base::UIThread::Init();
+    lynx::tasm::performance::MemoryMonitor::SetForceEnable(false);
     facade_ = new MockNativeFacade;
 
     // FIXME(heshan): tricky, here must ensure manufactor not create thread
@@ -66,6 +70,7 @@ class LynxShellTest : public ::testing::Test {
     shell_->OnEnterForeground();
 
     shell_ = nullptr;
+    lynx::tasm::performance::MemoryMonitor::SetForceEnable(false);
   }
 
   MockNativeFacade* facade_;
@@ -114,6 +119,57 @@ TEST_F(LynxShellTest, OnUpdateDataWithoutChange) {
   tasm_mediator_->OnUpdateDataWithoutChange();
   arwe_->Wait();
   ASSERT_TRUE(*facade_);
+}
+
+TEST_F(LynxShellTest, GetAllPerformanceEntries) {
+  shell_->perf_controller_actor_->ActSync([](auto& controller) {
+    auto entry = controller->GetValueFactory()->CreateMap();
+    entry->PushStringToMap("entryType", "metric");
+    entry->PushStringToMap("name", "testMetric");
+    entry->PushDoubleToMap("startTime", 1.5);
+    controller->OnPerformanceEvent(std::move(entry));
+  });
+
+  lepus::Value entries = shell_->GetAllPerformanceEntries();
+  ASSERT_TRUE(entries.IsArray());
+  ASSERT_EQ(entries.Array()->size(), 1u);
+
+  lepus::Value first_entry = entries.Array()->get(0);
+  ASSERT_TRUE(first_entry.IsTable());
+  ASSERT_EQ(first_entry.Table()->GetValue("entryType").String().str(),
+            "metric");
+  ASSERT_EQ(first_entry.Table()->GetValue("name").String().str(), "testMetric");
+  ASSERT_DOUBLE_EQ(first_entry.Table()->GetValue("startTime").Number(), 1.5);
+  ASSERT_EQ(first_entry.Table()->GetValue("instanceId").Int32(),
+            shell_->perf_controller_actor_->GetInstanceId());
+}
+
+TEST_F(LynxShellTest, MemoryMonitorTeardownAfterAllocation) {
+  lynx::tasm::performance::MemoryMonitor::SetForceEnable(true);
+  shell_->perf_controller_actor_->ActSync([](auto& controller) {
+    controller->GetMemoryMonitor().AllocateMemory(
+        lynx::tasm::performance::MemoryRecord("test", 1024));
+  });
+
+  lepus::Value entries = shell_->GetAllPerformanceEntries();
+  ASSERT_TRUE(entries.IsArray());
+  ASSERT_GT(entries.Array()->size(), 0u);
+}
+
+TEST_F(LynxShellTest, ResetTimingBeforeReloadClearsPerformanceEntries) {
+  shell_->perf_controller_actor_->ActSync([](auto& controller) {
+    auto entry = controller->GetValueFactory()->CreateMap();
+    entry->PushStringToMap("entryType", "metric");
+    entry->PushStringToMap("name", "beforeReload");
+    controller->OnPerformanceEvent(std::move(entry));
+  });
+
+  shell_->ResetTimingBeforeReload();
+  shell_->perf_controller_actor_->ActSync([](auto& controller) {});
+
+  lepus::Value entries = shell_->GetAllPerformanceEntries();
+  ASSERT_TRUE(entries.IsArray());
+  ASSERT_EQ(entries.Array()->size(), 0u);
 }
 
 }  // namespace shell

--- a/core/shell/runtime/bts/bts_runtime_mediator.cc
+++ b/core/shell/runtime/bts/bts_runtime_mediator.cc
@@ -554,9 +554,8 @@ void BTSRuntimeMediator::ResetTimingBeforeReload() {
   if (!perf_controller_actor_) {
     return;
   }
-  perf_controller_actor_->ActAsync([](auto& performance) {
-    performance->GetTimingHandler().ResetTimingBeforeReload();
-  });
+  perf_controller_actor_->ActAsync(
+      [](auto& performance) { performance->ResetStateBeforeReload(); });
 }
 
 void BTSRuntimeMediator::AddJSBlockingTime(uint64_t enqueue_time) {

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_performance_agent.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_performance_agent.cc
@@ -14,6 +14,8 @@ InspectorPerformanceAgent::InspectorPerformanceAgent(
   functions_map_["Performance.disable"] = &InspectorPerformanceAgent::Disable;
   functions_map_["Performance.getAllTimingInfo"] =
       &InspectorPerformanceAgent::getAllTimingInfo;
+  functions_map_["Performance.getAllPerformanceEntries"] =
+      &InspectorPerformanceAgent::getAllPerformanceEntries;
 }
 
 InspectorPerformanceAgent::~InspectorPerformanceAgent() = default;
@@ -31,6 +33,11 @@ void InspectorPerformanceAgent::Disable(
 void InspectorPerformanceAgent::getAllTimingInfo(
     const std::shared_ptr<MessageSender>& sender, const Json::Value& message) {
   devtool_mediator_->getAllTimingInfo(sender, message);
+}
+
+void InspectorPerformanceAgent::getAllPerformanceEntries(
+    const std::shared_ptr<MessageSender>& sender, const Json::Value& message) {
+  devtool_mediator_->getAllPerformanceEntries(sender, message);
 }
 
 void InspectorPerformanceAgent::CallMethod(

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_performance_agent.h
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_performance_agent.h
@@ -30,6 +30,8 @@ class InspectorPerformanceAgent : public CDPDomainAgentBase {
                const Json::Value& message);
   void getAllTimingInfo(const std::shared_ptr<MessageSender>& sender,
                         const Json::Value& message);
+  void getAllPerformanceEntries(const std::shared_ptr<MessageSender>& sender,
+                                const Json::Value& message);
   std::map<std::string, PerformanceAgentMethod> functions_map_;
   const std::shared_ptr<LynxDevToolMediator> devtool_mediator_;
 };

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -635,6 +635,28 @@ void InspectorUIExecutor::getAllTimingInfo(
   sender->SendMessage("CDP", response);
 }
 
+void InspectorUIExecutor::getAllPerformanceEntries(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  Json::Value response(Json::ValueType::objectValue);
+  if (!ShellIsDestroyed()) {
+    Json::Value entries;
+    Json::Value result(Json::ValueType::objectValue);
+    Json::Reader reader;
+
+    lynx::lepus::Value all_performance_entries =
+        shell_->GetAllPerformanceEntries();
+    std::string entries_string =
+        lynx::devtool::ConvertLepusValueToJsonValue(all_performance_entries);
+
+    reader.parse(entries_string, entries);
+    result["entries"] = entries;
+    response["result"] = result;
+  }
+  response["id"] = message["id"].asInt64();
+  sender->SendMessage("CDP", response);
+}
+
 // end performance protocol
 
 // start input protocol

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.h
@@ -64,6 +64,7 @@ class InspectorUIExecutor
   DECLARE_DEVTOOL_METHOD(PerformanceEnable)
   DECLARE_DEVTOOL_METHOD(PerformanceDisable)
   DECLARE_DEVTOOL_METHOD(getAllTimingInfo)
+  DECLARE_DEVTOOL_METHOD(getAllPerformanceEntries)
 
   // Input domain
   DECLARE_DEVTOOL_METHOD(EmulateTouchFromMouseEvent)

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
@@ -1099,6 +1099,14 @@ void LynxDevToolMediator::getAllTimingInfo(
   });
 }
 
+void LynxDevToolMediator::getAllPerformanceEntries(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  RunOnUIThread([sender, message, executor = ui_executor_] {
+    executor->getAllPerformanceEntries(sender, message);
+  });
+}
+
 void LynxDevToolMediator::LogEnable(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
@@ -137,6 +137,7 @@ class LynxDevToolMediator
   DECLARE_DEVTOOL_METHOD(PerformanceEnable)
   DECLARE_DEVTOOL_METHOD(PerformanceDisable)
   DECLARE_DEVTOOL_METHOD(getAllTimingInfo)
+  DECLARE_DEVTOOL_METHOD(getAllPerformanceEntries)
 
   // Input domain -> ui executor
   DECLARE_DEVTOOL_METHOD(EmulateTouchFromMouseEvent)

--- a/devtool/lynx_devtool/element/helper_util.cc
+++ b/devtool/lynx_devtool/element/helper_util.cc
@@ -58,6 +58,19 @@ std::string ConvertLepusValueToJsonValue(const lynx::lepus::Value& lepus_value,
       result = std::to_string(lepus_value.Number());
       break;
     }
+    case lynx::lepus::ValueType::Value_Array: {
+      std::string array_string;
+      auto array = lepus_value.Array();
+      for (size_t i = 0; i < array->size(); ++i) {
+        array_string += ConvertLepusValueToJsonValue(array->get(i), sort_keys);
+        array_string += ",";
+      }
+      if (!array_string.empty()) {
+        array_string.pop_back();
+      }
+      result = "[" + array_string + "]";
+      break;
+    }
     case lynx::lepus::ValueType::Value_Table: {
       std::string table_string =
           convertLepusTableToDictionaryString(lepus_value, sort_keys);

--- a/devtool/lynx_devtool/element/helper_util_unittest.cc
+++ b/devtool/lynx_devtool/element/helper_util_unittest.cc
@@ -62,6 +62,15 @@ TEST(HelperUtilTest, ConvertLepusValueToJsonValueTest) {
   EXPECT_EQ(ConvertLepusValueToJsonValue(dict2, true),
             "{\"a\": null,\"b\": 3.897560,\"f\": {\"c\": 1,\"d\": "
             "\"url_link\",\"e\": 3333335},\"g\": {}}");
+
+  lepus::Value array1(lepus::CArray::Create());
+  array1.SetProperty(0, lepus::Value("foo"));
+  array1.SetProperty(1, lepus::Value(42));
+  lepus::Value array_item(lepus::Dictionary::Create());
+  array_item.SetProperty("ok", lepus::Value(true));
+  array1.SetProperty(2, array_item);
+  EXPECT_EQ(ConvertLepusValueToJsonValue(array1, true),
+            "[\"foo\",42,{\"ok\": 1}]");
 }
 
 TEST(HelperUtilTest, NormalizeAnimationStringTest) {

--- a/devtool/testing/agent/devtool_mediator_unittest.cc
+++ b/devtool/testing/agent/devtool_mediator_unittest.cc
@@ -393,6 +393,15 @@ TEST_F(DevToolMediatorTest, GetAllTimingInfoTest) {
             "{\n   \"id\" : 1\n}\n");
 }
 
+TEST_F(DevToolMediatorTest, GetAllPerformanceEntriesTest) {
+  Json::Value param;
+  param["id"] = 1;
+  devtool_mediator_->getAllPerformanceEntries(message_sender_, param);
+  ui_thread_->Join();
+  EXPECT_EQ(devtool::MockReceiver::GetInstance().received_message_.second,
+            "{\n   \"id\" : 1\n}\n");
+}
+
 TEST_F(DevToolMediatorTest, AddCDPEventListener) {
   auto listener_sender =
       std::make_shared<devtool::CDPEventListenerSenderMock>();

--- a/platform/darwin/common/lynx/performance/LynxPerformanceController.mm
+++ b/platform/darwin/common/lynx/performance/LynxPerformanceController.mm
@@ -211,7 +211,7 @@ std::unique_ptr<std::unordered_map<std::string, std::string>> ConvertNSDictToUno
     return;
   }
   [self ActAsync:^(const std::unique_ptr<performance::PerformanceController>& controller) {
-    controller->GetTimingHandler().ResetTimingBeforeReload();
+    controller->ResetStateBeforeReload();
   }];
 }
 

--- a/platform/darwin/common/lynx/performance/LynxPerformanceControllerUnitTest.mm
+++ b/platform/darwin/common/lynx/performance/LynxPerformanceControllerUnitTest.mm
@@ -146,6 +146,46 @@ class MockPerformanceSender : public performance::PerformanceEventSender {
       }];
 }
 
+- (void)testMemoryMonitorTeardownAfterAllocation {
+  NSString *category = @"test";
+  float sizeBytes = 1024;
+
+  [self
+      asyncVerify:^{
+        [self.controller allocateMemory:^LynxMemoryRecord * {
+          return [[LynxMemoryRecord alloc] initWithCategory:category
+                                                  sizeBytes:sizeBytes
+                                                     detail:nil];
+        }];
+      }
+      check:^(LynxPerformanceEntry *entry) {
+        XCTAssertEqualObjects(entry.name, @"memory");
+        XCTAssertEqualObjects(entry.entryType, @"memory");
+      }];
+
+  _actor.reset();
+}
+
+- (void)testResetTimingBeforeReloadClearsPerformanceEntries {
+  [self
+      asyncVerify:^{
+        [self.controller onPerformanceEvent:[[LynxPerformanceEntry alloc] init]];
+      }
+      check:^(LynxPerformanceEntry *entry) {
+        XCTAssertNotNil(entry);
+      }];
+
+  [self.controller resetTimingBeforeReload];
+  _actor->ActSync([](const std::unique_ptr<performance::PerformanceController> &) {});
+
+  size_t entriesCount =
+      _actor->ActSync([](const std::unique_ptr<performance::PerformanceController> &controller) {
+        auto entries = controller->GetAllPerformanceEntries();
+        return static_cast<size_t>(entries->Length());
+      });
+  XCTAssertEqual(entriesCount, 0u);
+}
+
 - (void)testTimingCollectorProtocolMethods {
   NSString *testKey = @"testMark";
   XCTAssertNoThrow([self.controller markTiming:testKey pipelineID:nil]);


### PR DESCRIPTION
## Summary
- add `Performance.getAllPerformanceEntries` to the CDP Performance domain
- cache `PerformanceEntry` records in `PerformanceController` and expose them through `LynxShell`
- add devtool and shell unit tests for the new query path

## Why
- CDP previously only supported `Performance.getAllTimingInfo`
- DevTools integrations also need structured `PerformanceEntry` access instead of only aggregated timing maps

## Validation
- rebuilt the modified native targets with `buildtools/ninja/ninja -C out/Default obj/core/services/performance/performance.performance_controller.o obj/core/shell/shell.lynx_shell.o obj/core/shell/shell_testset.lynx_shell_unittest.o obj/devtool/lynx_devtool/agent/domain_agent/agent.inspector_performance_agent.o obj/devtool/lynx_devtool/agent/agent.inspector_ui_executor.o obj/devtool/lynx_devtool/agent/agent.lynx_devtool_mediator.o obj/devtool/testing/agent/devtool_agent_testset.devtool_mediator_unittest.o`
- full native unittest executable build is currently blocked in this environment by an unrelated `third_party/libcxx` compile issue

Closes #6076
