### PR TITLE
fix: 1.the hide not called in the subroute goback 2.the card manager …

### DIFF
--- a/platform/darwin/common/lynx/navigator/LynxCardManager.m
+++ b/platform/darwin/common/lynx/navigator/LynxCardManager.m
@@ -14,11 +14,6 @@
 
 @implementation LynxCardManager
 
-@synthesize routeStack = _routeStack;
-@synthesize lruCache = _lruCache;
-@synthesize lynxView = _lynxView;
-@synthesize holder = _holder;
-
 - (void)hideLynxView:(LynxView*)lynxView {
 #if OS_IOS
   if (lynxView) {

--- a/platform/darwin/common/lynx/navigator/LynxNavigator.m
+++ b/platform/darwin/common/lynx/navigator/LynxNavigator.m
@@ -4,6 +4,12 @@
 
 #import <Lynx/LynxCardManager.h>
 #import <Lynx/LynxNavigator.h>
+#import "LynxBaseCardManager+Private.h"
+
+@interface LynxNavigator ()
+- (LynxCardManager *)getCurrentCardManager;
+- (LynxCardManager *)cardManagerForHolder:(id<LynxHolder>)lynxHolder;
+@end
 
 @implementation LynxNavigator {
   NSMutableArray<LynxCardManager *> *_innerCardManagerStack;
@@ -40,9 +46,7 @@
 }
 
 - (void)unregisterLynxHolder:(id<LynxHolder>)lynxHolder {
-  //  LynxCardManager *cardManager = [_pageDict objectForKey:lynxHolder];
-  //  [_pageDict removeObjectForKey:lynxHolder];
-  LynxCardManager *cardManager = [self getCurrentCardManager];
+  LynxCardManager *cardManager = [self cardManagerForHolder:lynxHolder];
   if (cardManager) {
     [cardManager clearCaches];
     [_innerCardManagerStack removeObject:cardManager];
@@ -94,12 +98,32 @@
   return [_innerCardManagerStack lastObject];
 }
 
+- (LynxCardManager *)cardManagerForHolder:(id<LynxHolder>)lynxHolder {
+  if (!lynxHolder) {
+    return nil;
+  }
+  for (LynxCardManager *cardManager in [_innerCardManagerStack reverseObjectEnumerator]) {
+    if (cardManager.holder == lynxHolder) {
+      return cardManager;
+    }
+  }
+  return nil;
+}
+
 - (void)didEnterForeground:(id<LynxHolder>)lynxHolder {
-  [[self getCurrentCardManager] didEnterForeground];
+  LynxCardManager *cardManager = [self cardManagerForHolder:lynxHolder];
+  if (!cardManager) {
+    cardManager = [self getCurrentCardManager];
+  }
+  [cardManager didEnterForeground];
 }
 
 - (void)didEnterBackground:(id<LynxHolder>)lynxHolder {
-  [[self getCurrentCardManager] didEnterBackground];
+  LynxCardManager *cardManager = [self cardManagerForHolder:lynxHolder];
+  if (!cardManager) {
+    cardManager = [self getCurrentCardManager];
+  }
+  [cardManager didEnterBackground];
 }
 
 @end

--- a/platform/darwin/ios/lynx/hero_transitions/LynxHeroTransition.m
+++ b/platform/darwin/ios/lynx/hero_transitions/LynxHeroTransition.m
@@ -210,12 +210,13 @@
         }
       }
     }
-    if (callback) {
-      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, animLength * NSEC_PER_SEC),
-                     dispatch_get_main_queue(), ^{
+  }
+  
+  if (callback) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, animLength * NSEC_PER_SEC),
+                 dispatch_get_main_queue(), ^{
                        callback();
                      });
-    }
   }
 }
 


### PR DESCRIPTION
Summary
This PR addresses several stability issues in Lynx view and routing handling:

1. When multiple Lynx views coexist, CardManager currently relies on a singleton array for lifecycle management, which can introduce lookup ambiguity and state inconsistency risks.
2. In sub-route navigation, the callback block is not executed when triggering goBack.
3. The current @synthesize pattern may cause an incorrect holder pointer address in subclasses.
These changes improve instance binding correctness, ensure goBack callbacks are reliably invoked, and reduce cross-view state confusion under multi-view scenarios.

