### PR TITLE
[Optimize][DevTool] Gate PerformanceEntry cache by DevTool state

### DIFF
--- a/core/services/performance/performance_controller.cc
+++ b/core/services/performance/performance_controller.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "core/public/performance_controller_platform_impl.h"
+#include "core/renderer/utils/lynx_env.h"
 #include "core/services/event_report/event_tracker_platform_impl.h"
 #include "core/services/performance/performance_event_sender.h"
 
@@ -28,8 +29,10 @@ void PerformanceController::SetPlatformImpl(
 void PerformanceController::OnPerformanceEvent(
     std::unique_ptr<pub::Value> entry, EventType type) {
   entry->PushInt32ToMap("instanceId", instance_id_);
-  performance_entries_.emplace_back(
-      pub::ValueUtils::ConvertValueToLepusValue(*entry));
+  if (tasm::LynxEnv::GetInstance().IsDevToolEnabled()) {
+    performance_entries_.emplace_back(
+        pub::ValueUtils::ConvertValueToLepusValue(*entry));
+  }
   if ((type & kEventTypePlatform) && platform_impl_) {
     platform_impl_->OnPerformanceEvent(entry);
   }
@@ -42,6 +45,9 @@ void PerformanceController::OnPerformanceEvent(
 std::unique_ptr<pub::Value> PerformanceController::GetAllPerformanceEntries()
     const {
   auto entries = value_factory_->CreateArray();
+  if (!tasm::LynxEnv::GetInstance().IsDevToolEnabled()) {
+    return entries;
+  }
   for (const auto& entry : performance_entries_) {
     entries->PushValueToArray(pub::ValueImplLepus(entry));
   }

--- a/core/shell/lynx_shell_unittest.cc
+++ b/core/shell/lynx_shell_unittest.cc
@@ -14,6 +14,7 @@
 #include "base/include/debug/lynx_error.h"
 #include "base/include/value/base_value.h"
 #include "core/public/pub_value.h"
+#include "core/renderer/utils/lynx_env.h"
 #include "core/services/performance/memory_monitor/memory_monitor.h"
 #include "core/services/performance/memory_monitor/memory_record.h"
 #include "core/shell/lynx_shell_builder.h"
@@ -32,6 +33,9 @@ class LynxShellTest : public ::testing::Test {
   void SetUp() override {
     base::UIThread::Init();
     lynx::tasm::performance::MemoryMonitor::SetForceEnable(false);
+    auto& env = lynx::tasm::LynxEnv::GetInstance();
+    env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, false);
+    env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, false);
     facade_ = new MockNativeFacade;
 
     // FIXME(heshan): tricky, here must ensure manufactor not create thread
@@ -71,6 +75,9 @@ class LynxShellTest : public ::testing::Test {
 
     shell_ = nullptr;
     lynx::tasm::performance::MemoryMonitor::SetForceEnable(false);
+    auto& env = lynx::tasm::LynxEnv::GetInstance();
+    env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, false);
+    env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, false);
   }
 
   MockNativeFacade* facade_;
@@ -122,6 +129,10 @@ TEST_F(LynxShellTest, OnUpdateDataWithoutChange) {
 }
 
 TEST_F(LynxShellTest, GetAllPerformanceEntries) {
+  auto& env = lynx::tasm::LynxEnv::GetInstance();
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, true);
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, true);
+
   shell_->perf_controller_actor_->ActSync([](auto& controller) {
     auto entry = controller->GetValueFactory()->CreateMap();
     entry->PushStringToMap("entryType", "metric");
@@ -144,7 +155,29 @@ TEST_F(LynxShellTest, GetAllPerformanceEntries) {
             shell_->perf_controller_actor_->GetInstanceId());
 }
 
+TEST_F(LynxShellTest, GetAllPerformanceEntriesReturnsEmptyWhenDevToolDisabled) {
+  auto& env = lynx::tasm::LynxEnv::GetInstance();
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, false);
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, false);
+
+  shell_->perf_controller_actor_->ActSync([](auto& controller) {
+    auto entry = controller->GetValueFactory()->CreateMap();
+    entry->PushStringToMap("entryType", "metric");
+    entry->PushStringToMap("name", "testMetric");
+    entry->PushDoubleToMap("startTime", 1.5);
+    controller->OnPerformanceEvent(std::move(entry));
+  });
+
+  lepus::Value entries = shell_->GetAllPerformanceEntries();
+  ASSERT_TRUE(entries.IsArray());
+  ASSERT_EQ(entries.Array()->size(), 0u);
+}
+
 TEST_F(LynxShellTest, MemoryMonitorTeardownAfterAllocation) {
+  auto& env = lynx::tasm::LynxEnv::GetInstance();
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, true);
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, true);
+
   lynx::tasm::performance::MemoryMonitor::SetForceEnable(true);
   shell_->perf_controller_actor_->ActSync([](auto& controller) {
     controller->GetMemoryMonitor().AllocateMemory(
@@ -157,6 +190,10 @@ TEST_F(LynxShellTest, MemoryMonitorTeardownAfterAllocation) {
 }
 
 TEST_F(LynxShellTest, ResetTimingBeforeReloadClearsPerformanceEntries) {
+  auto& env = lynx::tasm::LynxEnv::GetInstance();
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDebugEnabled, true);
+  env.SetBoolLocalEnv(lynx::tasm::LynxEnv::kLynxDevToolEnable, true);
+
   shell_->perf_controller_actor_->ActSync([](auto& controller) {
     auto entry = controller->GetValueFactory()->CreateMap();
     entry->PushStringToMap("entryType", "metric");


### PR DESCRIPTION
## Summary
- gate `PerformanceController`'s `PerformanceEntry` cache behind DevTool enablement
- return an empty `Performance.getAllPerformanceEntries` result when DevTool is disabled
- make shell tests explicitly cover enabled and disabled DevTool states

## Why
- `Performance.getAllPerformanceEntries` was introduced for DevTool inspection in #6076
- collecting every `PerformanceEntry` in normal runtime flows keeps unnecessary history in memory even when DevTool is off

## Validation
- `source tools/envsetup.sh && python3 tools_shared/git_lynx.py check --checkers coding-style --changed --verbose`
- `source tools/envsetup.sh && python3 tools_shared/git_lynx.py check --checkers cpplint --changed --verbose`
- `buildtools/gn/gn gen out/final_verify && buildtools/ninja/ninja -C out/final_verify shell_unittests_exec`  
  blocked by an unrelated baseline Darwin build issue in `core/base/darwin/lynx_env_darwin.mm`: `Lynx/LynxEnv.h` file not found

Follow-up to #6076.