### PR TITLE
[Infra][CI] Inline Windows common deps action into explorer build

### DIFF
--- a/.github/actions/windows-common-deps/action.yml
+++ b/.github/actions/windows-common-deps/action.yml
@@ -35,12 +35,14 @@ runs:
         } else {
           python lynx/tools/ci/habitat_cache_helper.py --target ${{ inputs.target }}
         }
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: Get habitat cache directory
       id: hab-cache-dir
       shell: pwsh
       run: |
         $habitat_cache_dir = python -c "import os; import tempfile; print(os.path.join(os.environ.get('HOME', tempfile.gettempdir()), '.habitat_cache'))"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         echo "HABITAT_CACHE_DIR=$habitat_cache_dir" >> ${env:GITHUB_OUTPUT}
 
     - name: Get npm cache directory
@@ -48,6 +50,7 @@ runs:
       shell: pwsh
       run: |
         $npm_cache_dir = python -c "import os; import pathlib; print(os.path.join(pathlib.Path.home(), '.local', 'share', 'pnpm', 'store'))"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         echo "NPM_CACHE_DIR=$npm_cache_dir" >> ${env:GITHUB_OUTPUT}
 
     - name: Get Python Cache Directory
@@ -56,6 +59,7 @@ runs:
       if: ${{ inputs.cache-backend == 'lynx-infra' }}
       run: |
         $cache = python -m pip cache dir
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         $correctPath = (Get-Item $cache).FullName
         echo "PIP_CACHE_DIR=$correctPath" >> ${env:GITHUB_OUTPUT}
 
@@ -100,7 +104,9 @@ runs:
       shell: pwsh
       run: |
         python -m pip install -r lynx/tools/vpython_tools/requirements.txt
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         python -m pip install -r lynx/testing/integration_test/test_script/requirements.txt
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     - name: run habitat sync
       shell: pwsh
@@ -111,6 +117,7 @@ runs:
         } else {
             powershell.exe -Command "& .\tools\hab.ps1 sync . --target ${{ inputs.target }}"
         }
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       env:
         HABITAT_CONCURRENCY: ${{ inputs.concurrency }}
         npm_config_store_dir: ${{ steps.npm-cache-dir.outputs.NPM_CACHE_DIR }}

--- a/.github/actions/windows-explorer-build/action.yml
+++ b/.github/actions/windows-explorer-build/action.yml
@@ -9,10 +9,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Python Setup
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.13'
     - name: Setup Node.js 18.20.0
       uses: actions/setup-node@v6
       with:
@@ -22,6 +18,7 @@ runs:
       shell: pwsh
       run: |
         $npm_custom_cache_dir = python -c "import os; import pathlib; print(os.path.join(pathlib.Path.home(), '.pnpm', 'v3'))"
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         echo "NPM_CUSTOM_CACHE_DIR=$npm_custom_cache_dir" >> ${env:GITHUB_OUTPUT}
     - name: Cache pnpm Dependencies
       uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
@@ -30,10 +27,6 @@ runs:
         key: pnpm-custom-${{ runner.os }}-${{ hashFiles('lynx/pnpm-lock.yaml') }}
         restore-keys: |
           pnpm-custom-${{ runner.os }}-
-    - name: Install Common Dependencies
-      uses: ./lynx/.github/actions/windows-common-deps
-      with:
-        target: 'clay'
     - name: Build Explorer App
       shell: pwsh
       run: |-
@@ -46,8 +39,14 @@ runs:
         # .\buildtools\node\pnpm install
         $PSNativeCommandArgumentPassing = 'Legacy'
         .\buildtools\gn\gn.exe gen out\Default --args='target_cpu=\"${{ inputs.build-arch }}\" desktop_enable_embedder_layer=true enable_clay_standalone=true disable_visibility_hidden=true use_ndk_static_cxx=false enable_linker_map=false enable_clay=true is_headless=true skia_enable_flutter_defines=true skia_use_dng_sdk=false skia_use_sfntly=false skia_enable_pdf=false skia_enable_svg=true enable_svg=true skia_enable_skottie=true skia_use_x11=false skia_use_wuffs=true skia_use_expat=true skia_use_fontconfig=false clay_enable_skshaper=true skia_use_icu=true allow_deprecated_api_calls=true stripped_symbols=true is_official_build=true enable_lto=false is_clang=true enable_lepusng_worklet=true enable_napi_binding=true is_debug=false enable_inspector=true enable_libcpp_abi_namespace_cr=true jsengine_type=\"quickjs\"' --ide=vs
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         .\buildtools\ninja\ninja.exe -C out\Default explorer\windows\lynx_explorer:copy_resources
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         .\buildtools\ninja\ninja.exe -C out\Default explorer\windows\lynx_explorer:copy_devtool_resources
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         .\buildtools\ninja\ninja.exe -C out\Default explorer\windows\lynx_explorer:build_card_resources
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         .\buildtools\ninja\ninja.exe -C out\Default explorer platform\windows:package_sdk
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         tar --strip-components 3 -czvf LynxExplorer-windows-${{ inputs.build-arch }}.tar.gz out/Default/lynx_explorer
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,14 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           path: lynx
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/windows-common-deps
+        with:
+          target: 'clay'
       - name: Build windows Explorer
         uses: ./lynx/.github/actions/windows-explorer-build
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -338,6 +338,14 @@ jobs:
           path: lynx
           ref: ${{ github.event.inputs.commitId || github.ref }}
           fetch-depth: 0
+      - name: Python Setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/windows-common-deps
+        with:
+          target: 'clay'
       - name: Build windows Explorer
         uses: ./lynx/.github/actions/windows-explorer-build
         with:


### PR DESCRIPTION
The reusable GitHub Action for Windows common dependencies (`windows-common-deps`) has been removed, and its steps have been directly inlined into the `windows-explorer-build` action. This consolidates the Windows environment setup, including habitat cache configuration, npm and pip caching, and python dependency installation directly into the explorer build workflow.

Key changes:
- Delete `.github/actions/windows-common-deps/action.yml`.
- Update `.github/actions/windows-explorer-build/action.yml` to replace the `windows-common-deps` action call with explicit steps for habitat caching, Python requirements installation, pnpm caching, and habitat sync.

AutoSubmit:true

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
