### PR TITLE
[BugFix][iOS] Fix LynxServiceAPI header search path for CocoaPod consumers

### DIFF
--- a/platform/darwin/ios/lynx_service_api/BUILD.gn
+++ b/platform/darwin/ios/lynx_service_api/BUILD.gn
@@ -36,7 +36,10 @@ podspec_target("LynxServiceAPI_podspec") {
       CLANG_CXX_LANGUAGE_STANDARD = "gnu++17"
       OTHER_CPLUSPLUSFLAGS =
           "-fno-aligned-allocation -fno-c++-static-destructors -std=gnu++17"
-      HEADER_SEARCH_PATHS = [ "../../../.." ]
+      HEADER_SEARCH_PATHS = [
+        "../../../..",
+        "//",
+      ]
     }
     if (!is_debug) {
       pod_target_xcconfig.GCC_PREPROCESSOR_DEFINITIONS += [ "NDEBUG=1" ]


### PR DESCRIPTION
## Summary

When `LynxServiceAPI` is consumed as a CocoaPod, compilation fails with header-not-found errors (e.g. `'service_api/service_api.h' file not found`).

The root cause is that `HEADER_SEARCH_PATHS` in `BUILD.gn` only declared `"../../../.."`, which GN resolves to the absolute local machine path at podspec generation time. This path is invalid in any other build environment.

This PR adds `"//"` (GN repo root) to `HEADER_SEARCH_PATHS`. The podspec generator translates `"//"` to `${PODS_TARGET_SRCROOT}`, making repo-root-relative includes resolvable in any pod consumer's build.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
