### PR TITLE
[Autolink] Add native autolink marker APIs

### DIFF
--- a/core/runtime/js/bindings/modules/ios/lynx_module_creator_darwin.h
+++ b/core/runtime/js/bindings/modules/ios/lynx_module_creator_darwin.h
@@ -19,6 +19,7 @@
 
 @property(nonatomic, readwrite, strong) Class<LynxModule> moduleClass;
 @property(nonatomic, readwrite, strong) id param;
+@property(nonatomic, readwrite, copy) NSString *moduleName;
 @property(nonatomic, readwrite, weak) NSString *namescope;
 
 @end

--- a/core/runtime/js/bindings/modules/ios/lynx_module_darwin.h
+++ b/core/runtime/js/bindings/modules/ios/lynx_module_darwin.h
@@ -32,6 +32,7 @@ base::expected<std::unique_ptr<pub::Value>, std::string> PerformMethodInvocation
 class LynxModuleDarwin : public LynxNativeModule {
  public:
   LynxModuleDarwin(id<LynxModule> module);
+  LynxModuleDarwin(id<LynxModule> module, NSString *moduleName);
   void Destroy() override;
 
   base::expected<std::unique_ptr<pub::Value>, std::string> InvokeMethod(

--- a/core/runtime/js/bindings/modules/ios/lynx_module_darwin.mm
+++ b/core/runtime/js/bindings/modules/ios/lynx_module_darwin.mm
@@ -90,9 +90,12 @@ void LynxModuleDarwin::buildLookupMap(NSDictionary<NSString *, NSString *> *look
 }
 
 LynxModuleDarwin::LynxModuleDarwin(id<LynxModule> instance)
+    : LynxModuleDarwin(instance, [[instance class] name]) {}
+
+LynxModuleDarwin::LynxModuleDarwin(id<LynxModule> instance, NSString *moduleName)
     : LynxNativeModule(std::make_shared<pub::PubValueFactoryDarwin>()),
       instance_(instance),
-      module_name_(std::string([[[instance class] name] UTF8String])) {
+      module_name_(std::string([moduleName UTF8String])) {
   methodLookup = [[instance class] methodLookup];
   buildLookupMap(methodLookup);
   if ([[instance class] respondsToSelector:@selector(attributeLookup)]) {

--- a/core/runtime/js/bindings/modules/ios/module_factory_darwin.h
+++ b/core/runtime/js/bindings/modules/ios/module_factory_darwin.h
@@ -38,6 +38,8 @@ class ModuleFactoryDarwin : public NativeModuleFactory {
   // register module class and param.
   void registerModule(Class<LynxModule> cls);
   void registerModule(Class<LynxModule> cls, id param);
+  void registerModule(NSString *name, Class<LynxModule> cls);
+  void registerModule(NSString *name, Class<LynxModule> cls, id param);
   void registerMethodAuth(LynxMethodBlock block);
   void registerExtraInfo(NSDictionary *extra);
   void registerMethodSession(LynxMethodSessionBlock block);

--- a/core/runtime/js/bindings/modules/ios/module_factory_darwin.mm
+++ b/core/runtime/js/bindings/modules/ios/module_factory_darwin.mm
@@ -82,7 +82,9 @@ std::shared_ptr<LynxNativeModule> ModuleFactoryDarwin::CreateModule(const std::s
       [instance setExtraData:lynxModuleExtraData_];
     }
     // create lynx module darwin
-    std::shared_ptr<LynxModuleDarwin> moduleDarwin = std::make_shared<LynxModuleDarwin>(instance);
+    NSString *moduleName = wrapper.moduleName ?: str;
+    std::shared_ptr<LynxModuleDarwin> moduleDarwin =
+        std::make_shared<LynxModuleDarwin>(instance, moduleName);
     moduleDarwin->SetMethodAuth(methodAuthBlocks_);
     moduleDarwin->SetMethodSession(methodSessionBlocks_);
     moduleDarwin->SetContextFinder(module_creator_->CurrentContextFinder());
@@ -108,14 +110,23 @@ std::shared_ptr<LynxNativeModule> ModuleFactoryDarwin::CreateModule(const std::s
 void ModuleFactoryDarwin::registerModule(Class<LynxModule> cls) { registerModule(cls, nil); }
 
 void ModuleFactoryDarwin::registerModule(Class<LynxModule> cls, id param) {
+  registerModule([cls name], cls, param);
+}
+
+void ModuleFactoryDarwin::registerModule(NSString *name, Class<LynxModule> cls) {
+  registerModule(name, cls, nil);
+}
+
+void ModuleFactoryDarwin::registerModule(NSString *name, Class<LynxModule> cls, id param) {
   LynxModuleWrapper *wrapper = [[LynxModuleWrapper alloc] init];
   wrapper.moduleClass = cls;
   wrapper.param = param;
+  wrapper.moduleName = name;
   if (param && [param isKindOfClass:[NSDictionary class]] &&
       [((NSDictionary *)param) objectForKey:@"namescope"]) {
     wrapper.namescope = [((NSDictionary *)param) objectForKey:@"namescope"];
   }
-  modulesClasses_[[cls name]] = wrapper;
+  modulesClasses_[name] = wrapper;
   _LogI(@"NativeModule: LynxModule, module: %@ registered with param (address): %p", cls, param);
 }
 

--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -3930,6 +3930,21 @@ public enum com::lynx::tasm::animation::keyframe::LynxKeyframeAnimator::LynxAnim
 public interface com::lynx::jsbridge::LynxAttribute {
 }
 
+public interface com::lynx::tasm::behavior::LynxAutolinkElement {
+  public String com.lynx.tasm.behavior.LynxAutolinkElement.name();
+  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.isCreateAsync() default false;
+  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.needProcessDirection() default false;
+  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.supportFragmentLayerRender() default false;
+  public Class<? extends IRendererHost > com.lynx.tasm.behavior.LynxAutolinkElement.fragmentLayerRendererHost() default IRendererHost.class;
+}
+
+public interface com::lynx::jsbridge::LynxAutolinkNativeModule {
+  public String com.lynx.jsbridge.LynxAutolinkNativeModule.name();
+}
+
+public interface com::lynx::tasm::service::LynxAutolinkService {
+}
+
 public class com::lynx::tasm::behavior::ui::utils::LynxBackground : LynxDrawableManager< BackgroundDrawable > {
   public com.lynx.tasm.behavior.ui.utils.LynxBackground.LynxBackground(LynxContext context);
   public void com.lynx.tasm.behavior.ui.utils.LynxBackground.setBackgroundColor(int color);
@@ -5548,6 +5563,21 @@ public class abstract com::lynx::jsbridge::LynxExtensionModule :  {
   public abstract void com.lynx.jsbridge.LynxExtensionModule.setUp();
   public abstract void com.lynx.jsbridge.LynxExtensionModule.onTemplateLoad(String url);
   public abstract void com.lynx.jsbridge.LynxExtensionModule.destroy();
+}
+
+public interface com::lynx::tasm::extension::LynxExtensionProvider {
+  public void com.lynx.tasm.extension.LynxExtensionProvider.register(@NonNull LynxExtensionRegistry registry);
+}
+
+public class com::lynx::tasm::extension::LynxExtensionRegistry :  {
+  public static void com.lynx.tasm.extension.LynxExtensionRegistry.setupGlobal(@NonNull Context context, @NonNull String[] providerClassNames);
+  public static void com.lynx.tasm.extension.LynxExtensionRegistry.setup(@NonNull LynxViewBuilder builder, @NonNull String[] providerClassNames);
+  public void com.lynx.tasm.extension.LynxExtensionRegistry.addBehaviors(@Nullable List< Behavior > behaviors);
+  public void com.lynx.tasm.extension.LynxExtensionRegistry.registerModule( @NonNull String name, @NonNull Class<? extends LynxModule > moduleClass);
+  public void com.lynx.tasm.extension.LynxExtensionRegistry.registerModule(@NonNull String name, @NonNull Class<? extends LynxModule > moduleClass, @Nullable Object param);
+  public void com.lynx.tasm.extension.LynxExtensionRegistry.registerService(@NonNull Class<? extends IServiceProvider > serviceClass);
+  public void com.lynx.tasm.extension.LynxExtensionRegistry.registerService(@NonNull IServiceProvider service);
+  public Context com.lynx.tasm.extension.LynxExtensionRegistry.getContextOrThrow();
 }
 
 public class com::lynx::tasm::provider::LynxExternalResourceFetcherWrapper :  {

--- a/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/extension/LynxExtensionRegistryTest.java
+++ b/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/extension/LynxExtensionRegistryTest.java
@@ -1,0 +1,205 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.extension;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import com.lynx.jsbridge.LynxModule;
+import com.lynx.jsbridge.ParamWrapper;
+import com.lynx.tasm.LynxBackgroundRuntimeOptions;
+import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.LynxViewBuilder;
+import com.lynx.tasm.behavior.Behavior;
+import com.lynx.tasm.behavior.BehaviorRegistry;
+import com.lynx.tasm.service.IServiceProvider;
+import com.lynx.tasm.service.LynxServiceCenter;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class LynxExtensionRegistryTest {
+  private static final String BUILDER_BEHAVIOR = "autolink-builder-behavior";
+  private static final String BUILDER_MODULE = "AutolinkBuilderModule";
+  private static final String GLOBAL_BEHAVIOR = "autolink-global-behavior";
+  private static final String GLOBAL_MODULE = "AutolinkGlobalModule";
+
+  public static class TestModule extends LynxModule {
+    public TestModule(Context context) {
+      super(context);
+    }
+  }
+
+  public static class BuilderProvider implements LynxExtensionProvider {
+    static boolean sContextRejected;
+
+    @Override
+    public void register(@NonNull LynxExtensionRegistry registry) {
+      registry.addBehaviors(Arrays.asList(new Behavior(BUILDER_BEHAVIOR)));
+      registry.registerModule(BUILDER_MODULE, TestModule.class, "builder-param");
+      registry.registerService(new ConstructorService());
+      try {
+        registry.getContextOrThrow();
+      } catch (IllegalStateException e) {
+        sContextRejected = true;
+      }
+    }
+  }
+
+  public static class GlobalProvider implements LynxExtensionProvider {
+    static Context sContext;
+
+    @Override
+    public void register(@NonNull LynxExtensionRegistry registry) {
+      registry.addBehaviors(null);
+      registry.addBehaviors(Arrays.asList(new Behavior(GLOBAL_BEHAVIOR)));
+      registry.registerModule(GLOBAL_MODULE, TestModule.class);
+      registry.registerService(SingletonService.class);
+      sContext = registry.getContextOrThrow();
+    }
+  }
+
+  public static class NonProvider {}
+
+  public static class ConstructorService implements IServiceProvider {
+    boolean mInitialized;
+
+    @Override
+    public Class<? extends IServiceProvider> getServiceClass() {
+      return ConstructorService.class;
+    }
+
+    @Override
+    public void onInitialize(Context context) {
+      mInitialized = true;
+    }
+  }
+
+  public static class SingletonService implements IServiceProvider {
+    public static final SingletonService INSTANCE = new SingletonService();
+    boolean mInitialized;
+
+    @Override
+    public Class<? extends IServiceProvider> getServiceClass() {
+      return SingletonService.class;
+    }
+
+    @Override
+    public void onInitialize(Context context) {
+      mInitialized = true;
+    }
+  }
+
+  @Before
+  public void setUp() {
+    LynxServiceCenter.inst().unregisterAllService();
+    BuilderProvider.sContextRejected = false;
+    GlobalProvider.sContext = null;
+    SingletonService.INSTANCE.mInitialized = false;
+  }
+
+  @After
+  public void tearDown() {
+    LynxServiceCenter.inst().unregisterAllService();
+  }
+
+  @Test
+  public void testSetupRegistersIntoBuilder() throws Exception {
+    LynxViewBuilder builder = new LynxViewBuilder();
+
+    LynxExtensionRegistry.setup(builder,
+        new String[] {null, "", "missing.Provider", NonProvider.class.getName(),
+            BuilderProvider.class.getName()});
+
+    BehaviorRegistry behaviorRegistry = getField(builder, "behaviorRegistry");
+    assertTrue(behaviorRegistry.getAllBehaviorRegistryName().contains(BUILDER_BEHAVIOR));
+
+    ParamWrapper wrapper = findWrapper(getRuntimeOptions(builder), BUILDER_MODULE);
+    assertNotNull(wrapper);
+    assertEquals(TestModule.class, wrapper.getModuleClass());
+    assertEquals("builder-param", wrapper.getParam());
+
+    LynxServiceCenter.inst().initialize(ApplicationProvider.getApplicationContext());
+    ConstructorService service = LynxServiceCenter.inst().getService(ConstructorService.class);
+    assertNotNull(service);
+    assertTrue(service.mInitialized);
+    assertTrue(BuilderProvider.sContextRejected);
+  }
+
+  @Test
+  public void testSetupGlobalRegistersIntoLynxEnv() throws Exception {
+    Application application = ApplicationProvider.getApplicationContext();
+
+    LynxExtensionRegistry.setupGlobal(application, new String[] {GlobalProvider.class.getName()});
+
+    assertSame(application, GlobalProvider.sContext);
+    assertTrue(hasGlobalBehavior(GLOBAL_BEHAVIOR));
+    assertNotNull(findWrapper(LynxEnv.inst().getModuleFactory(), GLOBAL_MODULE));
+    assertSame(
+        SingletonService.INSTANCE, LynxServiceCenter.inst().getService(SingletonService.class));
+    assertTrue(SingletonService.INSTANCE.mInitialized);
+  }
+
+  private static boolean hasGlobalBehavior(String behaviorName) {
+    for (Behavior behavior : LynxEnv.inst().getBehaviors()) {
+      if (behaviorName.equals(behavior.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static LynxBackgroundRuntimeOptions getRuntimeOptions(LynxViewBuilder builder)
+      throws Exception {
+    return getField(builder, "lynxRuntimeOptions");
+  }
+
+  private static ParamWrapper findWrapper(LynxBackgroundRuntimeOptions options, String moduleName) {
+    for (ParamWrapper wrapper : options.getWrappers()) {
+      if (moduleName.equals(wrapper.getName())) {
+        return wrapper;
+      }
+    }
+    return null;
+  }
+
+  private static ParamWrapper findWrapper(Object moduleFactory, String moduleName)
+      throws Exception {
+    Map<String, ParamWrapper> wrappers = getField(moduleFactory, "mWrappers");
+    for (ParamWrapper wrapper : wrappers.values()) {
+      if (moduleName.equals(wrapper.getName())) {
+        return wrapper;
+      }
+    }
+    return null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T getField(Object target, String fieldName) throws Exception {
+    Class<?> type = target.getClass();
+    while (type != null) {
+      try {
+        Field field = type.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(target);
+      } catch (NoSuchFieldException e) {
+        type = type.getSuperclass();
+      }
+    }
+    throw new NoSuchFieldException(fieldName);
+  }
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/jsbridge/LynxAutolinkNativeModule.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/jsbridge/LynxAutolinkNativeModule.java
@@ -1,0 +1,17 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.jsbridge;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkNativeModule {
+  String name();
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxAutolinkElement.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxAutolinkElement.java
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.behavior;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.lynx.tasm.behavior.render.IRendererHost;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkElement {
+  String name();
+  boolean isCreateAsync() default false;
+  boolean needProcessDirection() default false;
+  boolean supportFragmentLayerRender() default false;
+  Class<? extends IRendererHost> fragmentLayerRendererHost() default IRendererHost.class;
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/extension/LynxExtensionProvider.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/extension/LynxExtensionProvider.java
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.extension;
+
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+
+@Keep
+public interface LynxExtensionProvider {
+  void register(@NonNull LynxExtensionRegistry registry);
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/extension/LynxExtensionRegistry.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/extension/LynxExtensionRegistry.java
@@ -1,0 +1,138 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.extension;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.lynx.jsbridge.LynxModule;
+import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.LynxViewBuilder;
+import com.lynx.tasm.base.LLog;
+import com.lynx.tasm.behavior.Behavior;
+import com.lynx.tasm.service.IServiceProvider;
+import com.lynx.tasm.service.LynxServiceCenter;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+
+@Keep
+public final class LynxExtensionRegistry {
+  private static final String TAG = "LynxExtensionRegistry";
+
+  @Nullable private final Context mContext;
+  @Nullable private final LynxViewBuilder mBuilder;
+
+  private LynxExtensionRegistry(@Nullable Context context, @Nullable LynxViewBuilder builder) {
+    mContext = context;
+    mBuilder = builder;
+  }
+
+  public static void setupGlobal(@NonNull Context context, @NonNull String[] providerClassNames) {
+    LynxExtensionRegistry registry = new LynxExtensionRegistry(context, null);
+    setup(registry, providerClassNames);
+    Context appContext = context.getApplicationContext();
+    if (appContext instanceof Application) {
+      LynxServiceCenter.inst().initialize((Application) appContext);
+    }
+  }
+
+  public static void setup(@NonNull LynxViewBuilder builder, @NonNull String[] providerClassNames) {
+    setup(new LynxExtensionRegistry(null, builder), providerClassNames);
+  }
+
+  public void addBehaviors(@Nullable List<Behavior> behaviors) {
+    if (behaviors == null || behaviors.isEmpty()) {
+      return;
+    }
+    if (mBuilder != null) {
+      mBuilder.addBehaviors(behaviors);
+    } else {
+      LynxEnv.inst().addBehaviors(behaviors);
+    }
+  }
+
+  public void registerModule(
+      @NonNull String name, @NonNull Class<? extends LynxModule> moduleClass) {
+    registerModule(name, moduleClass, null);
+  }
+
+  public void registerModule(@NonNull String name, @NonNull Class<? extends LynxModule> moduleClass,
+      @Nullable Object param) {
+    if (mBuilder != null) {
+      mBuilder.registerModule(name, moduleClass, param);
+    } else {
+      LynxEnv.inst().registerModule(name, moduleClass, param);
+    }
+  }
+
+  public void registerService(@NonNull Class<? extends IServiceProvider> serviceClass) {
+    IServiceProvider service = createService(serviceClass);
+    if (service != null) {
+      LynxServiceCenter.inst().registerService(service);
+    }
+  }
+
+  public void registerService(@NonNull IServiceProvider service) {
+    LynxServiceCenter.inst().registerService(service);
+  }
+
+  private static void setup(
+      @NonNull LynxExtensionRegistry registry, @NonNull String[] providerClassNames) {
+    for (String providerClassName : providerClassNames) {
+      if (providerClassName == null || providerClassName.length() == 0) {
+        continue;
+      }
+      try {
+        Class<?> cls = Class.forName(providerClassName);
+        Constructor<?> constructor = cls.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Object instance = constructor.newInstance();
+        if (instance instanceof LynxExtensionProvider) {
+          ((LynxExtensionProvider) instance).register(registry);
+        } else {
+          LLog.e(TAG, providerClassName + " does not implement LynxExtensionProvider");
+        }
+      } catch (Throwable t) {
+        LLog.w(TAG, "Skip unavailable Lynx extension provider " + providerClassName + ": " + t);
+      }
+    }
+  }
+
+  @Nullable
+  private static IServiceProvider createService(
+      @NonNull Class<? extends IServiceProvider> serviceClass) {
+    try {
+      Field instanceField = serviceClass.getField("INSTANCE");
+      Object instance = instanceField.get(null);
+      if (instance instanceof IServiceProvider) {
+        return (IServiceProvider) instance;
+      }
+    } catch (NoSuchFieldException ignored) {
+      // Java services usually expose a public no-arg constructor instead of Kotlin INSTANCE.
+    } catch (Throwable t) {
+      LLog.w(TAG, "Failed to read service singleton " + serviceClass.getName() + ": " + t);
+    }
+
+    try {
+      Constructor<? extends IServiceProvider> constructor = serviceClass.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      return constructor.newInstance();
+    } catch (Throwable t) {
+      LLog.e(TAG, "Failed to create service " + serviceClass.getName() + ": " + t);
+      return null;
+    }
+  }
+
+  @NonNull
+  public Context getContextOrThrow() {
+    if (mContext == null) {
+      throw new IllegalStateException("Context is only available in setupGlobal().");
+    }
+    return mContext;
+  }
+}

--- a/platform/android/service_api/src/main/java/com/lynx/tasm/service/LynxAutolinkService.java
+++ b/platform/android/service_api/src/main/java/com/lynx/tasm/service/LynxAutolinkService.java
@@ -1,0 +1,15 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.service;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkService {}

--- a/platform/darwin/common/lynx/LynxConfig.mm
+++ b/platform/darwin/common/lynx/LynxConfig.mm
@@ -47,6 +47,19 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)init)
   _moduleFactoryPtr->registerModule(module, param);
 }
 
+- (void)registerModule:(Class<LynxModule>)module withName:(NSString *)name {
+  [self registerModule:module withName:name param:nil];
+}
+
+- (void)registerModule:(Class<LynxModule>)module withName:(NSString *)name param:(id)param {
+  std::shared_ptr<lynx::runtime::js::ModuleFactoryDarwin> lockPtr =
+      _sharedModuleFactoryWeakPtr.lock();
+  if (lockPtr) {
+    lockPtr->registerModule(name, module, param);
+  }
+  _moduleFactoryPtr->registerModule(name, module, param);
+}
+
 - (void)registerMethodAuth:(LynxMethodBlock)authBlock {
   _moduleFactoryPtr->registerMethodAuth(authBlock);
 }

--- a/platform/darwin/common/lynx/public/LynxConfig.h
+++ b/platform/darwin/common/lynx/public/LynxConfig.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithProvider:(nullable id<LynxTemplateProvider>)provider;
 - (void)registerModule:(Class<LynxModule>)module;
 - (void)registerModule:(Class<LynxModule>)module param:(nullable id)param;
+- (void)registerModule:(Class<LynxModule>)module withName:(NSString *)name;
+- (void)registerModule:(Class<LynxModule>)module withName:(NSString *)name param:(nullable id)param;
 - (void)registerUI:(Class)ui withName:(NSString *)name;
 - (void)registerShadowNode:(Class)node withName:(NSString *)name;
 - (void)registerMethodAuth:(LynxMethodBlock)authBlock;

--- a/platform/darwin/common/lynx/public/module/LynxModule.h
+++ b/platform/darwin/common/lynx/public/module/LynxModule.h
@@ -18,6 +18,10 @@ typedef NSDictionary *_Nullable (^LynxMethodSessionBlock)(NSString *method, NSSt
                                                           NSString *invoke_session,
                                                           NSString *name_space);
 
+#if defined(__OBJC__) && !defined(LynxAutolinkNativeModule)
+#define LynxAutolinkNativeModule(module_name) class LynxAutolinkNativeModuleMarker;
+#endif
+
 @protocol LynxModule <NSObject>
 
 /*! Module Name. */

--- a/platform/darwin/ios/api/lynx_ios.api
+++ b/platform/darwin/ios/api/lynx_ios.api
@@ -1083,6 +1083,8 @@ public class LynxConfig : NSObject {
   public instancetype LynxConfig::initWithProvider:(nullable id< LynxTemplateProvider > provider);
   public void LynxConfig::registerModule:(Class< LynxModule > module);
   public void LynxConfig::registerModule:param:(Class< LynxModule > module,[param] nullable id param);
+  public void LynxConfig::registerModule:withName:(Class< LynxModule > module,[withName] NSString *name);
+  public void LynxConfig::registerModule:withName:param:(Class< LynxModule > module,[withName] NSString *name,[param] nullable id param);
   public void LynxConfig::registerUI:withName:(Class ui,[withName] NSString *name);
   public void LynxConfig::registerShadowNode:withName:(Class node,[withName] NSString *name);
   public void LynxConfig::registerMethodAuth:(LynxMethodBlock authBlock);

--- a/platform/darwin/ios/lynx/LynxModuleManagerDarwinUnitTest.mm
+++ b/platform/darwin/ios/lynx/LynxModuleManagerDarwinUnitTest.mm
@@ -13,12 +13,16 @@
 #import "LynxBackgroundRuntime+Internal.h"
 #import "LynxUnitTestUtils.h"
 
+#include "core/runtime/js/bindings/modules/ios/common_module_creator.h"
 #include "core/runtime/js/bindings/modules/ios/lynx_module_darwin.h"
 
 @interface LynxModuleMockGlobal : NSObject <LynxModule>
 @end
 
 @interface LynxModuleMockInstance : NSObject <LynxModule>
+@end
+
+@interface LynxModuleMockExplicitName : NSObject <LynxModule>
 @end
 
 @implementation LynxModuleMockGlobal
@@ -52,6 +56,12 @@
   return self;
 }
 
++ (NSDictionary<NSString *, NSString *> *)methodLookup {
+  return @{};
+}
+@end
+
+@implementation LynxModuleMockExplicitName
 + (NSDictionary<NSString *, NSString *> *)methodLookup {
   return @{};
 }
@@ -95,6 +105,19 @@ class ModuleFactoryDarwinTester : public lynx::runtime::js::ModuleFactoryDarwin 
   XCTAssertNotEqual(platform_module, nullptr);
 
   // TODO(huzhanbo.luc) Test ModuleManager overwriting behavior here later
+}
+
+- (void)testExplicitModuleNameRegistration {
+  auto factory = std::make_shared<ModuleFactoryDarwinTester>();
+  factory->Bind(std::make_unique<lynx::runtime::js::CommonModuleCreator>());
+  factory->registerModule(@"ExplicitModule", LynxModuleMockExplicitName.class);
+
+  std::shared_ptr<lynx::pub::LynxNativeModuleManager> native_module_manager =
+      std::make_shared<lynx::pub::LynxNativeModuleManager>();
+  native_module_manager->SetPlatformModuleFactory(factory);
+  native_module_manager->SetModuleDelegate(_mockDelegate);
+  auto platform_module = native_module_manager->GetModule("ExplicitModule");
+  XCTAssertNotEqual(platform_module, nullptr);
 }
 
 @end

--- a/platform/darwin/ios/lynx/public/ui/LynxUI.h
+++ b/platform/darwin/ios/lynx/public/ui/LynxUI.h
@@ -16,6 +16,10 @@
 #import <Lynx/LynxUITarget.h>
 #import <Lynx/UIScrollView+Nested.h>
 
+#if defined(__OBJC__) && !defined(LynxAutolinkUI)
+#define LynxAutolinkUI(name) class LynxAutolinkUIMarker;
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class LynxUI;

--- a/platform/darwin/ios/lynx_service_api/ServiceAPI.h
+++ b/platform/darwin/ios/lynx_service_api/ServiceAPI.h
@@ -66,6 +66,10 @@ typedef struct {
   @end
 #endif
 
+#ifndef LynxAutolinkService
+#define LynxAutolinkService(clsName, protocolName) LynxServiceRegister(clsName, protocolName)
+#endif
+
 /**
  * Bind protocol and class, e.g., LYNX_SERVICE_BIND (LynxMonitorService,
  * LynxMonitorProtocol)


### PR DESCRIPTION
## Summary
- Add Android `LynxAutolink*` marker annotations and runtime extension provider/registry helpers.
- Add Android `LynxExtensionRegistryTest` coverage for provider loading, builder/global registration, services, and context handling.
- Add iOS Autolink marker macros and explicit native module-name registration path.
- Refresh Android/iOS public API metadata for the new native Autolink API surface.

## Related Split PRs
- Processor support: https://github.com/lynx-family/lynx/pull/6520
- Build plugin support: https://github.com/lynx-family/lynx/pull/6521

## RFC
- https://github.com/lynx-family/lynx/discussions/2653

## Validation
- `coding-style`
- `android-check-style`
- `commit-message`

## Related Issue
- #3588