### PR TITLE
[Autolink] Generate native extension providers

### DIFF
--- a/platform/android/lynx_processor/src/main/java/com/lynx/jsbridge/LynxAutolinkNativeModule.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/jsbridge/LynxAutolinkNativeModule.java
@@ -1,0 +1,21 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.jsbridge;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
+ * LynxAutolinkNativeModule annotation.
+ */
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkNativeModule {
+  String name();
+}

--- a/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxBehaviorProcessor.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxBehaviorProcessor.java
@@ -12,6 +12,7 @@ import static javax.tools.Diagnostic.Kind.WARNING;
 
 import androidx.annotation.Keep;
 import com.google.auto.service.AutoService;
+import com.lynx.tasm.behavior.LynxAutolinkElement;
 import com.lynx.tasm.behavior.LynxBehavior;
 import com.lynx.tasm.behavior.LynxGeneratorName;
 import com.lynx.tasm.behavior.LynxShadowNode;
@@ -46,6 +47,10 @@ import javax.lang.model.util.Types;
 
 @AutoService(Processor.class)
 public class LynxBehaviorProcessor extends AbstractProcessor {
+  private static final String DEFAULT_RENDERER_HOST_TYPE_NAME =
+      "com.lynx.tasm.behavior.render.IRendererHost";
+  private static final String VOID_TYPE_NAME = "void";
+
   private Filer mFiler;
   private Messager mMessager;
   private Types mTypes;
@@ -68,6 +73,7 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
   public Set<String> getSupportedAnnotationTypes() {
     Set<String> types = new HashSet<>();
     types.add(LynxBehavior.class.getCanonicalName());
+    types.add(LynxAutolinkElement.class.getCanonicalName());
     types.add(LynxShadowNode.class.getCanonicalName());
     types.add(LynxGeneratorName.class.getCanonicalName());
     return types;
@@ -112,6 +118,24 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
           TypeElement classType = (TypeElement) element;
           ClassName className = ClassName.get(classType);
           ClassInfo classInfo = parseBehaviorClass(className, classType);
+          if (packageName.isEmpty()) {
+            packageName = className.packageName();
+          }
+          mBehaviorClasses.put(className, classInfo);
+        } catch (Exception e) {
+          error(element, e.getMessage());
+        }
+      }
+    }
+
+    Set<? extends Element> elementAnnotatedClasses =
+        roundEnvironment.getElementsAnnotatedWith(LynxAutolinkElement.class);
+    if (elementAnnotatedClasses != null) {
+      for (Element element : elementAnnotatedClasses) {
+        try {
+          TypeElement classType = (TypeElement) element;
+          ClassName className = ClassName.get(classType);
+          ClassInfo classInfo = parseAutolinkElementClass(className, classType);
           if (packageName.isEmpty()) {
             packageName = className.packageName();
           }
@@ -315,6 +339,16 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
     return classInfo;
   }
 
+  private ClassInfo parseAutolinkElementClass(ClassName className, TypeElement typeElement) {
+    ClassInfo classInfo = new ClassInfo(className, typeElement);
+    classInfo.addAutolinkElementTag(typeElement);
+    classInfo.addAutolinkElementIsCreateAsync(typeElement);
+    classInfo.addAutolinkElementNeedProcessDirection(typeElement);
+    classInfo.addAutolinkElementSupportFragmentLayerRender(typeElement);
+    classInfo.addAutolinkElementFragmentLayerRendererHost(typeElement);
+    return classInfo;
+  }
+
   private ClassInfo parseShadowNodeClass(ClassName className, TypeElement typeElement) {
     ClassInfo classInfo = new ClassInfo(className, typeElement);
     classInfo.addShadowNodeTag(typeElement);
@@ -362,8 +396,18 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       tagName.addAll(Arrays.asList(annotation.tagName()));
     }
 
+    public void addAutolinkElementTag(Element element) {
+      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+      tagName.add(annotation.name());
+    }
+
     public void addBehaviorIsCreateAsync(Element element) {
       LynxBehavior annotation = element.getAnnotation(LynxBehavior.class);
+      isCreateAsync = annotation.isCreateAsync();
+    }
+
+    public void addAutolinkElementIsCreateAsync(Element element) {
+      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
       isCreateAsync = annotation.isCreateAsync();
     }
 
@@ -372,8 +416,18 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       needProcessDirection = annotation.needProcessDirection();
     }
 
+    public void addAutolinkElementNeedProcessDirection(Element element) {
+      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+      needProcessDirection = annotation.needProcessDirection();
+    }
+
     public void addBehaviorSupportFragmentLayerRender(Element element) {
       LynxBehavior annotation = element.getAnnotation(LynxBehavior.class);
+      supportFragmentLayerRender = annotation.supportFragmentLayerRender();
+    }
+
+    public void addAutolinkElementSupportFragmentLayerRender(Element element) {
+      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
       supportFragmentLayerRender = annotation.supportFragmentLayerRender();
     }
 
@@ -387,7 +441,23 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       }
       if (typeMirror != null) {
         String typeName = typeMirror.toString();
-        if (!typeName.equals("void")) {
+        if (isFragmentLayerRendererHostSet(typeName)) {
+          fragmentLayerRendererHost = typeName;
+        }
+      }
+    }
+
+    public void addAutolinkElementFragmentLayerRendererHost(Element element) {
+      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+      TypeMirror typeMirror = null;
+      try {
+        annotation.fragmentLayerRendererHost();
+      } catch (MirroredTypeException e) {
+        typeMirror = e.getTypeMirror();
+      }
+      if (typeMirror != null) {
+        String typeName = typeMirror.toString();
+        if (isFragmentLayerRendererHostSet(typeName)) {
           fragmentLayerRendererHost = typeName;
         }
       }
@@ -397,5 +467,9 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       LynxShadowNode annotation = element.getAnnotation(LynxShadowNode.class);
       shadowNodeTag = annotation.tagName();
     }
+  }
+
+  private static boolean isFragmentLayerRendererHostSet(String typeName) {
+    return !VOID_TYPE_NAME.equals(typeName) && !DEFAULT_RENDERER_HOST_TYPE_NAME.equals(typeName);
   }
 }

--- a/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxExtensionProcessor.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxExtensionProcessor.java
@@ -1,0 +1,193 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.processor;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+import androidx.annotation.Keep;
+import com.google.auto.service.AutoService;
+import com.lynx.jsbridge.LynxAutolinkNativeModule;
+import com.lynx.tasm.behavior.LynxAutolinkElement;
+import com.lynx.tasm.behavior.LynxBehavior;
+import com.lynx.tasm.behavior.LynxGeneratorName;
+import com.lynx.tasm.service.LynxAutolinkService;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+@AutoService(Processor.class)
+public class LynxExtensionProcessor extends AbstractProcessor {
+  public static final String OPTION_EXTENSION_PACKAGE_NAME = "lynx.extension.packageName";
+
+  private Filer mFiler;
+  private Messager mMessager;
+  private boolean mCreated;
+
+  @Override
+  public synchronized void init(ProcessingEnvironment processingEnvironment) {
+    super.init(processingEnvironment);
+    mFiler = processingEnvironment.getFiler();
+    mMessager = processingEnvironment.getMessager();
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  @Override
+  public Set<String> getSupportedAnnotationTypes() {
+    Set<String> annotations = new HashSet<>();
+    annotations.add(LynxBehavior.class.getCanonicalName());
+    annotations.add(LynxAutolinkElement.class.getCanonicalName());
+    annotations.add(LynxAutolinkNativeModule.class.getCanonicalName());
+    annotations.add(LynxAutolinkService.class.getCanonicalName());
+    annotations.add(LynxGeneratorName.class.getCanonicalName());
+    return annotations;
+  }
+
+  @Override
+  public Set<String> getSupportedOptions() {
+    return new HashSet<>(Arrays.asList(OPTION_EXTENSION_PACKAGE_NAME));
+  }
+
+  @Override
+  public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    if (mCreated || roundEnv.processingOver()) {
+      return false;
+    }
+
+    String providerPackageName = getProviderPackageName();
+    if (providerPackageName.length() == 0) {
+      return false;
+    }
+    mCreated = true;
+
+    String behaviorGeneratorPackageName = getBehaviorGeneratorPackageName(roundEnv);
+    List<ModuleInfo> modules = getNativeModules(roundEnv);
+    List<ClassName> services = getServices(roundEnv);
+    boolean hasBehaviors = behaviorGeneratorPackageName.length() > 0;
+
+    try {
+      generateProvider(
+          providerPackageName, behaviorGeneratorPackageName, hasBehaviors, modules, services);
+    } catch (IOException e) {
+      error(e.getMessage());
+    }
+    return false;
+  }
+
+  private String getProviderPackageName() {
+    Map<String, String> options = processingEnv.getOptions();
+    String packageName = options.get(OPTION_EXTENSION_PACKAGE_NAME);
+    if (packageName != null && packageName.trim().length() > 0) {
+      return packageName.trim();
+    }
+    // Provider generation is opt-in through the Autolink Gradle plugin. Regular Lynx
+    // modules may use the same annotations for behavior generation and should not emit
+    // an extension provider.
+    return "";
+  }
+
+  private String getBehaviorGeneratorPackageName(RoundEnvironment roundEnv) {
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxGeneratorName.class)) {
+      LynxGeneratorName annotation = element.getAnnotation(LynxGeneratorName.class);
+      if (annotation.packageName().length() > 0) {
+        return annotation.packageName();
+      }
+    }
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxBehavior.class)) {
+      return ClassName.get((TypeElement) element).packageName();
+    }
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkElement.class)) {
+      return ClassName.get((TypeElement) element).packageName();
+    }
+    return "";
+  }
+
+  private List<ModuleInfo> getNativeModules(RoundEnvironment roundEnv) {
+    List<ModuleInfo> modules = new ArrayList<>();
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkNativeModule.class)) {
+      TypeElement typeElement = (TypeElement) element;
+      LynxAutolinkNativeModule annotation =
+          typeElement.getAnnotation(LynxAutolinkNativeModule.class);
+      modules.add(new ModuleInfo(annotation.name(), ClassName.get(typeElement)));
+    }
+    return modules;
+  }
+
+  private List<ClassName> getServices(RoundEnvironment roundEnv) {
+    List<ClassName> services = new ArrayList<>();
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkService.class)) {
+      services.add(ClassName.get((TypeElement) element));
+    }
+    return services;
+  }
+
+  private void generateProvider(String providerPackageName, String behaviorGeneratorPackageName,
+      boolean hasBehaviors, List<ModuleInfo> modules, List<ClassName> services) throws IOException {
+    ClassName provider = ClassName.get("com.lynx.tasm.extension", "LynxExtensionProvider");
+    ClassName registry = ClassName.get("com.lynx.tasm.extension", "LynxExtensionRegistry");
+
+    MethodSpec.Builder register = MethodSpec.methodBuilder("register")
+                                      .addAnnotation(Override.class)
+                                      .addModifiers(PUBLIC)
+                                      .addParameter(registry, "registry");
+    if (hasBehaviors) {
+      register.addStatement("registry.addBehaviors($T.getBehaviors())",
+          ClassName.get(behaviorGeneratorPackageName, "BehaviorGenerator"));
+    }
+    for (ModuleInfo module : modules) {
+      register.addStatement("registry.registerModule($S, $T.class)", module.name, module.className);
+    }
+    for (ClassName service : services) {
+      register.addStatement("registry.registerService($T.class)", service);
+    }
+
+    TypeSpec providerClass = TypeSpec.classBuilder("LynxExtensionProviderImpl")
+                                 .addAnnotation(Keep.class)
+                                 .addModifiers(PUBLIC)
+                                 .addSuperinterface(provider)
+                                 .addMethod(register.build())
+                                 .build();
+
+    JavaFile.builder(providerPackageName, providerClass)
+        .addFileComment("Generated by " + getClass().getName())
+        .build()
+        .writeTo(mFiler);
+  }
+
+  private void error(String message) {
+    mMessager.printMessage(ERROR, message);
+  }
+
+  private static class ModuleInfo {
+    final String name;
+    final ClassName className;
+
+    ModuleInfo(String name, ClassName className) {
+      this.name = name;
+      this.className = className;
+    }
+  }
+}

--- a/platform/android/lynx_processor/src/main/java/com/lynx/tasm/behavior/LynxAutolinkElement.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/tasm/behavior/LynxAutolinkElement.java
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.behavior;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
+ * LynxAutolinkElement annotation.
+ */
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkElement {
+  String name();
+  boolean isCreateAsync() default false;
+  boolean needProcessDirection() default false;
+  boolean supportFragmentLayerRender() default false;
+  Class<?> fragmentLayerRendererHost() default void.class;
+}

--- a/platform/android/lynx_processor/src/main/java/com/lynx/tasm/service/LynxAutolinkService.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/tasm/service/LynxAutolinkService.java
@@ -1,0 +1,19 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm.service;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
+ * LynxAutolinkService annotation.
+ */
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+public @interface LynxAutolinkService {}

--- a/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxBehaviorProcessorTest.java
+++ b/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxBehaviorProcessorTest.java
@@ -109,6 +109,29 @@ public class LynxBehaviorProcessorTest {
   }
 
   @Test
+  public void testLynxAutolinkElementAnnotation() throws IOException {
+    JavaFileObject testClass = JavaFileObjects.forSourceString("com.test.TestElement",
+        "package com.test;\n"
+            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxContext;\n"
+            + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
+            + "@LynxAutolinkElement(name = \"test-element\", isCreateAsync = true)\n"
+            + "public class TestElement extends LynxUI {\n"
+            + "  public TestElement(LynxContext context) { super(context); }\n"
+            + "}\n");
+
+    Compilation compilation = javac()
+                                  .withProcessors(new LynxBehaviorProcessor())
+                                  .compile(merge(getCommonStubs(), testClass));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+
+    String source = getGeneratedSource(compilation, "com.test.BehaviorGenerator");
+    assertTrue("Should use LynxAutolinkElement name",
+        source.contains("new Behavior(\"test-element\", false, true, false)"));
+  }
+
+  @Test
   public void testBehaviorWithFragmentLayerRender() throws IOException {
     JavaFileObject rendererHostClass = JavaFileObjects.forSourceString("com.test.TestRendererHost",
         "package com.test;\n"
@@ -166,6 +189,56 @@ public class LynxBehaviorProcessorTest {
     assertTrue("Should use 5-arg Behavior constructor with true",
         source.contains("new Behavior(\"test\", false, false, false, true)"));
     assertFalse("Should not contain createPlatformRendererHost when no host is set",
+        source.contains("createPlatformRendererHost"));
+  }
+
+  @Test
+  public void testBehaviorWithDefaultRendererHostSentinel() throws IOException {
+    JavaFileObject testClass = JavaFileObjects.forSourceString("com.test.TestUI",
+        "package com.test;\n"
+            + "import com.lynx.tasm.behavior.LynxBehavior;\n"
+            + "import com.lynx.tasm.behavior.LynxContext;\n"
+            + "import com.lynx.tasm.behavior.render.IRendererHost;\n"
+            + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
+            + "@LynxBehavior(tagName = \"test\", supportFragmentLayerRender = true, "
+            + "fragmentLayerRendererHost = IRendererHost.class)\n"
+            + "public class TestUI extends LynxUI {\n"
+            + "  public TestUI(LynxContext context) { super(context); }\n"
+            + "}\n");
+
+    Compilation compilation = javac()
+                                  .withProcessors(new LynxBehaviorProcessor())
+                                  .compile(merge(getCommonStubs(), testClass));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+
+    String source = getGeneratedSource(compilation, "com.test.BehaviorGenerator");
+    assertFalse("Should not instantiate the default IRendererHost sentinel",
+        source.contains("createPlatformRendererHost"));
+  }
+
+  @Test
+  public void testAutolinkElementWithDefaultRendererHostSentinel() throws IOException {
+    JavaFileObject testClass = JavaFileObjects.forSourceString("com.test.TestElement",
+        "package com.test;\n"
+            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxContext;\n"
+            + "import com.lynx.tasm.behavior.render.IRendererHost;\n"
+            + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
+            + "@LynxAutolinkElement(name = \"test\", supportFragmentLayerRender = true, "
+            + "fragmentLayerRendererHost = IRendererHost.class)\n"
+            + "public class TestElement extends LynxUI {\n"
+            + "  public TestElement(LynxContext context) { super(context); }\n"
+            + "}\n");
+
+    Compilation compilation = javac()
+                                  .withProcessors(new LynxBehaviorProcessor())
+                                  .compile(merge(getCommonStubs(), testClass));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+
+    String source = getGeneratedSource(compilation, "com.test.BehaviorGenerator");
+    assertFalse("Should not instantiate the default IRendererHost sentinel",
         source.contains("createPlatformRendererHost"));
   }
 

--- a/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxExtensionProcessorTest.java
+++ b/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxExtensionProcessorTest.java
@@ -1,0 +1,214 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.processor;
+
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.io.IOException;
+import javax.tools.JavaFileObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class LynxExtensionProcessorTest {
+  private static final JavaFileObject KEEP_STUB =
+      JavaFileObjects.forSourceString("androidx.annotation.Keep",
+          "package androidx.annotation;\n"
+              + "import java.lang.annotation.Retention;\n"
+              + "import java.lang.annotation.RetentionPolicy;\n"
+              + "@Retention(RetentionPolicy.CLASS)\n"
+              + "public @interface Keep {}\n");
+
+  private static final JavaFileObject PROVIDER_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.extension.LynxExtensionProvider",
+          "package com.lynx.tasm.extension;\n"
+              + "public interface LynxExtensionProvider {\n"
+              + "  void register(LynxExtensionRegistry registry);\n"
+              + "}\n");
+
+  private static final JavaFileObject REGISTRY_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.extension.LynxExtensionRegistry",
+          "package com.lynx.tasm.extension;\n"
+              + "import java.util.List;\n"
+              + "import com.lynx.jsbridge.LynxModule;\n"
+              + "import com.lynx.tasm.behavior.Behavior;\n"
+              + "import com.lynx.tasm.service.IServiceProvider;\n"
+              + "public class LynxExtensionRegistry {\n"
+              + "  public void addBehaviors(List<Behavior> behaviors) {}\n"
+              + "  public void registerModule(String name, Class<? extends LynxModule> cls) {}\n"
+              + "  public void registerService(Class<? extends IServiceProvider> cls) {}\n"
+              + "}\n");
+
+  private static final JavaFileObject LYNX_MODULE_STUB =
+      JavaFileObjects.forSourceString("com.lynx.jsbridge.LynxModule",
+          "package com.lynx.jsbridge;\n"
+              + "public class LynxModule {}\n");
+
+  private static final JavaFileObject SERVICE_PROVIDER_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.service.IServiceProvider",
+          "package com.lynx.tasm.service;\n"
+              + "public interface IServiceProvider {}\n");
+
+  private static final JavaFileObject BEHAVIOR_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.behavior.Behavior",
+          "package com.lynx.tasm.behavior;\n"
+              + "public class Behavior {\n"
+              + "  public Behavior(String name, boolean flatten, boolean createAsync, boolean "
+              + "needProcessDirection) {}\n"
+              + "  public Behavior(String name, boolean flatten, boolean createAsync, boolean "
+              + "needProcessDirection, boolean supportFragmentLayerRender) {}\n"
+              + "  public com.lynx.tasm.behavior.ui.LynxUI createUI(LynxContext context) { return "
+              + "null; }\n"
+              + "  public com.lynx.tasm.behavior.shadow.ShadowNode createShadowNode() { return "
+              + "null; }\n"
+              + "}\n");
+
+  private static final JavaFileObject LYNX_CONTEXT_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.behavior.LynxContext",
+          "package com.lynx.tasm.behavior;\n"
+              + "public class LynxContext {}\n");
+
+  private static final JavaFileObject LYNX_UI_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.behavior.ui.LynxUI",
+          "package com.lynx.tasm.behavior.ui;\n"
+              + "import com.lynx.tasm.behavior.LynxContext;\n"
+              + "public class LynxUI {\n"
+              + "  public LynxUI(LynxContext context) {}\n"
+              + "}\n");
+
+  private static final JavaFileObject SHADOW_NODE_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.behavior.shadow.ShadowNode",
+          "package com.lynx.tasm.behavior.shadow;\n"
+              + "public class ShadowNode {}\n");
+
+  private static final JavaFileObject I_RENDERER_HOST_STUB =
+      JavaFileObjects.forSourceString("com.lynx.tasm.behavior.render.IRendererHost",
+          "package com.lynx.tasm.behavior.render;\n"
+              + "public interface IRendererHost {}\n");
+
+  @Test
+  public void testMixedExtensionProviderGeneration() throws IOException {
+    JavaFileObject element = JavaFileObjects.forSourceString("com.ext.Button",
+        "package com.ext;\n"
+            + "import com.lynx.tasm.behavior.LynxContext;\n"
+            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
+            + "@LynxAutolinkElement(name = \"button\")\n"
+            + "public class Button extends LynxUI {\n"
+            + "  public Button(LynxContext context) { super(context); }\n"
+            + "}\n");
+    JavaFileObject module = JavaFileObjects.forSourceString("com.ext.StorageModule",
+        "package com.ext;\n"
+            + "import com.lynx.jsbridge.LynxModule;\n"
+            + "import com.lynx.jsbridge.LynxAutolinkNativeModule;\n"
+            + "@LynxAutolinkNativeModule(name = \"NativeLocalStorage\")\n"
+            + "public class StorageModule extends LynxModule {}\n");
+    JavaFileObject service = JavaFileObjects.forSourceString("com.ext.LogService",
+        "package com.ext;\n"
+            + "import com.lynx.tasm.service.IServiceProvider;\n"
+            + "import com.lynx.tasm.service.LynxAutolinkService;\n"
+            + "@LynxAutolinkService\n"
+            + "public class LogService implements IServiceProvider {}\n");
+
+    Compilation compilation =
+        javac()
+            .withOptions("-A"
+                + "lynx.extension.packageName=com.generated.ext")
+            .withProcessors(new LynxBehaviorProcessor(), new LynxExtensionProcessor())
+            .compile(merge(getCommonStubs(), element, module, service));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+
+    String source = getGeneratedSource(compilation, "com.generated.ext.LynxExtensionProviderImpl");
+    assertTrue(source.contains("registry.addBehaviors(BehaviorGenerator.getBehaviors())"));
+    assertTrue(
+        source.contains("registry.registerModule(\"NativeLocalStorage\", StorageModule.class)"));
+    assertTrue(source.contains("registry.registerService(LogService.class)"));
+  }
+
+  @Test
+  public void testEmptyExtensionDoesNotForceProcessorRun() {
+    JavaFileObject emptyClass = JavaFileObjects.forSourceString("com.ext.Empty",
+        "package com.ext;\n"
+            + "public class Empty {}\n");
+
+    Compilation compilation = javac()
+                                  .withOptions("-A"
+                                      + "lynx.extension.packageName=com.ext")
+                                  .withProcessors(new LynxExtensionProcessor())
+                                  .compile(merge(getCommonStubs(), emptyClass));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+    assertFalse(compilation.generatedSourceFile("com.ext.LynxExtensionProviderImpl").isPresent());
+  }
+
+  @Test
+  public void testExtensionProviderRequiresPackageNameOption() {
+    JavaFileObject element = JavaFileObjects.forSourceString("com.ext.Button",
+        "package com.ext;\n"
+            + "import com.lynx.tasm.behavior.LynxContext;\n"
+            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
+            + "@LynxAutolinkElement(name = \"button\")\n"
+            + "public class Button extends LynxUI {\n"
+            + "  public Button(LynxContext context) { super(context); }\n"
+            + "}\n");
+    JavaFileObject module = JavaFileObjects.forSourceString("com.ext.StorageModule",
+        "package com.ext;\n"
+            + "import com.lynx.jsbridge.LynxModule;\n"
+            + "import com.lynx.jsbridge.LynxAutolinkNativeModule;\n"
+            + "@LynxAutolinkNativeModule(name = \"NativeLocalStorage\")\n"
+            + "public class StorageModule extends LynxModule {}\n");
+    JavaFileObject service = JavaFileObjects.forSourceString("com.ext.LogService",
+        "package com.ext;\n"
+            + "import com.lynx.tasm.service.IServiceProvider;\n"
+            + "import com.lynx.tasm.service.LynxAutolinkService;\n"
+            + "@LynxAutolinkService\n"
+            + "public class LogService implements IServiceProvider {}\n");
+
+    Compilation compilation = javac()
+                                  .withProcessors(new LynxExtensionProcessor())
+                                  .compile(merge(getCommonStubs(), element, module, service));
+
+    assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
+    assertFalse(compilation.generatedSourceFile("com.ext.LynxExtensionProviderImpl").isPresent());
+  }
+
+  @Test
+  public void testDoesNotClaimAllAnnotationTypes() {
+    assertFalse(new LynxExtensionProcessor().getSupportedAnnotationTypes().contains("*"));
+  }
+
+  private static JavaFileObject[] getCommonStubs() {
+    return new JavaFileObject[] {KEEP_STUB, PROVIDER_STUB, REGISTRY_STUB, LYNX_MODULE_STUB,
+        SERVICE_PROVIDER_STUB, BEHAVIOR_STUB, LYNX_CONTEXT_STUB, LYNX_UI_STUB, SHADOW_NODE_STUB,
+        I_RENDERER_HOST_STUB};
+  }
+
+  private static String getGeneratedSource(Compilation compilation, String qualifiedName)
+      throws IOException {
+    JavaFileObject generated = compilation.generatedSourceFile(qualifiedName).orElseThrow(() -> {
+      StringBuilder sb = new StringBuilder(
+          "Expected generated file not found: " + qualifiedName + "\nGenerated files:\n");
+      for (JavaFileObject file : compilation.generatedSourceFiles()) {
+        sb.append("  ").append(file.getName()).append("\n");
+      }
+      return new AssertionError(sb.toString());
+    });
+    return generated.getCharContent(true).toString();
+  }
+
+  private static JavaFileObject[] merge(JavaFileObject[] base, JavaFileObject... extras) {
+    JavaFileObject[] result = new JavaFileObject[base.length + extras.length];
+    System.arraycopy(base, 0, result, 0, base.length);
+    System.arraycopy(extras, 0, result, base.length, extras.length);
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- Extend Android `lynx_processor` to handle Autolink element, native module, and service markers.
- Generate `<extensionPackage>.LynxExtensionProviderImpl` for Autolink registration.
- Add processor tests for mixed extensions, no-marker packages, annotation filtering, and renderer-host sentinel handling.

## Related Split PRs
- Annotation/runtime APIs: https://github.com/lynx-family/lynx/pull/6519
- Build plugin support: https://github.com/lynx-family/lynx/pull/6521

## RFC
- https://github.com/lynx-family/lynx/discussions/2653

## Validation
- `./gradlew :LynxProcessor:test --tests com.lynx.processor.LynxBehaviorProcessorTest --tests com.lynx.processor.LynxExtensionProcessorTest`
- `commit-message`

## Related Issue
- #3588