### PR TITLE
[Feature][DevTool] Wire Input.insertText CDP dispatch

### DIFF
--- a/devtool/lynx_devtool/agent/devtool_platform_facade.h
+++ b/devtool/lynx_devtool/agent/devtool_platform_facade.h
@@ -56,6 +56,7 @@ class DevToolPlatformFacade
   virtual void GetLynxScreenShot() = 0;
 
   virtual void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent>) = 0;
+  virtual void InsertText(const std::string& text) {}
 
   virtual std::string GetUINodeInfo(int id) { return ""; }
   virtual std::string GetLynxUITree() { return ""; }

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent.cc
@@ -16,6 +16,7 @@ InspectorInputAgent::InspectorInputAgent(
     : devtool_mediator_(devtool_mediator) {
   functions_map_["Input.emulateTouchFromMouseEvent"] =
       &InspectorInputAgent::EmulateTouchFromMouseEvent;
+  functions_map_["Input.insertText"] = &InspectorInputAgent::InsertText;
 }
 
 InspectorInputAgent::~InspectorInputAgent() = default;
@@ -23,6 +24,11 @@ InspectorInputAgent::~InspectorInputAgent() = default;
 void InspectorInputAgent::EmulateTouchFromMouseEvent(
     const std::shared_ptr<MessageSender>& sender, const Json::Value& message) {
   devtool_mediator_->EmulateTouchFromMouseEvent(sender, message);
+}
+
+void InspectorInputAgent::InsertText(
+    const std::shared_ptr<MessageSender>& sender, const Json::Value& message) {
+  devtool_mediator_->InsertText(sender, message);
 }
 
 void InspectorInputAgent::CallMethod(

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent.h
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent.h
@@ -30,6 +30,8 @@ class InspectorInputAgent : public CDPDomainAgentBase {
 
   void EmulateTouchFromMouseEvent(const std::shared_ptr<MessageSender>& sender,
                                   const Json::Value& message);
+  void InsertText(const std::shared_ptr<MessageSender>& sender,
+                  const Json::Value& message);
 
   std::map<std::string, InputAgentMethod> functions_map_;
   const std::shared_ptr<LynxDevToolMediator> devtool_mediator_;

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent_unittest.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent_unittest.cc
@@ -1,0 +1,72 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#define protected public
+#define private public
+
+#include "devtool/lynx_devtool/agent/domain_agent/inspector_input_agent.h"
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "base/include/fml/thread.h"
+#include "devtool/base_devtool/native/test/message_sender_mock.h"
+#include "devtool/base_devtool/native/test/mock_receiver.h"
+#include "devtool/lynx_devtool/agent/inspector_ui_executor.h"
+#include "devtool/testing/mock/devtool_platform_facade_mock.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+#include "third_party/jsoncpp/include/json/value.h"
+
+namespace lynx {
+namespace devtool {
+namespace testing {
+
+class InspectorInputAgentTest : public ::testing::Test {
+ public:
+  InspectorInputAgentTest() = default;
+  ~InspectorInputAgentTest() override = default;
+
+  void SetUp() override {
+    MockReceiver::GetInstance().ResetAll();
+    devtool_mediator_ = std::make_shared<LynxDevToolMediator>();
+    ui_executor_ = std::make_shared<InspectorUIExecutor>(devtool_mediator_);
+    ui_executor_->SetDevToolPlatformFacade(
+        std::make_shared<lynx::testing::DevToolPlatformFacadeMock>());
+    ui_thread_ = std::make_unique<fml::Thread>("ui");
+    devtool_mediator_->ui_task_runner_ = ui_thread_->GetTaskRunner();
+    devtool_mediator_->ui_executor_ = ui_executor_;
+    agent_ = std::make_shared<InspectorInputAgent>(devtool_mediator_);
+    message_sender_ = std::make_shared<MessageSenderMock>();
+  }
+
+ protected:
+  void WaitForUIThread() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  std::shared_ptr<InspectorInputAgent> agent_;
+  std::shared_ptr<LynxDevToolMediator> devtool_mediator_;
+  std::shared_ptr<InspectorUIExecutor> ui_executor_;
+  std::shared_ptr<MessageSenderMock> message_sender_;
+  std::unique_ptr<fml::Thread> ui_thread_;
+};
+
+TEST_F(InspectorInputAgentTest, InsertTextReturnsSuccess) {
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 7;
+  message["method"] = "Input.insertText";
+  message["params"]["text"] = "hello";
+
+  agent_->CallMethod(message_sender_, message);
+  WaitForUIThread();
+
+  EXPECT_EQ(MockReceiver::GetInstance().received_message_.first, "CDP");
+  EXPECT_EQ(MockReceiver::GetInstance().received_message_.second,
+            "{\n   \"id\" : 7,\n   \"result\" : {}\n}\n");
+}
+
+}  // namespace testing
+}  // namespace devtool
+}  // namespace lynx

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -688,6 +688,22 @@ void InspectorUIExecutor::EmulateTouchFromMouseEvent(
   sender->SendMessage("CDP", response);
 }
 
+void InspectorUIExecutor::InsertText(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  Json::Value response(Json::ValueType::objectValue);
+  Json::Value content(Json::ValueType::objectValue);
+  Json::Value params = message["params"];
+
+  CHECK_NULL_AND_LOG_RETURN(devtool_platform_facade_,
+                            "devtool_platform_facade_ is null");
+  devtool_platform_facade_->InsertText(params["text"].asString());
+
+  response["result"] = content;
+  response["id"] = message["id"].asInt64();
+  sender->SendMessage("CDP", response);
+}
+
 // end input protocol
 
 // The following three functions are used for handling Layout Nodes

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.h
@@ -68,6 +68,7 @@ class InspectorUIExecutor
 
   // Input domain
   DECLARE_DEVTOOL_METHOD(EmulateTouchFromMouseEvent)
+  DECLARE_DEVTOOL_METHOD(InsertText)
 
   // event
  public:

--- a/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
@@ -151,5 +151,23 @@ TEST_F(InspectorUIExecutorTest, StartScreencastTest) {
   }
 }
 
+TEST_F(InspectorUIExecutorTest, InsertTextTest) {
+  std::shared_ptr<testing::DevToolPlatformFacadeMock> facade =
+      std::make_shared<testing::DevToolPlatformFacadeMock>();
+  ui_executor_->SetDevToolPlatformFacade(facade);
+
+  Json::Value message;
+  message["id"] = 41;
+  Json::Value params;
+  params["text"] = "hello";
+  message["params"] = params;
+
+  ui_executor_->InsertText(message_sender_, message);
+
+  EXPECT_EQ(facade->inserted_text_, "hello");
+  EXPECT_EQ(devtool::MockReceiver::GetInstance().received_message_.second,
+            "{\n   \"id\" : 41,\n   \"result\" : {}\n}\n");
+}
+
 }  // namespace testing
 }  // namespace lynx

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
@@ -1072,6 +1072,14 @@ void LynxDevToolMediator::EmulateTouchFromMouseEvent(
   });
 }
 
+void LynxDevToolMediator::InsertText(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  RunOnUIThread([sender, message, executor = ui_executor_] {
+    executor->InsertText(sender, message);
+  });
+}
+
 void LynxDevToolMediator::InspectorEnable(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
@@ -142,6 +142,7 @@ class LynxDevToolMediator
 
   // Input domain -> ui executor
   DECLARE_DEVTOOL_METHOD(EmulateTouchFromMouseEvent)
+  DECLARE_DEVTOOL_METHOD(InsertText)
 
   // Inspector domain -> devtools executor
   DECLARE_DEVTOOL_METHOD(InspectorEnable)

--- a/devtool/testing/agent/BUILD.gn
+++ b/devtool/testing/agent/BUILD.gn
@@ -8,6 +8,7 @@ unittest_set("devtool_agent_testset") {
   testonly = true
   sources = [
     "../../lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc",
+    "../../lynx_devtool/agent/domain_agent/inspector_input_agent_unittest.cc",
     "../../lynx_devtool/agent/domain_agent/inspector_log_agent_unittest.cc",
     "../../lynx_devtool/agent/inspector_tasm_executor_unittest.cc",
     "../../lynx_devtool/agent/inspector_ui_executor_unittest.cc",

--- a/devtool/testing/mock/devtool_platform_facade_mock.h
+++ b/devtool/testing/mock/devtool_platform_facade_mock.h
@@ -44,6 +44,7 @@ class DevToolPlatformFacadeMock : public lynx::devtool::DevToolPlatformFacade {
   void GetLynxScreenShot() override;
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override {
   }
+  void InsertText(const std::string& text) override { inserted_text_ = text; }
 
   std::string GetDebugInfoByUrl(const std::string& url) override {
     return devtool::DevToolStatus::NO_DEBUG_INFO_FOUND_BY_URL;
@@ -64,6 +65,7 @@ class DevToolPlatformFacadeMock : public lynx::devtool::DevToolPlatformFacade {
   }
 
   std::unordered_map<std::string, bool> devtools_switch_;
+  std::string inserted_text_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
## Summary

- Adds `Input.insertText` dispatch in the Lynx DevTool CDP `Input` domain.
- Routes the request through `LynxDevToolMediator` and `InspectorUIExecutor` to the platform facade.
- Adds focused unit coverage for the new agent method and UI executor path.

## Issue

Refs #6524.

This is the first PR in the split implementation. It wires the CDP/API surface and tests the dispatch path; platform-specific Android and iOS input bridges will be submitted separately.

## Test Plan

- `PATH=/Users/colin/lynx/src/lynx/buildtools/llvm/bin:/Users/colin/lynx/src/lynx/buildtools/gn:/Users/colin/lynx/src/lynx/buildtools/ninja:$PATH tools/rtf/rtf native-ut run --names devtool --target devtool_agent_unittest_exec --disable-flutter-cxx`
- `git diff --check origin/develop..HEAD`
