### PR TITLE
[Feature][Android] Bridge DevTool insertText to focused input

### DIFF
--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
@@ -234,6 +234,18 @@ void DevToolPlatformAndroid::Focus(int node_id) {
   Java_DevToolPlatformAndroidDelegate_focus(env, ref.Get(), node_id);
 }
 
+void DevToolPlatformAndroid::InsertText(const std::string& text) {
+  JNIEnv* env = lynx::base::android::AttachCurrentThread();
+  lynx::base::android::ScopedLocalJavaRef<jobject> ref(weak_android_delegate_);
+  if (ref.IsNull()) {
+    return;
+  }
+  lynx::base::android::ScopedLocalJavaRef<jstring> jni_text =
+      lynx::base::android::JNIConvertHelper::ConvertToJNIStringUTF(env, text);
+  Java_DevToolPlatformAndroidDelegate_insertText(env, ref.Get(),
+                                                 jni_text.Get());
+}
+
 void DevToolPlatformAndroid::OnConsoleMessage(const std::string& message) {
   std::lock_guard<std::mutex> lock(mutex_);
   JNIEnv* env = lynx::base::android::AttachCurrentThread();

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.h
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.h
@@ -40,6 +40,7 @@ class DevToolPlatformAndroid : public DevToolPlatformFacade {
 
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override;
   void Focus(int node_id) override;
+  void InsertText(const std::string& text) override;
 
   std::vector<float> GetRectToWindow() const override;
   std::string GetLynxVersion() const override;

--- a/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
+++ b/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
@@ -1,0 +1,65 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.devtool;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+import android.content.Context;
+import android.view.View;
+import android.widget.EditText;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.LynxView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class DevToolPlatformAndroidDelegateTest {
+  private Context mContext;
+  private LynxView mLynxView;
+  private DevToolPlatformAndroidDelegate mPlatformDelegate;
+
+  @Before
+  public void setUp() {
+    mContext =
+        InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
+    LynxEnv.inst().init((Application) mContext, null, null, null, null);
+    LynxDevtoolEnv.inst().init(mContext);
+
+    mLynxView = mock(LynxView.class);
+    mPlatformDelegate = new DevToolPlatformAndroidDelegate(mLynxView);
+  }
+
+  @Test
+  public void insertTextCommitsToFocusedEditText() {
+    EditText editText = new EditText(mContext);
+    editText.setText("ac");
+    editText.setSelection(1);
+    when(mLynxView.findFocus()).thenReturn(editText);
+
+    mPlatformDelegate.insertText("b");
+
+    assertEquals("abc", editText.getText().toString());
+  }
+
+  @Test
+  public void insertTextFallsBackToRootFocusedEditText() {
+    EditText editText = new EditText(mContext);
+    editText.setText("acd");
+    editText.setSelection(1, 2);
+    View rootView = mock(View.class);
+    when(rootView.findFocus()).thenReturn(editText);
+    when(mLynxView.findFocus()).thenReturn(null);
+    when(mLynxView.getRootView()).thenReturn(rootView);
+
+    mPlatformDelegate.insertText("b");
+
+    assertEquals("abd", editText.getText().toString());
+  }
+}

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
@@ -4,6 +4,10 @@
 package com.lynx.devtool;
 
 import android.text.TextUtils;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.widget.EditText;
 import android.widget.Toast;
 import androidx.annotation.Keep;
 import com.lynx.devtool.helper.EmulateTouchHelper;
@@ -365,6 +369,42 @@ public class DevToolPlatformAndroidDelegate {
             "DOM.focus failed for nodeId " + nodeId + ", code: " + args[0] + ", data: " + detail);
       }
     });
+  }
+
+  @CalledByNative
+  public void insertText(final String text) {
+    if (text == null) {
+      return;
+    }
+    LynxView lynxView = mLynxView.get();
+    if (lynxView == null) {
+      return;
+    }
+    View focusedView = lynxView.findFocus();
+    if (focusedView == null && lynxView.getRootView() != null) {
+      focusedView = lynxView.getRootView().findFocus();
+    }
+    if (!(focusedView instanceof EditText)) {
+      LLog.w(TAG, "Input.insertText ignored because no EditText is focused.");
+      return;
+    }
+
+    EditText editText = (EditText) focusedView;
+    InputConnection inputConnection = editText.onCreateInputConnection(new EditorInfo());
+    if (inputConnection != null && inputConnection.commitText(text, 1)) {
+      return;
+    }
+
+    int selectionStart = editText.getSelectionStart();
+    int selectionEnd = editText.getSelectionEnd();
+    if (selectionStart < 0 || selectionEnd < 0) {
+      editText.getText().append(text);
+      return;
+    }
+    int textLength = editText.getText().length();
+    int start = Math.min(textLength, Math.max(0, Math.min(selectionStart, selectionEnd)));
+    int end = Math.min(textLength, Math.max(0, Math.max(selectionStart, selectionEnd)));
+    editText.getText().replace(start, end, text);
   }
 
   @CalledByNative


### PR DESCRIPTION
Refs #6524
Depends on #6525

## Summary
- include the `Input.insertText` CDP dispatch commit so this branch builds independently
- bridge DevTool `insertText` from native Android code into `DevToolPlatformAndroidDelegate`
- insert text into the currently focused Android input view through the platform delegate
- add Android instrumentation coverage for focused `EditText` insertion and root-view focus fallback

## Test Plan
- `python3 tools_shared/git_lynx.py check --checkers file-type`
- `python3 tools_shared/git_lynx.py check --checkers cpplint`
- `python3 tools_shared/git_lynx.py check --checkers java-lint`
- `python3 tools_shared/git_lynx.py check --checkers commit-message`
- `python3 tools_shared/git_lynx.py check --checkers coding-style`
- `./gradlew :LynxDevtool:compileNoasanDebugAndroidTestJavaWithJavac --parallel --configure-on-demand -x lint -PabiList=x86 -Penable_lynx_android_test=true -Penable_coverage=true`
