### PR TITLE
[Feature][iOS] Bridge DevTool insertText to first responder

### DIFF
--- a/platform/darwin/ios/lynx_devtool/BUILD.gn
+++ b/platform/darwin/ios/lynx_devtool/BUILD.gn
@@ -359,6 +359,7 @@ subspec_target("UnitTests") {
   sources = [
     "../../common/lynx_devtool/LynxDebugBridgeUnitTest.mm",
     "ConsoleDelegateManagerUnitTest.mm",
+    "DevToolPlatformDarwinDelegateUnitTest.mm",
     "Helper/LepusDebugInfoHelperUnitTest.mm",
     "Helper/LynxUITreeHelperUnitTest.m",
     "LynxDevToolErrorUtilsUnitTest.m",

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getLepusDebugInfoUrl:(NSString *_Nonnull)filename;
 
 - (void)emulateTouch:(std::shared_ptr<lynx::devtool::MouseEvent>)input;
+- (void)insertText:(nullable NSString *)text;
 - (void)emulateTouch:(nonnull NSString *)type
          coordinateX:(int)x
          coordinateY:(int)y

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
@@ -23,6 +23,10 @@
 #include "devtool/lynx_devtool/agent/devtool_platform_facade.h"
 #include "devtool/lynx_devtool/element/element_inspector.h"
 
+@interface DevToolPlatformDarwinDelegate ()
+- (nullable UIView*)firstResponderInView:(nullable UIView*)view;
+@end
+
 #pragma mark - DevToolPlatformDarwin
 namespace lynx {
 namespace devtool {
@@ -223,6 +227,16 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
     __strong typeof(_darwin) darwin = _darwin;
     if (darwin != nil) {
       [darwin emulateTouch:input];
+    }
+  }
+
+  void InsertText(const std::string& text) override {
+    __strong typeof(_darwin) darwin = _darwin;
+    if (darwin != nil) {
+      NSString* nsText = [[NSString alloc] initWithBytes:text.data()
+                                                  length:text.size()
+                                                encoding:NSUTF8StringEncoding];
+      [darwin insertText:nsText];
     }
   }
 
@@ -582,6 +596,34 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
               deltaY:input->delta_y_
            modifiers:input->modifiers_
           clickCount:input->click_count_];
+}
+
+- (void)insertText:(nullable NSString*)text {
+  if (text == nil) {
+    return;
+  }
+  __strong typeof(_lynxView) lynxView = _lynxView;
+  UIView* firstResponder = [self firstResponderInView:lynxView];
+  if ([firstResponder conformsToProtocol:@protocol(UITextInput)] &&
+      [firstResponder respondsToSelector:@selector(insertText:)]) {
+    [(id<UITextInput>)firstResponder insertText:text];
+  }
+}
+
+- (nullable UIView*)firstResponderInView:(nullable UIView*)view {
+  if (view == nil) {
+    return nil;
+  }
+  if (view.isFirstResponder) {
+    return view;
+  }
+  for (UIView* subview in view.subviews) {
+    UIView* firstResponder = [self firstResponderInView:subview];
+    if (firstResponder != nil) {
+      return firstResponder;
+    }
+  }
+  return nil;
 }
 
 - (void)emulateTouch:(nonnull NSString*)type

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
@@ -1,0 +1,45 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <LynxDevtool/DevToolPlatformDarwinDelegate.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface DevToolInsertTextField : UITextField
+@end
+
+@implementation DevToolInsertTextField
+
+- (BOOL)isFirstResponder {
+  return YES;
+}
+
+@end
+
+@interface DevToolPlatformDarwinDelegateUnitTest : XCTestCase
+@end
+
+@implementation DevToolPlatformDarwinDelegateUnitTest
+
+- (void)testInsertTextUsesFirstResponderTextInput {
+  UIView *lynxView = [[UIView alloc] initWithFrame:CGRectZero];
+  UIView *container = [[UIView alloc] initWithFrame:CGRectZero];
+  DevToolInsertTextField *textField = [[DevToolInsertTextField alloc] initWithFrame:CGRectZero];
+  textField.text = @"ac";
+  textField.selectedTextRange = [textField
+      textRangeFromPosition:[textField positionFromPosition:textField.beginningOfDocument offset:1]
+                 toPosition:[textField positionFromPosition:textField.beginningOfDocument
+                                                     offset:1]];
+  [container addSubview:textField];
+  [lynxView addSubview:container];
+
+  DevToolPlatformDarwinDelegate *platform =
+      [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:(LynxView *)lynxView];
+
+  [platform insertText:@"b"];
+
+  XCTAssertEqualObjects(textField.text, @"abc");
+}
+
+@end


### PR DESCRIPTION
Refs #6524
Depends on #6525

## Summary
- include the `Input.insertText` CDP dispatch commit so this branch builds independently
- bridge DevTool `insertText` through the Darwin platform delegate
- insert text into the current iOS first responder when it supports text input
- add XCTest coverage for inserting text into the first responder text input in the Lynx view tree

## Test Plan
- `python3 tools_shared/git_lynx.py check --checkers file-type`
- `python3 tools_shared/git_lynx.py check --checkers cpplint`
- `python3 tools_shared/git_lynx.py check --checkers java-lint`
- `python3 tools_shared/git_lynx.py check --checkers commit-message`
- `python3 tools_shared/git_lynx.py check --checkers coding-style`
