### PR TITLE
[Feature][DevTool] Wire DOM focus CDP dispatch

### DIFF
--- a/devtool/lynx_devtool/agent/devtool_platform_facade.h
+++ b/devtool/lynx_devtool/agent/devtool_platform_facade.h
@@ -41,6 +41,7 @@ class DevToolPlatformFacade
 
   virtual std::string GetDebugInfoByUrl(const std::string& url) = 0;
   virtual void ScrollIntoView(int node_id) = 0;
+  virtual void Focus(int node_id) {}
   virtual int FindNodeIdForLocation(float x, float y,
                                     std::string screen_shot_mode) = 0;
   virtual void StartScreenCast(ScreenshotRequest request) = 0;

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng.cc
@@ -48,6 +48,7 @@ InspectorDOMAgentNG::InspectorDOMAgentNG(
       &InspectorDOMAgentNG::DiscardSearchResults;
   functions_map_["DOM.scrollIntoViewIfNeeded"] =
       &InspectorDOMAgentNG::ScrollIntoViewIfNeeded;
+  functions_map_["DOM.focus"] = &InspectorDOMAgentNG::Focus;
   functions_map_["DOM.getOriginalNodeIndex"] =
       &InspectorDOMAgentNG::GetOriginalNodeIndex;
 }
@@ -187,6 +188,11 @@ void InspectorDOMAgentNG::DiscardSearchResults(
 void InspectorDOMAgentNG::ScrollIntoViewIfNeeded(
     const std::shared_ptr<MessageSender>& sender, const Json::Value& message) {
   devtool_mediator_->ScrollIntoViewIfNeeded(sender, message);
+}
+
+void InspectorDOMAgentNG::Focus(const std::shared_ptr<MessageSender>& sender,
+                                const Json::Value& message) {
+  devtool_mediator_->DOM_Focus(sender, message);
 }
 
 void InspectorDOMAgentNG::GetOriginalNodeIndex(

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng.h
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng.h
@@ -84,6 +84,8 @@ class InspectorDOMAgentNG : public CDPDomainAgentBase {
                             const Json::Value& message);
   void ScrollIntoViewIfNeeded(const std::shared_ptr<MessageSender>& sender,
                               const Json::Value& message);
+  void Focus(const std::shared_ptr<MessageSender>& sender,
+             const Json::Value& message);
   void GetOriginalNodeIndex(const std::shared_ptr<MessageSender>& sender,
                             const Json::Value& message);
 

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc
@@ -1,0 +1,174 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#define private public
+#define protected public
+
+#include "devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng.h"
+
+#include <future>
+#include <memory>
+
+#include "base/include/fml/thread.h"
+#include "core/renderer/dom/element.h"
+#include "core/renderer/dom/element_manager.h"
+#include "core/renderer/tasm/react/testing/mock_painting_context.h"
+#include "core/shell/testing/mock_tasm_delegate.h"
+#include "devtool/base_devtool/native/test/message_sender_mock.h"
+#include "devtool/base_devtool/native/test/mock_receiver.h"
+#include "devtool/lynx_devtool/agent/inspector_tasm_executor.h"
+#include "devtool/lynx_devtool/agent/inspector_ui_executor.h"
+#include "devtool/lynx_devtool/element/element_inspector.h"
+#include "devtool/testing/mock/devtool_platform_facade_mock.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+#include "third_party/jsoncpp/include/json/reader.h"
+#include "third_party/jsoncpp/include/json/value.h"
+
+namespace lynx {
+namespace devtool {
+namespace testing {
+
+static constexpr int32_t kWidth = 1080;
+static constexpr int32_t kHeight = 1920;
+static constexpr float kDefaultLayoutsUnitPerPx = 1.f;
+static constexpr double kDefaultPhysicalPixelsPerLayoutUnit = 1.f;
+
+class FocusRecordingPlatformFacade
+    : public lynx::testing::DevToolPlatformFacadeMock {
+ public:
+  void Focus(int node_id) override { focused_node_id_ = node_id; }
+
+  int focused_node_id_ = -1;
+};
+
+class InspectorDOMAgentNGTest : public ::testing::Test {
+ public:
+  InspectorDOMAgentNGTest() = default;
+  ~InspectorDOMAgentNGTest() override = default;
+
+  void SetUp() override {
+    lynx::tasm::LynxEnvConfig lynx_env_config(
+        kWidth, kHeight, kDefaultLayoutsUnitPerPx,
+        kDefaultPhysicalPixelsPerLayoutUnit);
+    tasm_mediator_ = std::make_shared<
+        ::testing::NiceMock<lynx::tasm::test::MockTasmDelegate>>();
+    manager_ = std::make_unique<lynx::tasm::ElementManager>(
+        std::make_unique<lynx::tasm::MockPaintingContext>(),
+        tasm_mediator_.get(), lynx_env_config);
+    MockReceiver::GetInstance().ResetAll();
+    devtool_mediator_ = std::make_shared<LynxDevToolMediator>();
+    message_sender_ = std::make_shared<MessageSenderMock>();
+    element_executor_ =
+        std::make_shared<InspectorTasmExecutor>(devtool_mediator_, nullptr, 1);
+    ui_executor_ = std::make_shared<InspectorUIExecutor>(devtool_mediator_);
+    facade_ = std::make_shared<FocusRecordingPlatformFacade>();
+    ui_executor_->SetDevToolPlatformFacade(facade_);
+    tasm_thread_ = std::make_unique<fml::Thread>("tasm");
+    ui_thread_ = std::make_unique<fml::Thread>("ui");
+    devtool_mediator_->tasm_task_runner_ = tasm_thread_->GetTaskRunner();
+    devtool_mediator_->ui_task_runner_ = ui_thread_->GetTaskRunner();
+    devtool_mediator_->element_executor_ = element_executor_;
+    devtool_mediator_->ui_executor_ = ui_executor_;
+    agent_ = std::make_shared<InspectorDOMAgentNG>(devtool_mediator_);
+  }
+
+ protected:
+  void FlushTasmTasks() {
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    devtool_mediator_->RunOnTASMThread([&promise]() { promise.set_value(); },
+                                       true);
+    future.wait();
+  }
+
+  void FlushUITasks() {
+    std::promise<void> promise;
+    auto future = promise.get_future();
+    devtool_mediator_->RunOnUIThread([&promise]() { promise.set_value(); },
+                                     true);
+    future.wait();
+  }
+
+  Json::Value ParseLastResponse() {
+    Json::Value response;
+    Json::Reader reader;
+    EXPECT_TRUE(reader.parse(
+        MockReceiver::GetInstance().received_message_.second, response));
+    return response;
+  }
+
+  std::shared_ptr<InspectorDOMAgentNG> agent_;
+  std::shared_ptr<LynxDevToolMediator> devtool_mediator_;
+  std::shared_ptr<InspectorTasmExecutor> element_executor_;
+  std::shared_ptr<InspectorUIExecutor> ui_executor_;
+  std::shared_ptr<MessageSenderMock> message_sender_;
+  std::shared_ptr<FocusRecordingPlatformFacade> facade_;
+  std::unique_ptr<lynx::tasm::ElementManager> manager_;
+  std::unique_ptr<fml::Thread> tasm_thread_;
+  std::unique_ptr<fml::Thread> ui_thread_;
+  std::shared_ptr<::testing::NiceMock<lynx::tasm::test::MockTasmDelegate>>
+      tasm_mediator_;
+};
+
+TEST_F(InspectorDOMAgentNGTest, FocusReturnsSuccessAndFocusesNode) {
+  auto input = manager_->CreateFiberElement("input");
+  ElementInspector::InitForInspector(std::make_tuple(input.get()));
+  input->MarkCanBeLayoutOnly(false);
+  element_executor_->element_root_ = input.get();
+  int node_id = ElementInspector::NodeId(input.get());
+
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 11;
+  message["method"] = "DOM.focus";
+  message["params"]["nodeId"] = node_id;
+
+  agent_->CallMethod(message_sender_, message);
+  FlushTasmTasks();
+  FlushUITasks();
+
+  Json::Value response = ParseLastResponse();
+  EXPECT_EQ(response["id"], 11);
+  EXPECT_TRUE(response["error"].isNull());
+  EXPECT_TRUE(response["result"].isObject());
+  EXPECT_EQ(facade_->focused_node_id_, node_id);
+}
+
+TEST_F(InspectorDOMAgentNGTest, FocusMissingNodeReturnsError) {
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 12;
+  message["method"] = "DOM.focus";
+  message["params"]["nodeId"] = 99999;
+
+  agent_->CallMethod(message_sender_, message);
+  FlushTasmTasks();
+
+  Json::Value response = ParseLastResponse();
+  EXPECT_EQ(response["id"], 12);
+  EXPECT_EQ(response["error"]["code"], -32000);
+  EXPECT_EQ(response["error"]["message"], "Element not found.");
+  EXPECT_TRUE(response["result"].isNull());
+  EXPECT_EQ(facade_->focused_node_id_, -1);
+}
+
+TEST_F(InspectorDOMAgentNGTest, FocusMissingNodeIdReturnsInvalidParams) {
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 13;
+  message["method"] = "DOM.focus";
+  message["params"] = Json::Value(Json::ValueType::objectValue);
+
+  agent_->CallMethod(message_sender_, message);
+  FlushTasmTasks();
+
+  Json::Value response = ParseLastResponse();
+  EXPECT_EQ(response["id"], 13);
+  EXPECT_EQ(response["error"]["code"], -32602);
+  EXPECT_EQ(response["error"]["message"],
+            "DOM.focus requires a numeric nodeId parameter.");
+  EXPECT_TRUE(response["result"].isNull());
+  EXPECT_EQ(facade_->focused_node_id_, -1);
+}
+
+}  // namespace testing
+}  // namespace devtool
+}  // namespace lynx

--- a/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
@@ -954,6 +954,48 @@ void InspectorTasmExecutor::ScrollIntoViewIfNeeded(
   sender->SendMessage("CDP", response.toStyledString());
 }
 
+void InspectorTasmExecutor::DOM_Focus(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  Json::Value response(Json::ValueType::objectValue);
+  Json::Value content(Json::ValueType::objectValue);
+  response["id"] = message["id"].asInt64();
+
+  const Json::Value& params = message["params"];
+  if (!params.isObject() || !params.isMember("nodeId") ||
+      (!params["nodeId"].isInt() && !params["nodeId"].isUInt())) {
+    Json::Value error(Json::ValueType::objectValue);
+    error["code"] = kInvalidParams;
+    error["message"] = "DOM.focus requires a numeric nodeId parameter.";
+    response["error"] = error;
+    sender->SendMessage("CDP", response);
+    return;
+  }
+
+  const Json::Value& node_id_value = params["nodeId"];
+  Element* current_element = GetElementById(node_id_value.asInt());
+  while (current_element != nullptr && (current_element->is_virtual() ||
+                                        current_element->CanBeLayoutOnly())) {
+    current_element = current_element->parent();
+  }
+  if (current_element == nullptr) {
+    Json::Value error(Json::ValueType::objectValue);
+    error["code"] = kServerError;
+    error["message"] = "Element not found.";
+    response["error"] = error;
+    sender->SendMessage("CDP", response);
+    return;
+  }
+
+  auto devtool_mediator = devtool_mediator_wp_.lock();
+  CHECK_NULL_AND_LOG_RETURN(devtool_mediator, "devtool_mediator is null");
+
+  devtool_mediator->Focus(ElementInspector::NodeId(current_element));
+
+  response["result"] = content;
+  sender->SendMessage("CDP", response);
+}
+
 void InspectorTasmExecutor::WhiteBoardEnable(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {

--- a/devtool/lynx_devtool/agent/inspector_tasm_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_tasm_executor.h
@@ -117,6 +117,7 @@ class InspectorTasmExecutor
   DECLARE_DEVTOOL_METHOD(GetSearchResults)
   DECLARE_DEVTOOL_METHOD(DiscardSearchResults)
   DECLARE_DEVTOOL_METHOD(GetOriginalNodeIndex)
+  DECLARE_DEVTOOL_METHOD(DOM_Focus)
 
   // css domain
   DECLARE_DEVTOOL_METHOD(CSS_Enable)

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -86,6 +86,12 @@ void InspectorUIExecutor::ScrollIntoView(int node_id) {
   devtool_platform_facade_->ScrollIntoView(node_id);
 }
 
+void InspectorUIExecutor::Focus(int node_id) {
+  CHECK_NULL_AND_LOG_RETURN(devtool_platform_facade_,
+                            "devtool_platform_facade_ is null");
+  devtool_platform_facade_->Focus(node_id);
+}
+
 void InspectorUIExecutor::PageReload(bool ignore_cache,
                                      const std::string& template_binary,
                                      const std::string& reload_url,

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.h
@@ -83,6 +83,7 @@ class InspectorUIExecutor
 
   // task run on ui thread
   void ScrollIntoView(int node_id);
+  void Focus(int node_id);
   void PageReload(bool ignore_cache, const std::string& template_binary = "",
                   const std::string& reload_url = "",
                   bool from_template_fragments = false,

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
@@ -477,6 +477,14 @@ void LynxDevToolMediator::ScrollIntoViewIfNeeded(
   });
 }
 
+void LynxDevToolMediator::DOM_Focus(
+    const std::shared_ptr<lynx::devtool::MessageSender>& sender,
+    const Json::Value& message) {
+  RunOnTASMThread([sender, message, executor = element_executor_] {
+    executor->DOM_Focus(sender, message);
+  });
+}
+
 void LynxDevToolMediator::DOMEnableDomTree(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {
@@ -497,6 +505,11 @@ void LynxDevToolMediator::ScrollIntoView(int node_id) {
   RunOnUIThread([executor = ui_executor_, node_id] {
     executor->ScrollIntoView(node_id);
   });
+}
+
+void LynxDevToolMediator::Focus(int node_id) {
+  RunOnUIThread(
+      [executor = ui_executor_, node_id] { executor->Focus(node_id); });
 }
 
 void LynxDevToolMediator::PageReload(bool ignore_cache) {

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
@@ -113,6 +113,7 @@ class LynxDevToolMediator
   DECLARE_DEVTOOL_METHOD(DiscardSearchResults);
   DECLARE_DEVTOOL_METHOD(GetOriginalNodeIndex);
   DECLARE_DEVTOOL_METHOD(ScrollIntoViewIfNeeded);
+  DECLARE_DEVTOOL_METHOD(DOM_Focus);
   DECLARE_DEVTOOL_METHOD(DOMEnableDomTree);
   DECLARE_DEVTOOL_METHOD(DOMDisableDomTree);
   DECLARE_DEVTOOL_METHOD(GetNodeForLocation);
@@ -248,6 +249,7 @@ class LynxDevToolMediator
 
   // implemented by ui executor
   void ScrollIntoView(int node_id);
+  void Focus(int node_id);
   void PageReload(bool ignore_cache);
 
   void InitWhiteBoardInspector(

--- a/devtool/testing/agent/BUILD.gn
+++ b/devtool/testing/agent/BUILD.gn
@@ -7,6 +7,7 @@ import("../../../testing/test.gni")
 unittest_set("devtool_agent_testset") {
   testonly = true
   sources = [
+    "../../lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc",
     "../../lynx_devtool/agent/domain_agent/inspector_log_agent_unittest.cc",
     "../../lynx_devtool/agent/inspector_tasm_executor_unittest.cc",
     "../../lynx_devtool/agent/inspector_ui_executor_unittest.cc",


### PR DESCRIPTION
## Summary
- Add DOM.focus CDP routing through the DOM agent, TASM executor, and UI executor.
- Validate the required nodeId parameter and return CDP errors for malformed requests or missing elements.
- Add devtool agent coverage for success and error responses.

Refs #6528

## Tests
- tools/rtf/rtf native-ut run --names devtool --target devtool_agent_testset --gtest-filter='InspectorDOMAgentNGTest.*'
- python3 tools_shared/git_lynx.py check --checkers file-type
- python3 tools_shared/git_lynx.py check --checkers cpplint
- python3 tools_shared/git_lynx.py check --checkers java-lint
- python3 tools_shared/git_lynx.py check --checkers commit-message
- python3 tools_shared/git_lynx.py check --checkers coding-style
- python3 tools_shared/git_lynx.py check --checkers android-check-style
- python3 tools_shared/git_lynx.py check --checkers api-check --all
- python3 tools_shared/git_lynx.py check --checkers gn-relative-path-check
