### PR TITLE
[Feature][Android] Bridge DevTool DOM focus to UI method

### DIFF
--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
@@ -225,6 +225,15 @@ void DevToolPlatformAndroid::EmulateTouch(
       env, ref.Get(), type.Get(), x, y, deltaX, deltaY, button.Get());
 }
 
+void DevToolPlatformAndroid::Focus(int node_id) {
+  JNIEnv* env = lynx::base::android::AttachCurrentThread();
+  lynx::base::android::ScopedLocalJavaRef<jobject> ref(weak_android_delegate_);
+  if (ref.IsNull()) {
+    return;
+  }
+  Java_DevToolPlatformAndroidDelegate_focus(env, ref.Get(), node_id);
+}
+
 void DevToolPlatformAndroid::OnConsoleMessage(const std::string& message) {
   std::lock_guard<std::mutex> lock(mutex_);
   JNIEnv* env = lynx::base::android::AttachCurrentThread();

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.h
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.h
@@ -39,6 +39,7 @@ class DevToolPlatformAndroid : public DevToolPlatformFacade {
   int SetUIStyle(int id, std::string name, std::string content) override;
 
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override;
+  void Focus(int node_id) override;
 
   std::vector<float> GetRectToWindow() const override;
   std::string GetLynxVersion() const override;

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
@@ -20,6 +20,7 @@ import com.lynx.tasm.LynxView;
 import com.lynx.tasm.base.CalledByNative;
 import com.lynx.tasm.base.LLog;
 import com.lynx.tasm.base.PageReloadHelper;
+import com.lynx.tasm.behavior.LynxUIMethodConstants;
 import com.lynx.tasm.behavior.LynxUIOwner;
 import java.lang.ref.WeakReference;
 
@@ -340,6 +341,30 @@ public class DevToolPlatformAndroidDelegate {
       mTouchHelper.emulateTouch(type, (int) (x * scale + 0.5f), (int) (y * scale + 0.5f),
           deltaX * scale + 0.5f, deltaY * scale + 0.5f, button, mDevToolDelegate);
     }
+  }
+
+  @CalledByNative
+  public void focus(final int nodeId) {
+    LynxView lynxView = mLynxView.get();
+    if (lynxView == null || lynxView.getLynxContext() == null) {
+      return;
+    }
+    LynxUIOwner uiOwner = lynxView.getLynxContext().getLynxUIOwner();
+    if (uiOwner == null) {
+      return;
+    }
+    uiOwner.invokeUIMethodForSelectorQuery(nodeId, "focus", new JavaOnlyMap(), new Callback() {
+      @Override
+      public void invoke(Object... args) {
+        if (args == null || args.length == 0 || !(args[0] instanceof Integer)
+            || ((Integer) args[0]) == LynxUIMethodConstants.SUCCESS) {
+          return;
+        }
+        Object detail = args.length > 1 ? args[1] : "";
+        LLog.w(TAG,
+            "DOM.focus failed for nodeId " + nodeId + ", code: " + args[0] + ", data: " + detail);
+      }
+    });
   }
 
   @CalledByNative


### PR DESCRIPTION
## Summary
- Includes the core DOM.focus CDP dispatch commit.
- Add the Android DevTool platform Focus override and JNI dispatch.
- Invoke the target LynxUI focus method from DevToolPlatformAndroidDelegate.

Refs #6528

## Tests
- python3 tools_shared/git_lynx.py check --checkers file-type
- python3 tools_shared/git_lynx.py check --checkers cpplint
- python3 tools_shared/git_lynx.py check --checkers java-lint
- python3 tools_shared/git_lynx.py check --checkers commit-message
- python3 tools_shared/git_lynx.py check --checkers coding-style
- python3 tools_shared/git_lynx.py check --checkers android-check-style
- python3 tools_shared/git_lynx.py check --checkers api-check --all
- python3 tools_shared/git_lynx.py check --checkers gn-relative-path-check
