### PR TITLE
[Feature][iOS] Bridge DevTool DOM focus to UI method

### DIFF
--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (std::shared_ptr<lynx::devtool::DevToolPlatformFacade>)getNativePtr;
 
 - (void)scrollIntoView:(int)node_index;
+- (void)focus:(int)node_index;
 
 - (int)findNodeIdForLocationWithX:(float)x withY:(float)y mode:(NSString *)mode;
 

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
@@ -60,6 +60,13 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
     }
   }
 
+  void Focus(int node_index) override {
+    __strong typeof(_darwin) darwin = _darwin;
+    if (darwin) {
+      [darwin focus:node_index];
+    }
+  }
+
   void OnConsoleMessage(const std::string& message) override {
     __strong typeof(_darwin) darwin = _darwin;
     if (darwin) {
@@ -348,6 +355,12 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
 - (void)scrollIntoView:(int)node_index {
   if (_uiTreeHelper) {
     return [_uiTreeHelper scrollIntoView:node_index];
+  }
+}
+
+- (void)focus:(int)node_index {
+  if (_uiTreeHelper) {
+    [_uiTreeHelper focus:node_index];
   }
 }
 

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.h
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)attachLynxUIOwner:(nullable LynxUIOwner *)uiOwner;
 
 - (void)scrollIntoView:(int)node_id;
+- (void)focus:(int)node_id;
 
 - (CGRect)getRectToWindow;
 

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.mm
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.mm
@@ -5,6 +5,7 @@
 #import <Lynx/LynxLog.h>
 #import <Lynx/LynxRootUI.h>
 #import <Lynx/LynxUI+Internal.h>
+#import <Lynx/LynxUIMethodProcessor.h>
 #import <LynxDevtool/LynxScreenCastHelper.h>
 #import <LynxDevtool/LynxUITreeHelper.h>
 #import <objc/message.h>
@@ -53,6 +54,22 @@
   __strong typeof(_uiOwner) uiOwner = _uiOwner;
   LynxUI* ui = [uiOwner findUIBySign:node_id];
   [ui scrollIntoViewWithSmooth:false blockType:@"center" inlineType:@"center" callback:nil];
+}
+
+- (void)focus:(int)node_id {
+  __strong typeof(_uiOwner) uiOwner = _uiOwner;
+  if (uiOwner == nil) {
+    return;
+  }
+  [uiOwner invokeUIMethodForSelectorQuery:@"focus"
+                                   params:@{}
+                                 callback:^(int code, id _Nullable data) {
+                                   if (code != kUIMethodSuccess) {
+                                     LLogWarn(@"DOM.focus failed for nodeId:%d code:%d data:%@",
+                                              node_id, code, data);
+                                   }
+                                 }
+                                   toNode:node_id];
 }
 
 - (NSString*)dictionaryToJson:(NSMutableDictionary*)dict {


### PR DESCRIPTION
## Summary
- Includes the core DOM.focus CDP dispatch commit.
- Add the Darwin DevTool platform Focus override.
- Route DOM focus through LynxUITreeHelper to the target LynxUI focus method.

Refs #6528

## Tests
- python3 tools_shared/git_lynx.py check --checkers file-type
- python3 tools_shared/git_lynx.py check --checkers cpplint
- python3 tools_shared/git_lynx.py check --checkers java-lint
- python3 tools_shared/git_lynx.py check --checkers commit-message
- python3 tools_shared/git_lynx.py check --checkers coding-style
- python3 tools_shared/git_lynx.py check --checkers android-check-style
- python3 tools_shared/git_lynx.py check --checkers api-check --all
- python3 tools_shared/git_lynx.py check --checkers gn-relative-path-check
