### PR TITLE
[BugFix][DevTool] Return DOM focus UI method errors

### DIFF
--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
@@ -6,6 +6,8 @@
 
 #include <sys/system_properties.h>
 
+#include <utility>
+
 #include "core/base/android/jni_helper.h"
 #include "devtool/base_devtool/native/public/devtool_status.h"
 #include "devtool/lynx_devtool/agent/inspector_util.h"
@@ -133,6 +135,25 @@ void SendCDPEvent(JNIEnv* env, jobject jcaller, jlong facadePtr,
       lynx::base::android::JNIConvertHelper::ConvertToString(env, message));
 }
 
+void ReportFocusResult(JNIEnv* env, jclass /*jcaller*/, jlong callbackPtr,
+                       jboolean success, jstring errorMessage) {
+  auto* callback =
+      reinterpret_cast<lynx::devtool::DevToolPlatformFocusCallback*>(
+          callbackPtr);
+  if (!callback) {
+    return;
+  }
+  std::string error_message;
+  if (errorMessage != nullptr) {
+    error_message = lynx::base::android::JNIConvertHelper::ConvertToString(
+        env, errorMessage);
+  }
+  if (*callback) {
+    (*callback)(success, error_message);
+  }
+  delete callback;
+}
+
 namespace lynx {
 namespace devtool {
 DevToolPlatformAndroid::DevToolPlatformAndroid(JNIEnv* env, jobject owner)
@@ -225,13 +246,19 @@ void DevToolPlatformAndroid::EmulateTouch(
       env, ref.Get(), type.Get(), x, y, deltaX, deltaY, button.Get());
 }
 
-void DevToolPlatformAndroid::Focus(int node_id) {
+void DevToolPlatformAndroid::Focus(int node_id,
+                                   DevToolPlatformFocusCallback callback) {
   JNIEnv* env = lynx::base::android::AttachCurrentThread();
   lynx::base::android::ScopedLocalJavaRef<jobject> ref(weak_android_delegate_);
   if (ref.IsNull()) {
+    if (callback) {
+      callback(true, "");
+    }
     return;
   }
-  Java_DevToolPlatformAndroidDelegate_focus(env, ref.Get(), node_id);
+  auto* callback_ptr = new DevToolPlatformFocusCallback(std::move(callback));
+  Java_DevToolPlatformAndroidDelegate_focus(
+      env, ref.Get(), node_id, reinterpret_cast<jlong>(callback_ptr));
 }
 
 void DevToolPlatformAndroid::OnConsoleMessage(const std::string& message) {

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.h
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.h
@@ -39,7 +39,7 @@ class DevToolPlatformAndroid : public DevToolPlatformFacade {
   int SetUIStyle(int id, std::string name, std::string content) override;
 
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override;
-  void Focus(int node_id) override;
+  void Focus(int node_id, DevToolPlatformFocusCallback callback) override;
 
   std::vector<float> GetRectToWindow() const override;
   std::string GetLynxVersion() const override;

--- a/devtool/lynx_devtool/agent/devtool_platform_facade.h
+++ b/devtool/lynx_devtool/agent/devtool_platform_facade.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "base/include/closure.h"
 #include "base/include/value/base_value.h"
 #include "core/renderer/dom/element.h"
 #include "devtool/lynx_devtool/base/mouse_event.h"
@@ -16,6 +17,9 @@
 
 namespace lynx {
 namespace devtool {
+
+using DevToolPlatformFocusCallback =
+    lynx::base::MoveOnlyClosure<void, bool, const std::string&>;
 
 class LynxDevToolMediator;
 class InspectorUIExecutor;
@@ -41,7 +45,11 @@ class DevToolPlatformFacade
 
   virtual std::string GetDebugInfoByUrl(const std::string& url) = 0;
   virtual void ScrollIntoView(int node_id) = 0;
-  virtual void Focus(int node_id) {}
+  virtual void Focus(int node_id, DevToolPlatformFocusCallback callback) {
+    if (callback) {
+      callback(true, "");
+    }
+  }
   virtual int FindNodeIdForLocation(float x, float y,
                                     std::string screen_shot_mode) = 0;
   virtual void StartScreenCast(ScreenshotRequest request) = 0;

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_dom_agent_ng_unittest.cc
@@ -9,6 +9,7 @@
 
 #include <future>
 #include <memory>
+#include <string>
 
 #include "base/include/fml/thread.h"
 #include "core/renderer/dom/element.h"
@@ -37,9 +38,18 @@ static constexpr double kDefaultPhysicalPixelsPerLayoutUnit = 1.f;
 class FocusRecordingPlatformFacade
     : public lynx::testing::DevToolPlatformFacadeMock {
  public:
-  void Focus(int node_id) override { focused_node_id_ = node_id; }
+  void Focus(int node_id, DevToolPlatformFocusCallback callback) override {
+    focused_node_id_ = node_id;
+    if (fail_focus_) {
+      callback(false, focus_error_message_);
+      return;
+    }
+    callback(true, "");
+  }
 
   int focused_node_id_ = -1;
+  bool fail_focus_ = false;
+  std::string focus_error_message_;
 };
 
 class InspectorDOMAgentNGTest : public ::testing::Test {
@@ -131,6 +141,32 @@ TEST_F(InspectorDOMAgentNGTest, FocusReturnsSuccessAndFocusesNode) {
   EXPECT_EQ(response["id"], 11);
   EXPECT_TRUE(response["error"].isNull());
   EXPECT_TRUE(response["result"].isObject());
+  EXPECT_EQ(facade_->focused_node_id_, node_id);
+}
+
+TEST_F(InspectorDOMAgentNGTest, FocusReturnsErrorWhenPlatformFocusFails) {
+  auto input = manager_->CreateFiberElement("input");
+  ElementInspector::InitForInspector(std::make_tuple(input.get()));
+  input->MarkCanBeLayoutOnly(false);
+  element_executor_->element_root_ = input.get();
+  int node_id = ElementInspector::NodeId(input.get());
+  facade_->fail_focus_ = true;
+  facade_->focus_error_message_ = "code: 8, data: input is disabled.";
+
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 14;
+  message["method"] = "DOM.focus";
+  message["params"]["nodeId"] = node_id;
+
+  agent_->CallMethod(message_sender_, message);
+  FlushTasmTasks();
+  FlushUITasks();
+
+  Json::Value response = ParseLastResponse();
+  EXPECT_EQ(response["id"], 14);
+  EXPECT_EQ(response["error"]["code"], -32000);
+  EXPECT_EQ(response["error"]["message"], "code: 8, data: input is disabled.");
+  EXPECT_TRUE(response["result"].isNull());
   EXPECT_EQ(facade_->focused_node_id_, node_id);
 }
 

--- a/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_tasm_executor.cc
@@ -990,10 +990,21 @@ void InspectorTasmExecutor::DOM_Focus(
   auto devtool_mediator = devtool_mediator_wp_.lock();
   CHECK_NULL_AND_LOG_RETURN(devtool_mediator, "devtool_mediator is null");
 
-  devtool_mediator->Focus(ElementInspector::NodeId(current_element));
-
-  response["result"] = content;
-  sender->SendMessage("CDP", response);
+  devtool_mediator->Focus(
+      ElementInspector::NodeId(current_element),
+      [sender, response, content](bool success,
+                                  const std::string& error_message) mutable {
+        if (success) {
+          response["result"] = content;
+        } else {
+          Json::Value error(Json::ValueType::objectValue);
+          error["code"] = kServerError;
+          error["message"] =
+              error_message.empty() ? "DOM.focus failed." : error_message;
+          response["error"] = error;
+        }
+        sender->SendMessage("CDP", response);
+      });
 }
 
 void InspectorTasmExecutor::WhiteBoardEnable(

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -5,6 +5,7 @@
 #include "devtool/lynx_devtool/agent/inspector_ui_executor.h"
 
 #include <regex>
+#include <utility>
 
 #include "core/renderer/dom/element_manager.h"
 #include "core/runtime/lepus/json_parser.h"
@@ -86,10 +87,16 @@ void InspectorUIExecutor::ScrollIntoView(int node_id) {
   devtool_platform_facade_->ScrollIntoView(node_id);
 }
 
-void InspectorUIExecutor::Focus(int node_id) {
-  CHECK_NULL_AND_LOG_RETURN(devtool_platform_facade_,
-                            "devtool_platform_facade_ is null");
-  devtool_platform_facade_->Focus(node_id);
+void InspectorUIExecutor::Focus(int node_id,
+                                DevToolPlatformFocusCallback callback) {
+  if (!devtool_platform_facade_) {
+    LOGE("devtool_platform_facade_ is null");
+    if (callback) {
+      callback(true, "");
+    }
+    return;
+  }
+  devtool_platform_facade_->Focus(node_id, std::move(callback));
 }
 
 void InspectorUIExecutor::PageReload(bool ignore_cache,

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.h
@@ -84,7 +84,7 @@ class InspectorUIExecutor
 
   // task run on ui thread
   void ScrollIntoView(int node_id);
-  void Focus(int node_id);
+  void Focus(int node_id, DevToolPlatformFocusCallback callback);
   void PageReload(bool ignore_cache, const std::string& template_binary = "",
                   const std::string& reload_url = "",
                   bool from_template_fragments = false,

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.cc
@@ -507,9 +507,18 @@ void LynxDevToolMediator::ScrollIntoView(int node_id) {
   });
 }
 
-void LynxDevToolMediator::Focus(int node_id) {
-  RunOnUIThread(
-      [executor = ui_executor_, node_id] { executor->Focus(node_id); });
+void LynxDevToolMediator::Focus(int node_id,
+                                DevToolPlatformFocusCallback callback) {
+  if (!ui_task_runner_) {
+    if (callback) {
+      callback(true, "");
+    }
+    return;
+  }
+  RunOnUIThread([executor = ui_executor_, node_id,
+                 callback = std::move(callback)]() mutable {
+    executor->Focus(node_id, std::move(callback));
+  });
 }
 
 void LynxDevToolMediator::PageReload(bool ignore_cache) {

--- a/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
+++ b/devtool/lynx_devtool/agent/lynx_devtool_mediator.h
@@ -250,7 +250,7 @@ class LynxDevToolMediator
 
   // implemented by ui executor
   void ScrollIntoView(int node_id);
-  void Focus(int node_id);
+  void Focus(int node_id, DevToolPlatformFocusCallback callback);
   void PageReload(bool ignore_cache);
 
   void InitWhiteBoardInspector(

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
@@ -344,13 +344,15 @@ public class DevToolPlatformAndroidDelegate {
   }
 
   @CalledByNative
-  public void focus(final int nodeId) {
+  public void focus(final int nodeId, final long callbackPtr) {
     LynxView lynxView = mLynxView.get();
     if (lynxView == null || lynxView.getLynxContext() == null) {
+      reportFocusResult(callbackPtr, true, "");
       return;
     }
     LynxUIOwner uiOwner = lynxView.getLynxContext().getLynxUIOwner();
     if (uiOwner == null) {
+      reportFocusResult(callbackPtr, true, "");
       return;
     }
     uiOwner.invokeUIMethodForSelectorQuery(nodeId, "focus", new JavaOnlyMap(), new Callback() {
@@ -358,13 +360,22 @@ public class DevToolPlatformAndroidDelegate {
       public void invoke(Object... args) {
         if (args == null || args.length == 0 || !(args[0] instanceof Integer)
             || ((Integer) args[0]) == LynxUIMethodConstants.SUCCESS) {
+          reportFocusResult(callbackPtr, true, "");
           return;
         }
-        Object detail = args.length > 1 ? args[1] : "";
-        LLog.w(TAG,
-            "DOM.focus failed for nodeId " + nodeId + ", code: " + args[0] + ", data: " + detail);
+        Object detail = args.length > 1 && args[1] != null ? args[1] : "";
+        String errorMessage = "code: " + args[0] + ", data: " + detail;
+        LLog.w(TAG, "DOM.focus failed for nodeId " + nodeId + ", " + errorMessage);
+        reportFocusResult(callbackPtr, false, errorMessage);
       }
     });
+  }
+
+  private static void reportFocusResult(long callbackPtr, boolean success, String errorMessage) {
+    if (callbackPtr == 0) {
+      return;
+    }
+    nativeReportFocusResult(callbackPtr, success, errorMessage == null ? "" : errorMessage);
   }
 
   @CalledByNative
@@ -433,4 +444,6 @@ public class DevToolPlatformAndroidDelegate {
   private native void nativeSendLayerTreeDidChangeEvent(long facadePtr);
   private native String nativeGetLepusDebugInfoUrl(long facadePtr, String fileName);
   private native void nativeSendCDPEvent(long facadePtr, String message);
+  private static native void nativeReportFocusResult(
+      long callbackPtr, boolean success, String errorMessage);
 }

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (std::shared_ptr<lynx::devtool::DevToolPlatformFacade>)getNativePtr;
 
 - (void)scrollIntoView:(int)node_index;
-- (void)focus:(int)node_index;
+- (void)focus:(int)node_index
+    completion:(void (^)(BOOL success, NSString *_Nullable errorMessage))completion;
 
 - (int)findNodeIdForLocationWithX:(float)x withY:(float)y mode:(NSString *)mode;
 

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 #import <LynxDevtool/DevToolPlatformDarwinDelegate.h>
+#include <memory>
+#include <utility>
 #include <vector>
 
 #import <BaseDevTool/DevToolToast.h>
@@ -64,10 +66,21 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
     }
   }
 
-  void Focus(int node_index) override {
+  void Focus(int node_index, DevToolPlatformFocusCallback callback) override {
     __strong typeof(_darwin) darwin = _darwin;
     if (darwin) {
-      [darwin focus:node_index];
+      auto callback_ptr = std::make_shared<DevToolPlatformFocusCallback>(std::move(callback));
+      [darwin focus:node_index
+          completion:^(BOOL success, NSString* _Nullable errorMessage) {
+            if (*callback_ptr) {
+              const char* message = errorMessage != nil ? [errorMessage UTF8String] : "";
+              (*callback_ptr)(success, message != nullptr ? message : "");
+            }
+          }];
+      return;
+    }
+    if (callback) {
+      callback(true, "");
     }
   }
 
@@ -372,10 +385,13 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
   }
 }
 
-- (void)focus:(int)node_index {
+- (void)focus:(int)node_index
+    completion:(void (^)(BOOL success, NSString* _Nullable errorMessage))completion {
   if (_uiTreeHelper) {
-    [_uiTreeHelper focus:node_index];
+    [_uiTreeHelper focus:node_index completion:completion];
+    return;
   }
+  completion(YES, nil);
 }
 
 - (int)findNodeIdForLocationWithX:(float)x withY:(float)y mode:(NSString*)mode {

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.h
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.h
@@ -13,7 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)attachLynxUIOwner:(nullable LynxUIOwner *)uiOwner;
 
 - (void)scrollIntoView:(int)node_id;
-- (void)focus:(int)node_id;
+- (void)focus:(int)node_id
+    completion:(void (^)(BOOL success, NSString *_Nullable errorMessage))completion;
 
 - (CGRect)getRectToWindow;
 

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.mm
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxUITreeHelper.mm
@@ -56,17 +56,24 @@
   [ui scrollIntoViewWithSmooth:false blockType:@"center" inlineType:@"center" callback:nil];
 }
 
-- (void)focus:(int)node_id {
+- (void)focus:(int)node_id
+    completion:(void (^)(BOOL success, NSString* _Nullable errorMessage))completion {
   __strong typeof(_uiOwner) uiOwner = _uiOwner;
   if (uiOwner == nil) {
+    completion(YES, nil);
     return;
   }
   [uiOwner invokeUIMethodForSelectorQuery:@"focus"
                                    params:@{}
                                  callback:^(int code, id _Nullable data) {
-                                   if (code != kUIMethodSuccess) {
-                                     LLogWarn(@"DOM.focus failed for nodeId:%d code:%d data:%@",
-                                              node_id, code, data);
+                                   if (code == kUIMethodSuccess) {
+                                     completion(YES, nil);
+                                   } else {
+                                     NSString* errorMessage = [NSString
+                                         stringWithFormat:@"code: %d, data: %@", code, data ?: @""];
+                                     LLogWarn(@"DOM.focus failed for nodeId:%d %@", node_id,
+                                              errorMessage);
+                                     completion(NO, errorMessage);
                                    }
                                  }
                                    toNode:node_id];


### PR DESCRIPTION
## Summary
- Rebased this PR onto the latest `develop` now that #6538 and #6539 have landed.
- Keeps the Android and iOS DOM.focus platform bridge behavior from `develop`.
- Adds follow-up error handling so DOM.focus waits for the platform UI method callback and returns a CDP error when focus fails.

## Notes
#6538 and #6539 are merged, so this PR now contains only the follow-up error handling commit on top of `develop`.

## Verification
- `git diff --check origin/develop..HEAD`
- `tools/rtf/rtf native-ut run --names devtool` (blocked locally: `gn` is not installed in this environment, so `gn gen out/Default` failed before tests ran)
