### PR TITLE
[BugFix][iOS] Constrain autolink manifest paths

### DIFF
--- a/tools/ios_tools/cocoapods-lynx-extension/lib/lynx/extension/autolink.rb
+++ b/tools/ios_tools/cocoapods-lynx-extension/lib/lynx/extension/autolink.rb
@@ -4,7 +4,6 @@
 
 require 'fileutils'
 require 'json'
-require 'pathname'
 
 module Lynx
   module Extension
@@ -92,15 +91,17 @@ module Lynx
           raise "Invalid ios platform entry in #{manifest_file}" unless ios.is_a?(Hash)
 
           package_dir = File.dirname(manifest_file)
+          package_realpath = File.realpath(package_dir)
           source_dir_name = ios['sourceDir'] || 'ios'
-          source_dir = File.expand_path(source_dir_name, package_dir)
+          source_dir = resolve_package_path(package_realpath, source_dir_name, manifest_file, 'sourceDir')
           raise "iOS sourceDir '#{source_dir_name}' does not exist for #{manifest_file}" unless
             File.directory?(source_dir)
 
           podspec_path = if ios['podspecPath']
-                           File.expand_path(ios['podspecPath'], package_dir)
+                           resolve_package_path(package_realpath, ios['podspecPath'], manifest_file, 'podspecPath')
                          else
-                           Dir[File.join(source_dir, '**/*.podspec')].sort.first
+                           path = podspec_files(source_dir, package_realpath).first
+                           validate_package_path(package_realpath, path, manifest_file, 'podspecPath') if path
                          end
           raise "No iOS podspec found for #{manifest_file}" unless
             podspec_path && File.file?(podspec_path)
@@ -118,6 +119,41 @@ module Lynx
           match = content.match(/\.name\s*=\s*['"]([^'"]+)['"]/)
           raise "Unable to read pod name from #{podspec_path}" unless match
           match[1]
+        end
+
+        def resolve_package_path(package_realpath, configured_path, manifest_file, field_name)
+          path = File.expand_path(configured_path, package_realpath)
+          validate_package_path(package_realpath, path, manifest_file, field_name, configured_path)
+        end
+
+        def validate_package_path(package_realpath, path, manifest_file, field_name, configured_path = path)
+          path = File.realpath(path) if File.exist?(path)
+          return path if package_path?(package_realpath, path)
+
+          raise "iOS #{field_name} '#{configured_path}' must stay within package directory for #{manifest_file}"
+        end
+
+        def package_path?(package_realpath, path)
+          path == package_realpath || path.start_with?("#{package_realpath}#{File::SEPARATOR}")
+        end
+
+        def podspec_files(source_dir, package_realpath)
+          files = []
+          dirs = [source_dir]
+          until dirs.empty?
+            dir = dirs.pop
+            Dir.children(dir).each do |name|
+              path = File.join(dir, name)
+              if File.symlink?(path)
+                files << path if name.end_with?('.podspec')
+              elsif File.directory?(path)
+                dirs << path if package_path?(package_realpath, File.realpath(path))
+              elsif File.file?(path) && name.end_with?('.podspec')
+                files << path
+              end
+            end
+          end
+          files.sort
         end
 
         def source_files(source_dir)

--- a/tools/ios_tools/cocoapods-lynx-extension/test/autolink_test.rb
+++ b/tools/ios_tools/cocoapods-lynx-extension/test/autolink_test.rb
@@ -15,7 +15,7 @@ class LynxExtensionAutolinkTest < Minitest::Test
 
       assert_equal 1, extensions.size
       assert_equal 'demo-ext', extensions.first.npm_name
-      assert_equal File.join(dir, 'node_modules/demo-ext/ios/DemoExt.podspec'),
+      assert_equal File.realpath(File.join(dir, 'node_modules/demo-ext/ios/DemoExt.podspec')),
                    extensions.first.podspec_path
     end
   end
@@ -115,6 +115,122 @@ class LynxExtensionAutolinkTest < Minitest::Test
 
       error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
       assert_includes error.message, 'No iOS podspec found'
+    end
+  end
+
+  def test_manifest_rejects_source_dir_outside_package
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/bad-ext')
+      FileUtils.mkdir_p(package_dir)
+      File.write(File.join(package_dir, 'lynx.ext.json'),
+                 '{"platforms":{"ios":{"sourceDir":"../shared-ios"}}}')
+      FileUtils.mkdir_p(File.join(dir, 'node_modules/shared-ios'))
+
+      error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
+      assert_includes error.message, "iOS sourceDir '../shared-ios' must stay within package directory"
+    end
+  end
+
+  def test_manifest_rejects_podspec_path_outside_package
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/bad-ext')
+      FileUtils.mkdir_p(File.join(package_dir, 'ios'))
+      File.write(File.join(package_dir, 'lynx.ext.json'),
+                 '{"platforms":{"ios":{"podspecPath":"../shared/Shared.podspec"}}}')
+      shared_dir = File.join(dir, 'node_modules/shared')
+      FileUtils.mkdir_p(shared_dir)
+      File.write(File.join(shared_dir, 'Shared.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'Shared'
+        end
+      PODSPEC
+
+      error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
+      assert_includes error.message,
+                      "iOS podspecPath '../shared/Shared.podspec' must stay within package directory"
+    end
+  end
+
+  def test_manifest_rejects_source_dir_symlink_outside_package
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/bad-ext')
+      outside_dir = File.join(dir, 'outside-ios')
+      FileUtils.mkdir_p(package_dir)
+      FileUtils.mkdir_p(outside_dir)
+      File.symlink(outside_dir, File.join(package_dir, 'ios-link'))
+      File.write(File.join(package_dir, 'lynx.ext.json'),
+                 '{"platforms":{"ios":{"sourceDir":"ios-link"}}}')
+
+      error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
+      assert_includes error.message, "iOS sourceDir 'ios-link' must stay within package directory"
+    end
+  end
+
+  def test_manifest_rejects_podspec_path_symlink_outside_package
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/bad-ext')
+      outside_dir = File.join(dir, 'outside-ios')
+      FileUtils.mkdir_p(File.join(package_dir, 'ios'))
+      FileUtils.mkdir_p(outside_dir)
+      File.write(File.join(outside_dir, 'Outside.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'Outside'
+        end
+      PODSPEC
+      File.symlink(File.join(outside_dir, 'Outside.podspec'),
+                   File.join(package_dir, 'ios/Outside.podspec'))
+      File.write(File.join(package_dir, 'lynx.ext.json'),
+                 '{"platforms":{"ios":{"podspecPath":"ios/Outside.podspec"}}}')
+
+      error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
+      assert_includes error.message,
+                      "iOS podspecPath 'ios/Outside.podspec' must stay within package directory"
+    end
+  end
+
+  def test_manifest_rejects_default_podspec_symlink_outside_package
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/bad-ext')
+      outside_dir = File.join(dir, 'outside-ios')
+      FileUtils.mkdir_p(File.join(package_dir, 'ios'))
+      FileUtils.mkdir_p(outside_dir)
+      File.write(File.join(outside_dir, 'Outside.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'Outside'
+        end
+      PODSPEC
+      File.symlink(File.join(outside_dir, 'Outside.podspec'),
+                   File.join(package_dir, 'ios/Outside.podspec'))
+      File.write(File.join(package_dir, 'lynx.ext.json'), '{"platforms":{"ios":{}}}')
+
+      error = assert_raises(RuntimeError) { Lynx::Extension::Autolink.scan(dir) }
+      assert_includes error.message, 'must stay within package directory'
+    end
+  end
+
+  def test_manifest_ignores_symlinked_directories_during_default_podspec_discovery
+    Dir.mktmpdir do |dir|
+      package_dir = File.join(dir, 'node_modules/demo-ext')
+      outside_dir = File.join(dir, 'outside-ios')
+      FileUtils.mkdir_p(File.join(package_dir, 'ios'))
+      FileUtils.mkdir_p(outside_dir)
+      File.write(File.join(outside_dir, 'AOutside.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'Outside'
+        end
+      PODSPEC
+      File.write(File.join(package_dir, 'ios/DemoExt.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'DemoExt'
+        end
+      PODSPEC
+      File.symlink(outside_dir, File.join(package_dir, 'ios/linked'))
+      File.write(File.join(package_dir, 'lynx.ext.json'), '{"platforms":{"ios":{}}}')
+
+      extensions = Lynx::Extension::Autolink.scan(dir)
+
+      assert_equal File.realpath(File.join(package_dir, 'ios/DemoExt.podspec')),
+                   extensions.first.podspec_path
     end
   end
 


### PR DESCRIPTION
## Summary
- Validate iOS autolink manifest `sourceDir` and `podspecPath` against the package realpath before use.
- Validate default podspec discovery results and avoid descending into symlinked directories during discovery.
- Add regression coverage for traversal and symlink escape cases.

## Test Plan
- `ruby -Ilib test/autolink_test.rb`
- `ruby -c lib/lynx/extension/autolink.rb`
- `ruby -c test/autolink_test.rb`

## Related Issue
- #3588