### PR TITLE
[Explorer] Integrate Autolink extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ core/runtime/jsi/v8/CMakeLists_impl/
 
 explorer/darwin/ios/lynx_explorer/Podfile.lock
 explorer/darwin/ios/lynx_explorer/Pods
+explorer/darwin/ios/lynx_explorer/generated/lynx-extension/
 explorer/darwin/ios/lynx_explorer/LynxExplorer.xcworkspace/*
 explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/**
 !explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/

--- a/explorer/android/lynx_extension_plugin_loader.gradle
+++ b/explorer/android/lynx_extension_plugin_loader.gradle
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+// Explorer still runs on Gradle 6.7.1/AGP 4.1.0. Gradle 6.x cannot resolve a
+// settings plugin from pluginManagement { includeBuild(...) }, and a clean
+// checkout does not contain a prebuilt lynx_extension_plugin jar. Load the local
+// plugin sources directly so extension builds can be included before project
+// evaluation.
+ClassLoader lynxExtensionPluginLoaderParent = this.class.classLoader
+
+ext.loadLynxExtensionPluginClass = { File explorerAndroidDir, String pluginClassName,
+        List<String> pluginSourceFiles ->
+    File sourceDir = new File(explorerAndroidDir,
+            "../../platform/android/lynx_extension_plugin/src/main/groovy/org/lynxsdk/extension")
+    GroovyClassLoader loader = new GroovyClassLoader(lynxExtensionPluginLoaderParent)
+    ([
+            "LynxExtensionInfo.groovy",
+            "LynxExtensionScanner.groovy",
+    ] + pluginSourceFiles).each { String sourceName ->
+        loader.parseClass(new File(sourceDir, sourceName))
+    }
+    loader.loadClass(pluginClassName)
+}

--- a/explorer/android/settings.gradle
+++ b/explorer/android/settings.gradle
@@ -1,6 +1,22 @@
 // Copyright 2024 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
+apply from: new File(settingsDir, "lynx_extension_plugin_loader.gradle")
+apply plugin: loadLynxExtensionPluginClass(settingsDir,
+        "org.lynxsdk.extension.LynxExtensionSettingsPlugin",
+        ["LynxExtensionSettingsPlugin.groovy"])
+Class lynxExtensionBuildPluginClass = loadLynxExtensionPluginClass(settingsDir,
+        "org.lynxsdk.extension.LynxExtensionBuildPlugin",
+        [
+                "LynxExtensionRegistryGenerator.groovy",
+                "LynxExtensionBuildPlugin.groovy",
+        ])
+gradle.beforeProject { project ->
+    if (project == gradle.rootProject) {
+        project.apply plugin: lynxExtensionBuildPluginClass
+    }
+}
+
 rootProject.name = "Explorer"
 include ':LynxExplorer'
 project(":LynxExplorer").projectDir = new File(rootProject.projectDir, './lynx_explorer')

--- a/explorer/darwin/ios/lynx_explorer/Podfile
+++ b/explorer/darwin/ios/lynx_explorer/Podfile
@@ -1,6 +1,11 @@
 source 'https://cdn.cocoapods.org/'
 project './LynxExplorer.xcodeproj'
 
+lynx_root = File.expand_path('../../../..', __dir__)
+lynx_extension_plugin_dir = File.join(lynx_root, 'tools/ios_tools/cocoapods-lynx-extension/lib')
+$LOAD_PATH.unshift lynx_extension_plugin_dir
+load File.join(lynx_extension_plugin_dir, 'cocoapods_plugin.rb')
+
 platform :ios, '12.0'
 
 install!'cocoapods',:deterministic_uuids=>false,
@@ -44,6 +49,11 @@ target 'LynxExplorer' do
     'Core'
   ]
 
+  use_lynx_extension!(
+    :root => __dir__,
+    :output_dir => File.join(__dir__, 'generated/lynx-extension')
+  )
+
   pod 'XElement', :path => '../../../..', :subspecs => [
     'Behavior',
   ]
@@ -61,7 +71,6 @@ target 'LynxExplorer' do
   # Requires Swift 5.10+ (Xcode 15.3+). Skipped on GitHub Actions OSS CI which
   # uses Xcode 15.1. All Sparkling ObjC/Swift code is guarded by
   # #if HAS_SPARKLING / #if canImport(SparklingMethod).
-  lynx_root = File.expand_path('../../../..', __dir__)
   node_modules = File.join(lynx_root, 'node_modules')
 
   sparkling_pods = {


### PR DESCRIPTION
## Summary

- Integrate Android Explorer with the existing Lynx extension Gradle plugin.
- Integrate iOS Explorer with the existing `cocoapods-lynx-extension` plugin.
- Rely on the latest Autolink auto-initialization path: Android generates `com.lynx.tasm.extension.LynxAutolinkGenerated` and `LynxEnv` calls `setupGlobal`; iOS uses `LynxAutolinkGeneratedLoader` to setup generated registry entries for `LynxConfig`.
- Ignore generated iOS extension registry output from `pod install`.

## Verification

- Created a temporary Autolink extension package and verified `@lynx-js/autolink-codegen-canary@0.1.0-canary-20260512-482d8422` generates Android and iOS specs.
- Android: `./gradlew :LynxExplorer:generateNoasanDebugLynxExtensionRegistry :lynx_extension__tmp_lynx_autolink_storage_extension:assembleNoasanDebug :LynxExplorer:compileNoasanDebugJavaWithJavac` passed.
- Android: after cleaning `lynx_explorer/build/generated/source/lynxExtensionRegistry`, `:LynxExplorer:generateNoasanDebugLynxExtensionRegistry` generated only `com/lynx/tasm/extension/LynxAutolinkGenerated.java`, including the temporary extension provider.
- iOS: `LANG=en_US.UTF-8 RBENV_VERSION=3.2.8 pod install --no-repo-update --verbose` passed and installed `TmpAutolinkStorageExtension` plus `LynxExtensionRegistry`.
- iOS Autolink targets: `TmpAutolinkStorageExtension` and `LynxExtensionRegistry` both built successfully with xcodebuild for iphonesimulator.
- iOS full `LynxExplorer` scheme was previously attempted and is blocked by an unrelated `sparkling-method@2.1.0-rc.12` protocol mismatch: `SPKLynxModuleService` does not implement `initLynxViewGroup(_:)` required by `LynxServiceModuleProtocol`.

## Related Issue
- #3588