### PR TITLE
[Testing][DevTool] Add DOM focus E2E coverage

### DIFF
--- a/testing/integration_test/demo_pages/dom-focus/index.css
+++ b/testing/integration_test/demo_pages/dom-focus/index.css
@@ -1,0 +1,39 @@
+.root {
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  background-color: #f7f8fa;
+}
+
+.section {
+  margin-bottom: 16px;
+}
+
+.field {
+  margin-top: 18px;
+}
+
+.label {
+  color: #4f5b66;
+  font-size: 16px;
+  margin-bottom: 6px;
+}
+
+.value {
+  color: #111827;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  height: 52px;
+  padding-left: 16px;
+  padding-right: 16px;
+  border-radius: 4px;
+  border-width: 1px;
+  border-color: #9aa4b2;
+  background-color: #ffffff;
+  color: #111827;
+  font-size: 18px;
+}

--- a/testing/integration_test/demo_pages/dom-focus/index.tsx
+++ b/testing/integration_test/demo_pages/dom-focus/index.tsx
@@ -1,0 +1,61 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react';
+
+import './index.css';
+
+export function DomFocus() {
+  const [focusedInput, setFocusedInput] = useState('none');
+  const [blurredInput, setBlurredInput] = useState('none');
+
+  return (
+    <scroll-view className="root" lynx-test-tag="root" scroll-y>
+      <view className="section">
+        <text className="label">Focused input</text>
+        <text className="value" lynx-test-tag="focus-state">
+          {focusedInput}
+        </text>
+      </view>
+      <view className="section">
+        <text className="label">Blurred input</text>
+        <text className="value" lynx-test-tag="blur-state">
+          {blurredInput}
+        </text>
+      </view>
+      <view className="field">
+        <text className="label">Input A</text>
+        <input
+          className="input"
+          lynx-test-tag="focus-input-a"
+          placeholder="input-a"
+          show-soft-input-on-focus={false}
+          bindfocus={() => {
+            setFocusedInput('input-a');
+          }}
+          bindblur={() => {
+            setBlurredInput('input-a');
+          }}
+        />
+      </view>
+      <view className="field">
+        <text className="label">Input B</text>
+        <input
+          className="input"
+          lynx-test-tag="focus-input-b"
+          placeholder="input-b"
+          show-soft-input-on-focus={false}
+          bindfocus={() => {
+            setFocusedInput('input-b');
+          }}
+          bindblur={() => {
+            setBlurredInput('input-b');
+          }}
+        />
+      </view>
+    </scroll-view>
+  );
+}
+
+root.render(<DomFocus />);

--- a/testing/integration_test/demo_pages/dom-focus/lynx.config.mjs
+++ b/testing/integration_test/demo_pages/dom-focus/lynx.config.mjs
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from "@lynx-js/rspeedy";
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+
+export default defineConfig({
+  source: {
+    entry: "./index.tsx",
+  },
+  plugins: [pluginReactLynx(), pluginQRCode()],
+});

--- a/testing/integration_test/demo_pages/dom-focus/package.json
+++ b/testing/integration_test/demo_pages/dom-focus/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo_pages/dom-focus",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/react": "0.105.0"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "^0.3.3",
+    "@lynx-js/react-rsbuild-plugin": "0.9.8",
+    "@lynx-js/rspeedy": "0.9.3",
+    "@types/react": "^18.3.2",
+    "prettier": "3.4.2"
+  }
+}

--- a/testing/integration_test/demo_pages/pnpm-lock.yaml
+++ b/testing/integration_test/demo_pages/pnpm-lock.yaml
@@ -5,6 +5,23 @@ importers:
   .:
     specifiers: {}
 
+  dom-focus:
+    specifiers:
+      '@lynx-js/qrcode-rsbuild-plugin': ^0.3.3
+      '@lynx-js/react': 0.105.0
+      '@lynx-js/react-rsbuild-plugin': 0.9.8
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': ^18.3.2
+      prettier: 3.4.2
+    dependencies:
+      '@lynx-js/react': 0.105.0_@types+react@18.3.18
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin': 0.3.3
+      '@lynx-js/react-rsbuild-plugin': 0.9.8_@lynx-js+react@0.105.0
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': 18.3.18
+      prettier: 3.4.2
+
   event:
     specifiers:
       '@lynx-js/qrcode-rsbuild-plugin': ^0.3.3

--- a/testing/integration_test/demo_pages/pnpm-workspace.yaml
+++ b/testing/integration_test/demo_pages/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - 'dom-focus'
   - 'event'

--- a/testing/integration_test/test_script/case_sets/core/DomFocus.py
+++ b/testing/integration_test/test_script/case_sets/core/DomFocus.py
@@ -1,0 +1,60 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+from lynx_e2e.api.lynx_view import LynxView
+
+config = {
+    "type": "custom",
+    "path": "automation/dom-focus/main",
+}
+
+
+def send_cdp(test, session_id, method, params=None):
+    req_id = test.app.send_cdp_data(
+        session_id=session_id,
+        method=method,
+        params=params or {},
+    )
+    raw_response = test.app.wait_for_cdp_id(req_id, raw=True)
+    response = json.loads(raw_response["message"])
+    if "error" in response:
+        raise RuntimeError("%s failed: %s" % (method, response["error"]))
+    return response.get("result", {})
+
+
+def run(test):
+    lynxview = test.app.get_lynxview("lynxview", LynxView)
+    session_id = lynxview.get_session_id()
+
+    focus_state = lynxview.get_by_test_tag("focus-state")
+    blur_state = lynxview.get_by_test_tag("blur-state")
+    input_a = lynxview.get_by_test_tag("focus-input-a")
+    input_b = lynxview.get_by_test_tag("focus-input-b")
+
+    test.start_step("--------Test1: Focus input A with DOM.focus;-------")
+    send_cdp(test, session_id, "DOM.focus", {"nodeId": input_a.id})
+    test.wait_for_equal(
+        "DOM.focus did not focus input A!",
+        focus_state,
+        "text",
+        "input-a",
+    )
+
+    test.start_step("--------Test2: Focus input B with DOM.focus;-------")
+    send_cdp(test, session_id, "DOM.focus", {"nodeId": input_b.id})
+    test.wait_for_equal(
+        "DOM.focus did not focus input B!",
+        focus_state,
+        "text",
+        "input-b",
+    )
+    test.wait_for_equal(
+        "DOM.focus did not blur input A!",
+        blur_state,
+        "text",
+        "input-a",
+    )


### PR DESCRIPTION
## Summary

- add an automation/dom-focus demo page with two inputs and visible focus/blur state
- add a core DomFocus E2E case that sends DOM.focus over CDP and verifies focus transitions
- rebase onto latest develop now that lynx-family/lynx#6538 has landed, so this PR only carries the E2E coverage

## Validation

- python3 -m py_compile testing/integration_test/test_script/case_sets/core/DomFocus.py
- git diff --check origin/develop...HEAD
- pnpm run build in testing/integration_test/demo_pages

Note: device/Appium E2E was not run locally after the rebase; CI has been triggered again for the updated PR.