### PR TITLE
[Testing][DevTool] Add Input.insertText E2E coverage

### DIFF
--- a/testing/integration_test/demo_pages/input_insert_text/index.css
+++ b/testing/integration_test/demo_pages/input_insert_text/index.css
@@ -1,0 +1,42 @@
+.root {
+  width: 100%;
+  height: 100%;
+  padding-top: 36px;
+  padding-left: 24px;
+  padding-right: 24px;
+  background-color: #ffffff;
+}
+
+.field {
+  margin-bottom: 24px;
+}
+
+.label {
+  color: #2b2f36;
+  font-size: 16px;
+  margin-bottom: 12px;
+}
+
+.input-box {
+  width: 100%;
+  height: 48px;
+  padding-left: 12px;
+  padding-right: 12px;
+  border-width: 1px;
+  border-color: #4b7bec;
+  border-radius: 4px;
+  font-size: 16px;
+  color: #1f2933;
+}
+
+.value-label {
+  color: #657080;
+  font-size: 14px;
+  margin-top: 24px;
+  margin-bottom: 8px;
+}
+
+.value {
+  color: #111827;
+  font-size: 18px;
+}

--- a/testing/integration_test/demo_pages/input_insert_text/index.tsx
+++ b/testing/integration_test/demo_pages/input_insert_text/index.tsx
@@ -1,0 +1,95 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { root, useState } from '@lynx-js/react';
+
+import './index.css';
+
+export function InputInsertText() {
+  const [inputAValue, setInputAValue] = useState('');
+  const [inputBValue, setInputBValue] = useState('');
+  const [inputCValue, setInputCValue] = useState('');
+  const [inputCount, setInputCount] = useState(0);
+  const [lastInput, setLastInput] = useState('none');
+
+  const handleInputA = (event: { detail: { value: string } }) => {
+    setInputAValue(event.detail.value);
+    setInputCount((count) => count + 1);
+    setLastInput('input-a');
+  };
+
+  const handleInputB = (event: { detail: { value: string } }) => {
+    setInputBValue(event.detail.value);
+    setInputCount((count) => count + 1);
+    setLastInput('input-b');
+  };
+
+  const handleInputC = (event: { detail: { value: string } }) => {
+    setInputCValue(event.detail.value);
+    setInputCount((count) => count + 1);
+    setLastInput('input-c');
+  };
+
+  return (
+    <view className="root">
+      <view className="field">
+        <text className="label">Input A</text>
+        <input
+          className="input-box"
+          lynx-test-tag="insert-text-input-a"
+          bindinput={handleInputA}
+          placeholder="Waiting for DevTool text"
+          show-soft-input-on-focus={false}
+          text-color="#1f2933"
+        />
+        <text className="value-label">Input A value</text>
+        <text className="value" lynx-test-tag="insert-text-value-a">
+          {inputAValue}
+        </text>
+      </view>
+      <view className="field">
+        <text className="label">Input B</text>
+        <input
+          className="input-box"
+          lynx-test-tag="insert-text-input-b"
+          bindinput={handleInputB}
+          placeholder="Waiting for DevTool text"
+          show-soft-input-on-focus={false}
+          text-color="#1f2933"
+        />
+        <text className="value-label">Input B value</text>
+        <text className="value" lynx-test-tag="insert-text-value-b">
+          {inputBValue}
+        </text>
+      </view>
+      <view className="field">
+        <text className="label">Input C</text>
+        <input
+          className="input-box"
+          lynx-test-tag="insert-text-input-c"
+          bindinput={handleInputC}
+          placeholder="Waiting for DevTool text"
+          show-soft-input-on-focus={false}
+          text-color="#1f2933"
+        />
+        <text className="value-label">Input C value</text>
+        <text className="value" lynx-test-tag="insert-text-value-c">
+          {inputCValue}
+        </text>
+      </view>
+      <view className="field">
+        <text className="value-label">Input event count</text>
+        <text className="value" lynx-test-tag="insert-text-input-count">
+          {inputCount}
+        </text>
+        <text className="value-label">Last input target</text>
+        <text className="value" lynx-test-tag="insert-text-last-input">
+          {lastInput}
+        </text>
+      </view>
+    </view>
+  );
+}
+
+root.render(<InputInsertText />);

--- a/testing/integration_test/demo_pages/input_insert_text/lynx.config.mjs
+++ b/testing/integration_test/demo_pages/input_insert_text/lynx.config.mjs
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
+
+export default defineConfig({
+  source: {
+    entry: './index.tsx',
+  },
+  plugins: [pluginReactLynx(), pluginQRCode()],
+});

--- a/testing/integration_test/demo_pages/input_insert_text/package.json
+++ b/testing/integration_test/demo_pages/input_insert_text/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo_pages/input_insert_text",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/react": "0.105.0"
+  },
+  "devDependencies": {
+    "@lynx-js/react-rsbuild-plugin": "0.9.8",
+    "@lynx-js/rspeedy": "0.9.3",
+    "@types/react": "^18.3.2",
+    "prettier": "3.4.2",
+    "@lynx-js/qrcode-rsbuild-plugin": "^0.3.3"
+  }
+}

--- a/testing/integration_test/demo_pages/pnpm-lock.yaml
+++ b/testing/integration_test/demo_pages/pnpm-lock.yaml
@@ -39,6 +39,23 @@ importers:
       '@types/react': 18.3.18
       prettier: 3.4.2
 
+  input_insert_text:
+    specifiers:
+      '@lynx-js/qrcode-rsbuild-plugin': ^0.3.3
+      '@lynx-js/react': 0.105.0
+      '@lynx-js/react-rsbuild-plugin': 0.9.8
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': ^18.3.2
+      prettier: 3.4.2
+    dependencies:
+      '@lynx-js/react': 0.105.0_@types+react@18.3.18
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin': 0.3.3
+      '@lynx-js/react-rsbuild-plugin': 0.9.8_@lynx-js+react@0.105.0
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': 18.3.18
+      prettier: 3.4.2
+
 packages:
 
   /@babel/code-frame/7.26.2:

--- a/testing/integration_test/demo_pages/pnpm-workspace.yaml
+++ b/testing/integration_test/demo_pages/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'dom-focus'
   - 'event'
+  - 'input_insert_text'

--- a/testing/integration_test/test_script/case_sets/core/InputInsertText.py
+++ b/testing/integration_test/test_script/case_sets/core/InputInsertText.py
@@ -1,0 +1,184 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+
+from lynx_e2e.api.lynx_view import LynxView
+
+INPUT_A_TEXT = "first"
+INPUT_B_TEXT = "second"
+INPUT_C_TEXT = "value 123!?"
+IGNORED_TEXT = "ignored before focus"
+
+config = {
+    "type": "custom",
+    "path": "automation/input_insert_text/main",
+    "platform": ["android", "ios"],
+}
+
+
+def send_cdp(test, session_id, method, params=None):
+    request_id = test.app.send_cdp_data(
+        session_id=session_id,
+        method=method,
+        params=params or {},
+    )
+    raw_response = test.app.wait_for_cdp_id(request_id, raw=True)
+    response = json.loads(raw_response["message"])
+    if "error" in response:
+        raise RuntimeError("%s failed: %s" % (method, response["error"]))
+    return response.get("result", {})
+
+
+def assert_text(lynxview, tag, expected, message):
+    actual = lynxview.get_by_test_tag(tag).text
+    if actual != expected:
+        raise AssertionError("%s Expected %r, got %r." % (message, expected, actual))
+
+
+def run(test):
+    lynxview = test.app.get_lynxview("lynxview", LynxView)
+    input_a = lynxview.get_by_test_tag("insert-text-input-a")
+    input_b = lynxview.get_by_test_tag("insert-text-input-b")
+    input_c = lynxview.get_by_test_tag("insert-text-input-c")
+    value_a = lynxview.get_by_test_tag("insert-text-value-a")
+    value_b = lynxview.get_by_test_tag("insert-text-value-b")
+    value_c = lynxview.get_by_test_tag("insert-text-value-c")
+    input_count = lynxview.get_by_test_tag("insert-text-input-count")
+    last_input = lynxview.get_by_test_tag("insert-text-last-input")
+
+    test.assert_existing(input_a, "Input A element is not existing!")
+    test.assert_existing(input_b, "Input B element is not existing!")
+    test.assert_existing(input_c, "Input C element is not existing!")
+    test.assert_existing(value_a, "Input A value element is not existing!")
+    test.assert_existing(value_b, "Input B value element is not existing!")
+    test.assert_existing(value_c, "Input C value element is not existing!")
+    test.assert_existing(input_count, "Input count element is not existing!")
+    test.assert_existing(last_input, "Last input element is not existing!")
+
+    session_id = lynxview.get_session_id()
+
+    test.start_step("--------Test1: Input.insertText without focused input is ignored;-------")
+    send_cdp(test, session_id, "Input.insertText", {"text": IGNORED_TEXT})
+    assert_text(
+        lynxview,
+        "insert-text-value-a",
+        "",
+        "Input A should stay empty before focus!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-b",
+        "",
+        "Input B should stay empty before focus!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-c",
+        "",
+        "Input C should stay empty before focus!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-input-count",
+        "0",
+        "Input event count should stay zero before focus!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-last-input",
+        "none",
+        "Last input should stay none before focus!",
+    )
+
+    test.start_step("--------Test2: Insert text into focused input A;-------")
+    send_cdp(test, session_id, "DOM.focus", {"nodeId": input_a.id})
+    send_cdp(test, session_id, "Input.insertText", {"text": INPUT_A_TEXT})
+    test.wait_for_equal(
+        "Input.insertText did not update input A!",
+        value_a,
+        "text",
+        INPUT_A_TEXT,
+    )
+    test.wait_for_equal(
+        "Input A input event was not recorded!",
+        input_count,
+        "text",
+        "1",
+    )
+    test.wait_for_equal(
+        "Input A was not recorded as the last input target!",
+        last_input,
+        "text",
+        "input-a",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-b",
+        "",
+        "Input B should stay empty after inserting into input A!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-c",
+        "",
+        "Input C should stay empty after inserting into input A!",
+    )
+
+    test.start_step("--------Test3: Switch focus and insert text into input B;-------")
+    send_cdp(test, session_id, "DOM.focus", {"nodeId": input_b.id})
+    send_cdp(test, session_id, "Input.insertText", {"text": INPUT_B_TEXT})
+    test.wait_for_equal(
+        "Input.insertText did not update input B!",
+        value_b,
+        "text",
+        INPUT_B_TEXT,
+    )
+    test.wait_for_equal(
+        "Input B input event was not recorded!",
+        input_count,
+        "text",
+        "2",
+    )
+    test.wait_for_equal(
+        "Input B was not recorded as the last input target!",
+        last_input,
+        "text",
+        "input-b",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-a",
+        INPUT_A_TEXT,
+        "Input A should keep its value after inserting into input B!",
+    )
+    assert_text(
+        lynxview,
+        "insert-text-value-c",
+        "",
+        "Input C should stay empty after inserting into input B!",
+    )
+
+    test.start_step("--------Test4: Insert spaces, punctuation, and digits into input C;-------")
+    send_cdp(test, session_id, "DOM.focus", {"nodeId": input_c.id})
+    send_cdp(test, session_id, "Input.insertText", {"text": INPUT_C_TEXT})
+    test.wait_for_equal(
+        "Input.insertText did not preserve spaces, punctuation, and digits!",
+        value_c,
+        "text",
+        INPUT_C_TEXT,
+    )
+    test.wait_for_equal(
+        "Input C input event was not recorded!",
+        input_count,
+        "text",
+        "3",
+    )
+    test.wait_for_equal(
+        "Input C was not recorded as the last input target!",
+        last_input,
+        "text",
+        "input-c",
+    )


### PR DESCRIPTION
## Summary

- Add an `Input.insertText` E2E demo page and case that focuses the target input through `DOM.focus` before sending `Input.insertText`.
- Make the E2E helper surface CDP errors directly so failures fail fast instead of waiting for value assertions to time out.

## Validation

- `git diff --check origin/develop...HEAD`
- `python3 -m py_compile testing/integration_test/test_script/case_sets/core/InputInsertText.py`
- `source tools/envsetup.sh >/tmp/lynx_envsetup_e2e.log 2>&1 && PATH="$PWD/buildtools/llvm/bin:$PATH" python3 tools_shared/git_lynx.py check --checkers coding-style,commit-message`

## Notes

- Android/iOS E2E was not run locally.
