### PR TITLE
[Feature][iOS] Add podspec git source type

### DIFF
--- a/.github/actions/ios-sdk-publish/action.yml
+++ b/.github/actions/ios-sdk-publish/action.yml
@@ -21,6 +21,19 @@ inputs:
   github_token:
     description: The github token
     type: string
+  source_type:
+    required: false
+    description: The podspec source type.
+    type: string
+    default: 'zip'
+  git_source_ref:
+    required: false
+    description: The git ref value used when source_type is git.
+    type: string
+  git_source_ref_type:
+    required: false
+    description: The git ref field used when source_type is git.
+    type: string
 
 runs:
   using: composite
@@ -30,8 +43,17 @@ runs:
       run: |-
         cd $GITHUB_WORKSPACE/lynx
         source tools/envsetup.sh
-        python3 tools/ios_tools/cocoapods_publish_helper.py --prepare-source --tag ${{ inputs.tag }} --version ${{ inputs.version }} --component ${{ inputs.component }}
+        python3 tools/ios_tools/cocoapods_publish_helper.py \
+          --prepare-source \
+          --tag "${{ inputs.tag }}" \
+          --version "${{ inputs.version }}" \
+          --component "${{ inputs.component }}" \
+          --source-type "${{ inputs.source_type }}" \
+          --git-source-url "${{ github.server_url }}/${{ github.repository }}.git" \
+          --git-source-ref-type "${{ inputs.git_source_ref_type }}" \
+          --git-source-ref "${{ inputs.git_source_ref }}"
     - name: Push iOS SDK to release
+      if: ${{ inputs.source_type == 'zip' }}
       uses: ncipollo/release-action@v1
       with:
         tag: ${{ inputs.tag }}

--- a/tools/ios_tools/cocoapods_publish_helper.py
+++ b/tools/ios_tools/cocoapods_publish_helper.py
@@ -8,7 +8,12 @@ import os
 import shutil
 import subprocess
 import json
+import shlex
 from skip_pod_lint import skip_pod_lint
+
+SOURCE_TYPE_ZIP = 'zip'
+SOURCE_TYPE_GIT = 'git'
+GIT_SOURCE_REF_TYPES = ('commit', 'tag', 'branch')
 
 def run_command(command, check=True):
     # When the "command" is a multi-line command, only the status of the last line of the command is checked.
@@ -49,6 +54,47 @@ def generate_zip_file(src_dir, tag, component):
                 print(f'Generating zip file for {podspec_name}')
                 run_command(f'export PACKAGE_ENV=prod && geniospkg --output_type both --repo {podspec_name} --tag {tag} --cache_path .')
 
+def validate_git_source_options(git_source_ref_type, git_source_ref):
+    if not git_source_ref_type:
+        raise ValueError('--git-source-ref-type is required when --source-type=git')
+    if not git_source_ref:
+        raise ValueError('--git-source-ref is required when --source-type=git')
+    if git_source_ref_type not in GIT_SOURCE_REF_TYPES:
+        raise ValueError(f'--git-source-ref-type must be one of: {", ".join(GIT_SOURCE_REF_TYPES)}')
+
+def validate_source_type_options(source_type, git_source_url, git_source_ref_type, git_source_ref):
+    if source_type == SOURCE_TYPE_GIT:
+        if not git_source_url:
+            raise ValueError('--git-source-url is required when --source-type=git')
+        validate_git_source_options(git_source_ref_type, git_source_ref)
+    elif source_type != SOURCE_TYPE_ZIP:
+        raise ValueError(f'Unsupported source type: {source_type}')
+
+def use_git_pod_source(component, git_source_url, git_source_ref_type, git_source_ref):
+    with open(f"{component}.podspec.json", 'r', encoding='utf8') as f:
+        content = json.load(f)
+
+    content["source"] = {
+        "git": git_source_url,
+        git_source_ref_type: git_source_ref,
+    }
+
+    with open(f"{component}.podspec.json", "w", encoding='utf8') as f:
+        json.dump(content, f, indent=4)
+
+def generate_git_source_podspec_files(src_dir, component, git_source_url, git_source_ref_type, git_source_ref):
+    run_command('SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install --path .')
+
+    for filename in os.listdir(src_dir):
+        if filename.endswith('.podspec'):
+            podspec_name = filename.split('.')[0]
+            if component == podspec_name or component == 'all':
+                print(f'Generating git source podspec for {podspec_name}')
+                podspec_file = shlex.quote(f'{podspec_name}.podspec')
+                podspec_json_file = shlex.quote(f'{podspec_name}.podspec.json')
+                run_command(f'bundle exec pod ipc spec {podspec_file} > {podspec_json_file}')
+                use_git_pod_source(podspec_name, git_source_url, git_source_ref_type, git_source_ref)
+
 def get_enable_trace_param(version: str) -> str:
     """
     Returns '--enable-trace' if the version ends with '-dev', otherwise returns an empty string.
@@ -61,7 +107,16 @@ def get_enable_trace_param(version: str) -> str:
         return '--enable-trace'
     return ''
 
-def prepare_cocoapods_publish_source(version, tag, component):
+def prepare_cocoapods_publish_source(
+        version,
+        tag,
+        component,
+        source_type=SOURCE_TYPE_ZIP,
+        git_source_url=None,
+        git_source_ref_type=None,
+        git_source_ref=None):
+    validate_source_type_options(source_type, git_source_url, git_source_ref_type, git_source_ref)
+
     root_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
     # change to root path
@@ -73,6 +128,11 @@ def prepare_cocoapods_publish_source(version, tag, component):
 
     print('2. Generate podspec files')
     run_command(f'python3 tools/ios_tools/generate_podspec_scripts_by_gn.py --root {root_path} {get_enable_trace_param(version)}')
+
+    if source_type == SOURCE_TYPE_GIT:
+        print('3. Generate git source podspec files')
+        generate_git_source_podspec_files(root_path, component, git_source_url, git_source_ref_type, git_source_ref)
+        return
 
     print('3. Generate lynx_core.js')
     run_command(f'python3 tools/js_tools/build.py --platform ios --release_output platform/darwin/ios/JSAssets/release/lynx_core.js --dev_output platform/darwin/ios/lynx_devtool/assets/lynx_core_dev.js --version {version}')
@@ -184,10 +244,25 @@ def main():
     parser.add_argument('--sources', type=str, help='the cocoapods sources', required=False)
     parser.add_argument('--pod_lint', action="store_true", help='Run pod lint')
     parser.add_argument('--publish_local', type=str, help='Publish pod to local source')
+    parser.add_argument('--source-type', default=SOURCE_TYPE_ZIP, help='The podspec source type used by --prepare-source')
+    parser.add_argument('--git-source-url', type=str, help='The git repository URL used when --source-type=git', required=False)
+    parser.add_argument('--git-source-ref-type', help='The git ref field used when --source-type=git')
+    parser.add_argument('--git-source-ref', type=str, help='The git ref value used when --source-type=git', required=False)
 
     args = parser.parse_args()
     if args.prepare_source:
-        prepare_cocoapods_publish_source(args.version, args.tag, args.component)
+        try:
+            prepare_cocoapods_publish_source(
+                args.version,
+                args.tag,
+                args.component,
+                args.source_type,
+                args.git_source_url,
+                args.git_source_ref_type,
+                args.git_source_ref,
+            )
+        except ValueError as error:
+            parser.error(str(error))
     elif args.publish:
         publish_to_cocoapods(args.component, args.sources)
     elif args.pod_lint:

--- a/tools/ios_tools/cocoapods_publish_helper_test.py
+++ b/tools/ios_tools/cocoapods_publish_helper_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import cocoapods_publish_helper as helper
+
+
+class CocoapodsPublishHelperTest(unittest.TestCase):
+    def setUp(self):
+        self.cwd = os.getcwd()
+        self.temp_dir = tempfile.TemporaryDirectory()
+        os.chdir(self.temp_dir.name)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        self.temp_dir.cleanup()
+
+    def write_podspec_json(self, component, content):
+        with open(f'{component}.podspec.json', 'w', encoding='utf8') as f:
+            json.dump(content, f)
+
+    def read_podspec_json(self, component):
+        with open(f'{component}.podspec.json', 'r', encoding='utf8') as f:
+            return json.load(f)
+
+    def test_use_local_pod_source_keeps_http_source_format(self):
+        self.write_podspec_json('Lynx', {
+            'version': '1.2.3',
+            'source': {'git': 'https://example.com/old.git'},
+        })
+
+        helper.use_local_pod_source('Lynx')
+
+        content = self.read_podspec_json('Lynx')
+        self.assertEqual(
+            content['source'],
+            {'http': f'file:{os.getcwd()}/Lynx-1.2.3.zip'},
+        )
+
+    def test_use_git_pod_source_writes_commit_source_and_preserves_prepare_command(self):
+        self.write_podspec_json('Lynx', {
+            'version': '1.2.3',
+            'source': {'http': 'https://example.com/Lynx.zip'},
+            'prepare_command': 'python3 tools/js_tools/build.py --platform ios',
+        })
+
+        helper.use_git_pod_source(
+            'Lynx',
+            'https://github.com/lynx-family/lynx.git',
+            'commit',
+            'abcdef123456',
+        )
+
+        content = self.read_podspec_json('Lynx')
+        self.assertEqual(content['source'], {
+            'git': 'https://github.com/lynx-family/lynx.git',
+            'commit': 'abcdef123456',
+        })
+        self.assertEqual(
+            content['prepare_command'],
+            'python3 tools/js_tools/build.py --platform ios',
+        )
+
+    def test_missing_git_source_ref_fails_with_clear_error(self):
+        with self.assertRaisesRegex(ValueError, '--git-source-ref is required'):
+            helper.validate_git_source_options('commit', '')
+
+    def test_zip_source_type_accepts_empty_git_options(self):
+        helper.validate_source_type_options('zip', '', '', '')
+
+    def test_missing_git_source_url_fails_with_clear_error(self):
+        with self.assertRaisesRegex(ValueError, '--git-source-url is required'):
+            helper.validate_source_type_options('git', None, 'commit', 'abcdef123456')
+
+    def test_missing_git_source_ref_type_fails_with_clear_error(self):
+        with self.assertRaisesRegex(ValueError, '--git-source-ref-type is required'):
+            helper.validate_source_type_options(
+                'git',
+                'https://github.com/lynx-family/lynx.git',
+                None,
+                'abcdef123456',
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add an explicit git source type for iOS CocoaPods podspec generation.
- Keep the existing zip source path as the default through `source_type: zip` / `--source-type zip`.
- Derive the git source URL in the GitHub action from `${{ github.server_url }}/${{ github.repository }}.git`, so git type callers only pass the ref type and ref value.
- Keep helper-side validation strict: direct helper callers using git source still need `--git-source-url`, `--git-source-ref-type`, and `--git-source-ref`; missing values fail before source preparation mutates generated files.
- Leave existing release and CI workflow call sites on the default zip path to avoid unnecessary mirrored workflow diffs.

## Validation

- `python3 tools/ios_tools/cocoapods_publish_helper_test.py`
- `python3 -m py_compile tools/ios_tools/cocoapods_publish_helper.py tools/ios_tools/cocoapods_publish_helper_test.py`
- `git diff --check`
- Missing `--git-source-url` in git type exits with code `2`.
- Missing `--git-source-ref-type` in git type exits with code `2`.
