### PR TITLE
[BugFix][DevTool] Report Input.insertText failures

### DIFF
--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
@@ -234,6 +234,18 @@ void DevToolPlatformAndroid::Focus(int node_id) {
   Java_DevToolPlatformAndroidDelegate_focus(env, ref.Get(), node_id);
 }
 
+void DevToolPlatformAndroid::InsertText(const std::string& text) {
+  JNIEnv* env = lynx::base::android::AttachCurrentThread();
+  lynx::base::android::ScopedLocalJavaRef<jobject> ref(weak_android_delegate_);
+  if (ref.IsNull()) {
+    return;
+  }
+  lynx::base::android::ScopedLocalJavaRef<jstring> jni_text =
+      lynx::base::android::JNIConvertHelper::ConvertToJNIStringUTF(env, text);
+  Java_DevToolPlatformAndroidDelegate_insertText(env, ref.Get(),
+                                                 jni_text.Get());
+}
+
 void DevToolPlatformAndroid::OnConsoleMessage(const std::string& message) {
   std::lock_guard<std::mutex> lock(mutex_);
   JNIEnv* env = lynx::base::android::AttachCurrentThread();

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.cc
@@ -234,16 +234,18 @@ void DevToolPlatformAndroid::Focus(int node_id) {
   Java_DevToolPlatformAndroidDelegate_focus(env, ref.Get(), node_id);
 }
 
-void DevToolPlatformAndroid::InsertText(const std::string& text) {
+std::string DevToolPlatformAndroid::InsertText(const std::string& text) {
   JNIEnv* env = lynx::base::android::AttachCurrentThread();
   lynx::base::android::ScopedLocalJavaRef<jobject> ref(weak_android_delegate_);
   if (ref.IsNull()) {
-    return;
+    return "DevTool platform delegate is unavailable.";
   }
   lynx::base::android::ScopedLocalJavaRef<jstring> jni_text =
       lynx::base::android::JNIConvertHelper::ConvertToJNIStringUTF(env, text);
-  Java_DevToolPlatformAndroidDelegate_insertText(env, ref.Get(),
-                                                 jni_text.Get());
+  auto error_message = Java_DevToolPlatformAndroidDelegate_insertText(
+      env, ref.Get(), jni_text.Get());
+  return lynx::base::android::JNIConvertHelper::ConvertToString(
+      env, error_message.Get());
 }
 
 void DevToolPlatformAndroid::OnConsoleMessage(const std::string& message) {

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.h
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.h
@@ -40,6 +40,7 @@ class DevToolPlatformAndroid : public DevToolPlatformFacade {
 
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override;
   void Focus(int node_id) override;
+  void InsertText(const std::string& text) override;
 
   std::vector<float> GetRectToWindow() const override;
   std::string GetLynxVersion() const override;

--- a/devtool/lynx_devtool/agent/android/devtool_platform_android.h
+++ b/devtool/lynx_devtool/agent/android/devtool_platform_android.h
@@ -40,7 +40,7 @@ class DevToolPlatformAndroid : public DevToolPlatformFacade {
 
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override;
   void Focus(int node_id) override;
-  void InsertText(const std::string& text) override;
+  std::string InsertText(const std::string& text) override;
 
   std::vector<float> GetRectToWindow() const override;
   std::string GetLynxVersion() const override;

--- a/devtool/lynx_devtool/agent/devtool_platform_facade.h
+++ b/devtool/lynx_devtool/agent/devtool_platform_facade.h
@@ -56,7 +56,9 @@ class DevToolPlatformFacade
   virtual void GetLynxScreenShot() = 0;
 
   virtual void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent>) = 0;
-  virtual void InsertText(const std::string& text) {}
+  virtual std::string InsertText(const std::string& text) {
+    return "Input.insertText is not supported on this platform.";
+  }
 
   virtual std::string GetUINodeInfo(int id) { return ""; }
   virtual std::string GetLynxUITree() { return ""; }

--- a/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent_unittest.cc
+++ b/devtool/lynx_devtool/agent/domain_agent/inspector_input_agent_unittest.cc
@@ -15,6 +15,7 @@
 #include "devtool/base_devtool/native/test/message_sender_mock.h"
 #include "devtool/base_devtool/native/test/mock_receiver.h"
 #include "devtool/lynx_devtool/agent/inspector_ui_executor.h"
+#include "devtool/lynx_devtool/agent/inspector_util.h"
 #include "devtool/testing/mock/devtool_platform_facade_mock.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "third_party/jsoncpp/include/json/value.h"
@@ -65,6 +66,25 @@ TEST_F(InspectorInputAgentTest, InsertTextReturnsSuccess) {
   EXPECT_EQ(MockReceiver::GetInstance().received_message_.first, "CDP");
   EXPECT_EQ(MockReceiver::GetInstance().received_message_.second,
             "{\n   \"id\" : 7,\n   \"result\" : {}\n}\n");
+}
+
+TEST_F(InspectorInputAgentTest, InsertTextReturnsErrorForInvalidParams) {
+  Json::Value message(Json::ValueType::objectValue);
+  message["id"] = 8;
+  message["method"] = "Input.insertText";
+  message["params"] = Json::Value(Json::ValueType::objectValue);
+
+  agent_->CallMethod(message_sender_, message);
+  WaitForUIThread();
+
+  Json::Value response;
+  Json::Reader reader;
+  ASSERT_TRUE(reader.parse(MockReceiver::GetInstance().received_message_.second,
+                           response));
+  EXPECT_EQ(response["id"].asInt(), 8);
+  EXPECT_EQ(response["error"]["code"].asInt(), kInvalidParams);
+  EXPECT_EQ(response["error"]["message"].asString(),
+            "Input.insertText requires a string text parameter.");
 }
 
 }  // namespace testing

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -694,13 +694,39 @@ void InspectorUIExecutor::InsertText(
   Json::Value response(Json::ValueType::objectValue);
   Json::Value content(Json::ValueType::objectValue);
   Json::Value params = message["params"];
+  response["id"] = message["id"].asInt64();
 
-  CHECK_NULL_AND_LOG_RETURN(devtool_platform_facade_,
-                            "devtool_platform_facade_ is null");
-  devtool_platform_facade_->InsertText(params["text"].asString());
+  if (!params.isObject() || !params.isMember("text") ||
+      !params["text"].isString()) {
+    Json::Value error(Json::ValueType::objectValue);
+    error["code"] = kInvalidParams;
+    error["message"] = "Input.insertText requires a string text parameter.";
+    response["error"] = error;
+    sender->SendMessage("CDP", response);
+    return;
+  }
+
+  if (!devtool_platform_facade_) {
+    Json::Value error(Json::ValueType::objectValue);
+    error["code"] = kServerError;
+    error["message"] = "DevTool platform facade is unavailable.";
+    response["error"] = error;
+    sender->SendMessage("CDP", response);
+    return;
+  }
+
+  std::string insertion_error =
+      devtool_platform_facade_->InsertText(params["text"].asString());
+  if (!insertion_error.empty()) {
+    Json::Value error(Json::ValueType::objectValue);
+    error["code"] = kServerError;
+    error["message"] = insertion_error;
+    response["error"] = error;
+    sender->SendMessage("CDP", response);
+    return;
+  }
 
   response["result"] = content;
-  response["id"] = message["id"].asInt64();
   sender->SendMessage("CDP", response);
 }
 

--- a/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
@@ -14,6 +14,7 @@
 
 #include "devtool/base_devtool/native/test/message_sender_mock.h"
 #include "devtool/base_devtool/native/test/mock_receiver.h"
+#include "devtool/lynx_devtool/agent/inspector_util.h"
 #include "devtool/lynx_devtool/agent/lynx_devtool_mediator.h"
 #include "devtool/testing/mock/devtool_platform_facade_mock.h"
 #include "devtool/testing/mock/lynx_devtool_ng_mock.h"
@@ -167,6 +168,30 @@ TEST_F(InspectorUIExecutorTest, InsertTextTest) {
   EXPECT_EQ(facade->inserted_text_, "hello");
   EXPECT_EQ(devtool::MockReceiver::GetInstance().received_message_.second,
             "{\n   \"id\" : 41,\n   \"result\" : {}\n}\n");
+}
+
+TEST_F(InspectorUIExecutorTest, InsertTextReturnsErrorWhenPlatformFails) {
+  std::shared_ptr<testing::DevToolPlatformFacadeMock> facade =
+      std::make_shared<testing::DevToolPlatformFacadeMock>();
+  facade->insert_text_error_ = "No focused editable element found.";
+  ui_executor_->SetDevToolPlatformFacade(facade);
+
+  Json::Value message;
+  message["id"] = 42;
+  Json::Value params;
+  params["text"] = "hello";
+  message["params"] = params;
+
+  ui_executor_->InsertText(message_sender_, message);
+
+  Json::Value response;
+  Json::Reader reader;
+  ASSERT_TRUE(reader.parse(
+      devtool::MockReceiver::GetInstance().received_message_.second, response));
+  EXPECT_EQ(response["id"].asInt(), 42);
+  EXPECT_EQ(response["error"]["code"].asInt(), devtool::kServerError);
+  EXPECT_EQ(response["error"]["message"].asString(),
+            "No focused editable element found.");
 }
 
 }  // namespace testing

--- a/devtool/testing/mock/devtool_platform_facade_mock.h
+++ b/devtool/testing/mock/devtool_platform_facade_mock.h
@@ -44,7 +44,10 @@ class DevToolPlatformFacadeMock : public lynx::devtool::DevToolPlatformFacade {
   void GetLynxScreenShot() override;
   void EmulateTouch(std::shared_ptr<lynx::devtool::MouseEvent> input) override {
   }
-  void InsertText(const std::string& text) override { inserted_text_ = text; }
+  std::string InsertText(const std::string& text) override {
+    inserted_text_ = text;
+    return insert_text_error_;
+  }
 
   std::string GetDebugInfoByUrl(const std::string& url) override {
     return devtool::DevToolStatus::NO_DEBUG_INFO_FOUND_BY_URL;
@@ -66,6 +69,7 @@ class DevToolPlatformFacadeMock : public lynx::devtool::DevToolPlatformFacade {
 
   std::unordered_map<std::string, bool> devtools_switch_;
   std::string inserted_text_;
+  std::string insert_text_error_;
 };
 
 }  // namespace testing

--- a/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
+++ b/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
@@ -1,0 +1,65 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.devtool;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Application;
+import android.content.Context;
+import android.view.View;
+import android.widget.EditText;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.LynxView;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class DevToolPlatformAndroidDelegateTest {
+  private Context mContext;
+  private LynxView mLynxView;
+  private DevToolPlatformAndroidDelegate mPlatformDelegate;
+
+  @Before
+  public void setUp() {
+    mContext =
+        InstrumentationRegistry.getInstrumentation().getTargetContext().getApplicationContext();
+    LynxEnv.inst().init((Application) mContext, null, null, null, null);
+    LynxDevtoolEnv.inst().init(mContext);
+
+    mLynxView = mock(LynxView.class);
+    mPlatformDelegate = new DevToolPlatformAndroidDelegate(mLynxView);
+  }
+
+  @Test
+  public void insertTextCommitsToFocusedEditText() {
+    EditText editText = new EditText(mContext);
+    editText.setText("ac");
+    editText.setSelection(1);
+    when(mLynxView.findFocus()).thenReturn(editText);
+
+    mPlatformDelegate.insertText("b");
+
+    assertEquals("abc", editText.getText().toString());
+  }
+
+  @Test
+  public void insertTextFallsBackToRootFocusedEditText() {
+    EditText editText = new EditText(mContext);
+    editText.setText("acd");
+    editText.setSelection(1, 2);
+    View rootView = mock(View.class);
+    when(rootView.findFocus()).thenReturn(editText);
+    when(mLynxView.findFocus()).thenReturn(null);
+    when(mLynxView.getRootView()).thenReturn(rootView);
+
+    mPlatformDelegate.insertText("b");
+
+    assertEquals("abd", editText.getText().toString());
+  }
+}

--- a/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
+++ b/platform/android/lynx_devtool/src/androidTest/java/com/lynx/devtool/DevToolPlatformAndroidDelegateTest.java
@@ -4,6 +4,7 @@
 package com.lynx.devtool;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -43,7 +44,7 @@ public class DevToolPlatformAndroidDelegateTest {
     editText.setSelection(1);
     when(mLynxView.findFocus()).thenReturn(editText);
 
-    mPlatformDelegate.insertText("b");
+    assertNull(mPlatformDelegate.insertText("b"));
 
     assertEquals("abc", editText.getText().toString());
   }
@@ -58,8 +59,17 @@ public class DevToolPlatformAndroidDelegateTest {
     when(mLynxView.findFocus()).thenReturn(null);
     when(mLynxView.getRootView()).thenReturn(rootView);
 
-    mPlatformDelegate.insertText("b");
+    assertNull(mPlatformDelegate.insertText("b"));
 
     assertEquals("abd", editText.getText().toString());
+  }
+
+  @Test
+  public void insertTextReturnsErrorWithoutFocusedEditText() {
+    when(mLynxView.findFocus()).thenReturn(null);
+    when(mLynxView.getRootView()).thenReturn(null);
+
+    assertEquals(
+        "Input.insertText requires a focused EditText.", mPlatformDelegate.insertText("b"));
   }
 }

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
@@ -4,6 +4,10 @@
 package com.lynx.devtool;
 
 import android.text.TextUtils;
+import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
+import android.widget.EditText;
 import android.widget.Toast;
 import androidx.annotation.Keep;
 import com.lynx.devtool.helper.EmulateTouchHelper;
@@ -365,6 +369,42 @@ public class DevToolPlatformAndroidDelegate {
             "DOM.focus failed for nodeId " + nodeId + ", code: " + args[0] + ", data: " + detail);
       }
     });
+  }
+
+  @CalledByNative
+  public void insertText(final String text) {
+    if (text == null) {
+      return;
+    }
+    LynxView lynxView = mLynxView.get();
+    if (lynxView == null) {
+      return;
+    }
+    View focusedView = lynxView.findFocus();
+    if (focusedView == null && lynxView.getRootView() != null) {
+      focusedView = lynxView.getRootView().findFocus();
+    }
+    if (!(focusedView instanceof EditText)) {
+      LLog.w(TAG, "Input.insertText ignored because no EditText is focused.");
+      return;
+    }
+
+    EditText editText = (EditText) focusedView;
+    InputConnection inputConnection = editText.onCreateInputConnection(new EditorInfo());
+    if (inputConnection != null && inputConnection.commitText(text, 1)) {
+      return;
+    }
+
+    int selectionStart = editText.getSelectionStart();
+    int selectionEnd = editText.getSelectionEnd();
+    if (selectionStart < 0 || selectionEnd < 0) {
+      editText.getText().append(text);
+      return;
+    }
+    int textLength = editText.getText().length();
+    int start = Math.min(textLength, Math.max(0, Math.min(selectionStart, selectionEnd)));
+    int end = Math.min(textLength, Math.max(0, Math.max(selectionStart, selectionEnd)));
+    editText.getText().replace(start, end, text);
   }
 
   @CalledByNative

--- a/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
+++ b/platform/android/lynx_devtool/src/main/java/com/lynx/devtool/DevToolPlatformAndroidDelegate.java
@@ -372,13 +372,13 @@ public class DevToolPlatformAndroidDelegate {
   }
 
   @CalledByNative
-  public void insertText(final String text) {
+  public String insertText(final String text) {
     if (text == null) {
-      return;
+      return "Input.insertText requires a non-null text parameter.";
     }
     LynxView lynxView = mLynxView.get();
     if (lynxView == null) {
-      return;
+      return "LynxView is unavailable.";
     }
     View focusedView = lynxView.findFocus();
     if (focusedView == null && lynxView.getRootView() != null) {
@@ -386,25 +386,26 @@ public class DevToolPlatformAndroidDelegate {
     }
     if (!(focusedView instanceof EditText)) {
       LLog.w(TAG, "Input.insertText ignored because no EditText is focused.");
-      return;
+      return "Input.insertText requires a focused EditText.";
     }
 
     EditText editText = (EditText) focusedView;
     InputConnection inputConnection = editText.onCreateInputConnection(new EditorInfo());
     if (inputConnection != null && inputConnection.commitText(text, 1)) {
-      return;
+      return null;
     }
 
     int selectionStart = editText.getSelectionStart();
     int selectionEnd = editText.getSelectionEnd();
     if (selectionStart < 0 || selectionEnd < 0) {
       editText.getText().append(text);
-      return;
+      return null;
     }
     int textLength = editText.getText().length();
     int start = Math.min(textLength, Math.max(0, Math.min(selectionStart, selectionEnd)));
     int end = Math.min(textLength, Math.max(0, Math.max(selectionStart, selectionEnd)));
     editText.getText().replace(start, end, text);
+    return null;
   }
 
   @CalledByNative

--- a/platform/darwin/ios/lynx_devtool/BUILD.gn
+++ b/platform/darwin/ios/lynx_devtool/BUILD.gn
@@ -359,6 +359,7 @@ subspec_target("UnitTests") {
   sources = [
     "../../common/lynx_devtool/LynxDebugBridgeUnitTest.mm",
     "ConsoleDelegateManagerUnitTest.mm",
+    "DevToolPlatformDarwinDelegateUnitTest.mm",
     "Helper/LepusDebugInfoHelperUnitTest.mm",
     "Helper/LynxUITreeHelperUnitTest.m",
     "LynxDevToolErrorUtilsUnitTest.m",

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
@@ -95,6 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getLepusDebugInfoUrl:(NSString *_Nonnull)filename;
 
 - (void)emulateTouch:(std::shared_ptr<lynx::devtool::MouseEvent>)input;
+- (void)insertText:(nullable NSString *)text;
 - (void)emulateTouch:(nonnull NSString *)type
          coordinateX:(int)x
          coordinateY:(int)y

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.h
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getLepusDebugInfoUrl:(NSString *_Nonnull)filename;
 
 - (void)emulateTouch:(std::shared_ptr<lynx::devtool::MouseEvent>)input;
-- (void)insertText:(nullable NSString *)text;
+- (nullable NSString *)insertText:(nullable NSString *)text;
 - (void)emulateTouch:(nonnull NSString *)type
          coordinateX:(int)x
          coordinateY:(int)y

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
@@ -23,6 +23,10 @@
 #include "devtool/lynx_devtool/agent/devtool_platform_facade.h"
 #include "devtool/lynx_devtool/element/element_inspector.h"
 
+@interface DevToolPlatformDarwinDelegate ()
+- (nullable UIView*)firstResponderInView:(nullable UIView*)view;
+@end
+
 #pragma mark - DevToolPlatformDarwin
 namespace lynx {
 namespace devtool {
@@ -223,6 +227,16 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
     __strong typeof(_darwin) darwin = _darwin;
     if (darwin != nil) {
       [darwin emulateTouch:input];
+    }
+  }
+
+  void InsertText(const std::string& text) override {
+    __strong typeof(_darwin) darwin = _darwin;
+    if (darwin != nil) {
+      NSString* nsText = [[NSString alloc] initWithBytes:text.data()
+                                                  length:text.size()
+                                                encoding:NSUTF8StringEncoding];
+      [darwin insertText:nsText];
     }
   }
 
@@ -582,6 +596,34 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
               deltaY:input->delta_y_
            modifiers:input->modifiers_
           clickCount:input->click_count_];
+}
+
+- (void)insertText:(nullable NSString*)text {
+  if (text == nil) {
+    return;
+  }
+  __strong typeof(_lynxView) lynxView = _lynxView;
+  UIView* firstResponder = [self firstResponderInView:lynxView];
+  if ([firstResponder conformsToProtocol:@protocol(UITextInput)] &&
+      [firstResponder respondsToSelector:@selector(insertText:)]) {
+    [(id<UITextInput>)firstResponder insertText:text];
+  }
+}
+
+- (nullable UIView*)firstResponderInView:(nullable UIView*)view {
+  if (view == nil) {
+    return nil;
+  }
+  if (view.isFirstResponder) {
+    return view;
+  }
+  for (UIView* subview in view.subviews) {
+    UIView* firstResponder = [self firstResponderInView:subview];
+    if (firstResponder != nil) {
+      return firstResponder;
+    }
+  }
+  return nil;
 }
 
 - (void)emulateTouch:(nonnull NSString*)type

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegate.mm
@@ -230,14 +230,20 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
     }
   }
 
-  void InsertText(const std::string& text) override {
+  std::string InsertText(const std::string& text) override {
     __strong typeof(_darwin) darwin = _darwin;
     if (darwin != nil) {
       NSString* nsText = [[NSString alloc] initWithBytes:text.data()
                                                   length:text.size()
                                                 encoding:NSUTF8StringEncoding];
-      [darwin insertText:nsText];
+      if (nsText == nil) {
+        return "Input.insertText text is not valid UTF-8.";
+      }
+      NSString* error_message = [darwin insertText:nsText];
+      const char* error = error_message != nil ? [error_message UTF8String] : nullptr;
+      return error != nullptr ? std::string(error) : "";
     }
+    return "DevTool platform delegate is unavailable.";
   }
 
   void PageReload(bool ignore_cache, const std::string& template_binary,
@@ -598,16 +604,18 @@ class DevToolPlatformDarwin : public DevToolPlatformFacade {
           clickCount:input->click_count_];
 }
 
-- (void)insertText:(nullable NSString*)text {
+- (nullable NSString*)insertText:(nullable NSString*)text {
   if (text == nil) {
-    return;
+    return @"Input.insertText requires a non-null text parameter.";
   }
   __strong typeof(_lynxView) lynxView = _lynxView;
   UIView* firstResponder = [self firstResponderInView:lynxView];
   if ([firstResponder conformsToProtocol:@protocol(UITextInput)] &&
       [firstResponder respondsToSelector:@selector(insertText:)]) {
     [(id<UITextInput>)firstResponder insertText:text];
+    return nil;
   }
+  return @"Input.insertText requires a focused UITextInput.";
 }
 
 - (nullable UIView*)firstResponderInView:(nullable UIView*)view {

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
@@ -1,0 +1,45 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <LynxDevtool/DevToolPlatformDarwinDelegate.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+@interface DevToolInsertTextField : UITextField
+@end
+
+@implementation DevToolInsertTextField
+
+- (BOOL)isFirstResponder {
+  return YES;
+}
+
+@end
+
+@interface DevToolPlatformDarwinDelegateUnitTest : XCTestCase
+@end
+
+@implementation DevToolPlatformDarwinDelegateUnitTest
+
+- (void)testInsertTextUsesFirstResponderTextInput {
+  UIView *lynxView = [[UIView alloc] initWithFrame:CGRectZero];
+  UIView *container = [[UIView alloc] initWithFrame:CGRectZero];
+  DevToolInsertTextField *textField = [[DevToolInsertTextField alloc] initWithFrame:CGRectZero];
+  textField.text = @"ac";
+  textField.selectedTextRange = [textField
+      textRangeFromPosition:[textField positionFromPosition:textField.beginningOfDocument offset:1]
+                 toPosition:[textField positionFromPosition:textField.beginningOfDocument
+                                                     offset:1]];
+  [container addSubview:textField];
+  [lynxView addSubview:container];
+
+  DevToolPlatformDarwinDelegate *platform =
+      [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:(LynxView *)lynxView];
+
+  [platform insertText:@"b"];
+
+  XCTAssertEqualObjects(textField.text, @"abc");
+}
+
+@end

--- a/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
+++ b/platform/darwin/ios/lynx_devtool/DevToolPlatformDarwinDelegateUnitTest.mm
@@ -37,9 +37,18 @@
   DevToolPlatformDarwinDelegate *platform =
       [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:(LynxView *)lynxView];
 
-  [platform insertText:@"b"];
+  XCTAssertNil([platform insertText:@"b"]);
 
   XCTAssertEqualObjects(textField.text, @"abc");
+}
+
+- (void)testInsertTextReturnsErrorWithoutFirstResponder {
+  UIView *lynxView = [[UIView alloc] initWithFrame:CGRectZero];
+  DevToolPlatformDarwinDelegate *platform =
+      [[DevToolPlatformDarwinDelegate alloc] initWithLynxView:(LynxView *)lynxView];
+
+  XCTAssertEqualObjects([platform insertText:@"b"],
+                        @"Input.insertText requires a focused UITextInput.");
 }
 
 @end


### PR DESCRIPTION
## Summary

- Cherry-pick Android DevTool `Input.insertText` bridge support from lynx-family/lynx#6533.
- Cherry-pick iOS DevTool `Input.insertText` bridge support from lynx-family/lynx#6534.
- Return CDP errors when `Input.insertText` is missing a string `text` parameter or when the platform cannot insert text into a focused input.
- Propagate platform-specific insertion error messages through Android, iOS, and DevTool facade APIs instead of collapsing failures to `true` / `false`.
- Cover invalid params and platform failure paths in unit tests.

## Validation

- `git diff --check origin/develop...HEAD`
- `source tools/envsetup.sh >/tmp/envsetup_final_check.log 2>&1 && PATH="$PWD/buildtools/llvm/bin:$PATH" python3 tools_shared/git_lynx.py check --checkers coding-style,commit-message,java-lint`
- `source tools/envsetup.sh >/tmp/envsetup_ninja.log 2>&1 && ninja -C out/Default_agent_test_no_flutter_cxx devtool_agent_unittest_exec`
- `LLVM_PROFILE_FILE=/tmp/devtool_agent_unittest_exec_final.profraw out/Default_agent_test_no_flutter_cxx/devtool_agent_unittest_exec --gtest_filter='InspectorUIExecutorTest.InsertTextTest:InspectorUIExecutorTest.InsertTextReturnsErrorWhenPlatformFails:InspectorInputAgentTest.InsertTextReturnsSuccess:InspectorInputAgentTest.InsertTextReturnsErrorForInvalidParams'`

## Notes

- This branch includes the CI format fix for `devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc` reported by the previous `static-check` failure.
- Android assemble was attempted with `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew --parallel --configure-on-demand -x lint -PabiList=x86 -Penable_lynx_android_test=true -Penable_coverage=true LynxDevtool:assembleNoasanDebugAndroidTest` from `platform/android`, but this local machine is missing Android SDK CMake `3.18.1` and only has CMake `4.3.2` on PATH.
