### PR TITLE
[BugFix][Android] Return success for custom keyboard focus

### DIFF
--- a/platform/android/lynx_xelement/lynx_xelement_input/src/main/java/com/lynx/xelement/input/LynxUIBaseInput.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_input/src/main/java/com/lynx/xelement/input/LynxUIBaseInput.kt
@@ -805,6 +805,7 @@ open class LynxUIBaseInput(context: LynxContext, params: Any?) : LynxUI<LynxEdit
       if (mView.requestFocus()) {
         if (mUseCustomKeyboard) {
           hideSoftInput()
+          callback?.invoke(LynxUIMethodConstants.SUCCESS)
         } else if (showSoftInput()){
           callback?.invoke(LynxUIMethodConstants.SUCCESS)
         } else {
@@ -936,4 +937,3 @@ open class LynxUIBaseInput(context: LynxContext, params: Any?) : LynxUI<LynxEdit
     }
   }
 }
-


### PR DESCRIPTION
## Summary
- Report `LynxUIMethodConstants.SUCCESS` after `hideSoftInput()` when an input uses custom keyboard mode.

## Test Plan
- `ANDROID_HOME=/Users/colin/Library/Android/sdk ANDROID_SDK_ROOT=/Users/colin/Library/Android/sdk ./gradlew :LynxXElement:Input:compileDebugKotlin`
- `git diff --check HEAD^ HEAD`
