### PR TITLE
[Infra][Android] Fix extension plugin Maven publication

### DIFF
--- a/platform/android/lynx_extension_plugin/build.gradle
+++ b/platform/android/lynx_extension_plugin/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 }
 
 gradlePlugin {
+    // Keep the release artifact owned by ../publish.gradle and avoid
+    // java-gradle-plugin's pluginMaven / *PluginMarkerMaven publications.
+    // This also means the plugin is not published with Gradle plugin markers
+    // for Maven-based `plugins { id(...) version ... }` resolution.
+    automatedPublishing = false
     plugins {
         lynxExtensionSettings {
             id = 'org.lynxsdk.extension-settings'


### PR DESCRIPTION
Summary:
- Disable automatic Gradle plugin Maven publications for LynxExtensionPlugin.
- Keep the existing release publication generated by publish.gradle.

Validation:
- ./gradlew :LynxExtensionPlugin:test
- isolated clean publish for LynxExtensionPlugin
- git diff --check