### PR TITLE
[Infra][Release] Retry CocoaPods trunk publish

### DIFF
--- a/tools/ios_tools/cocoapods_publish_helper.py
+++ b/tools/ios_tools/cocoapods_publish_helper.py
@@ -7,13 +7,20 @@ import argparse
 import os
 import shutil
 import subprocess
+import time
 import json
 import shlex
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import urlopen
 from skip_pod_lint import skip_pod_lint
 
 SOURCE_TYPE_ZIP = 'zip'
 SOURCE_TYPE_GIT = 'git'
 GIT_SOURCE_REF_TYPES = ('commit', 'tag', 'branch')
+COCOAPODS_TRUNK_API = 'https://trunk.cocoapods.org/api/v1'
+PUBLISH_RETRY_ATTEMPTS = 3
+PUBLISH_RETRY_INITIAL_DELAY_SECONDS = 30
 
 def run_command(command, check=True):
     # When the "command" is a multi-line command, only the status of the last line of the command is checked.
@@ -23,6 +30,45 @@ def run_command(command, check=True):
     print(f'run command: {command}')
     res = subprocess.run(['bash', '-c', command], stderr=subprocess.STDOUT, check=check, text=True)
 
+def get_podspec_version(component):
+    with open(f"{component}.podspec.json", 'r', encoding='utf8') as f:
+        content = json.load(f)
+    return content['version']
+
+def is_pod_version_published(component, version):
+    component_path = quote(component, safe='')
+    version_path = quote(version, safe='')
+    url = f'{COCOAPODS_TRUNK_API}/pods/{component_path}/versions/{version_path}'
+
+    try:
+        with urlopen(url, timeout=15) as response:
+            content = json.load(response)
+            return bool(content.get('data_url'))
+    except HTTPError as e:
+        if e.code != 404:
+            print(f'Unable to check CocoaPods trunk for {component} {version}: HTTP {e.code}')
+        return False
+    except (URLError, TimeoutError) as e:
+        print(f'Unable to check CocoaPods trunk for {component} {version}: {e}')
+        return False
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        print(f'Unable to parse CocoaPods trunk response for {component} {version}: {e}')
+        return False
+
+def build_publish_command(component, sources):
+    podspec_json = shlex.quote(f'{component}.podspec.json')
+    command = f'COCOAPODS_TRUNK_TOKEN=$COCOAPODS_TRUNK_TOKEN bundle exec pod trunk push {podspec_json} --verbose --skip-import-validation --allow-warnings --skip-tests'
+    if sources is not None:
+        command += f' --sources={shlex.quote(sources)}'
+    return command
+
+def wait_before_publish_retry(component, version, attempt, delay_seconds):
+    print(
+        f'Failed to publish {component} {version} '
+        f'(attempt {attempt}/{PUBLISH_RETRY_ATTEMPTS}); '
+        f'retrying in {delay_seconds} seconds.'
+    )
+    time.sleep(delay_seconds)
 
 def replace_lynx_version(version):
     lines = []
@@ -187,10 +233,28 @@ def pod_lint_component(component, local_pod_source_name):
     run_command(f'bundle exec pod spec lint {component}.podspec.json --sources=trunk,{local_pod_source_name} --verbose --skip-import-validation --allow-warnings --skip-tests')
 
 def publish_component(component, sources):
-    if sources != None:
-        run_command(f'COCOAPODS_TRUNK_TOKEN=$COCOAPODS_TRUNK_TOKEN bundle exec pod trunk push {component}.podspec.json --verbose --skip-import-validation --allow-warnings --skip-tests --sources={sources}')
-    else:
-        run_command(f'COCOAPODS_TRUNK_TOKEN=$COCOAPODS_TRUNK_TOKEN bundle exec pod trunk push {component}.podspec.json --verbose --skip-import-validation --allow-warnings --skip-tests')
+    version = get_podspec_version(component)
+    command = build_publish_command(component, sources)
+    delay_seconds = PUBLISH_RETRY_INITIAL_DELAY_SECONDS
+
+    for attempt in range(1, PUBLISH_RETRY_ATTEMPTS + 1):
+        if is_pod_version_published(component, version):
+            print(f'Skip {component} {version}; it is already published to CocoaPods trunk.')
+            return
+
+        try:
+            run_command(command)
+            return
+        except subprocess.CalledProcessError:
+            if is_pod_version_published(component, version):
+                print(f'Treat {component} {version} as published after CocoaPods trunk confirmed it.')
+                return
+
+            if attempt == PUBLISH_RETRY_ATTEMPTS:
+                raise
+
+            wait_before_publish_retry(component, version, attempt, delay_seconds)
+            delay_seconds *= 2
 
 
 def publish_to_cocoapods(component, sources):

--- a/tools/ios_tools/cocoapods_publish_helper_test.py
+++ b/tools/ios_tools/cocoapods_publish_helper_test.py
@@ -5,9 +5,11 @@
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -90,6 +92,91 @@ class CocoapodsPublishHelperTest(unittest.TestCase):
                 None,
                 'abcdef123456',
             )
+
+    def test_publish_component_skips_existing_pod_version(self):
+        self.write_podspec_json('Lynx', {'version': '1.2.3'})
+
+        with mock.patch.object(helper, 'is_pod_version_published', return_value=True), \
+                mock.patch.object(helper, 'run_command') as run_command:
+            helper.publish_component('Lynx', None)
+
+        run_command.assert_not_called()
+
+    def test_publish_component_treats_confirmed_version_after_failure_as_success(self):
+        self.write_podspec_json('Lynx', {'version': '1.2.3'})
+
+        with mock.patch.object(helper, 'is_pod_version_published',
+                               side_effect=[False, True]), \
+                mock.patch.object(helper, 'run_command',
+                                  side_effect=subprocess.CalledProcessError(1, 'pod trunk push')), \
+                mock.patch.object(helper.time, 'sleep') as sleep:
+            helper.publish_component('Lynx', None)
+
+        sleep.assert_not_called()
+
+    def test_publish_component_retries_with_exponential_backoff(self):
+        self.write_podspec_json('Lynx', {'version': '1.2.3'})
+
+        with mock.patch.object(helper, 'is_pod_version_published', return_value=False), \
+                mock.patch.object(
+                    helper,
+                    'run_command',
+                    side_effect=[
+                        subprocess.CalledProcessError(1, 'pod trunk push'),
+                        subprocess.CalledProcessError(1, 'pod trunk push'),
+                        None,
+                    ],
+                ) as run_command, \
+                mock.patch.object(helper.time, 'sleep') as sleep:
+            helper.publish_component('Lynx', None)
+
+        self.assertEqual(run_command.call_count, 3)
+        sleep.assert_has_calls([
+            mock.call(helper.PUBLISH_RETRY_INITIAL_DELAY_SECONDS),
+            mock.call(helper.PUBLISH_RETRY_INITIAL_DELAY_SECONDS * 2),
+        ])
+
+    def test_publish_component_raises_after_retry_attempts(self):
+        self.write_podspec_json('Lynx', {'version': '1.2.3'})
+
+        with mock.patch.object(helper, 'is_pod_version_published', return_value=False), \
+                mock.patch.object(helper, 'run_command',
+                                  side_effect=subprocess.CalledProcessError(1, 'pod trunk push')), \
+                mock.patch.object(helper.time, 'sleep') as sleep, \
+                self.assertRaises(subprocess.CalledProcessError):
+            helper.publish_component('Lynx', None)
+
+        self.assertEqual(sleep.call_count, helper.PUBLISH_RETRY_ATTEMPTS - 1)
+
+    def test_build_publish_command_quotes_shell_arguments(self):
+        command = helper.build_publish_command(
+            'Lynx Kit',
+            'trunk,private specs; echo injected',
+        )
+
+        self.assertIn(
+            "pod trunk push 'Lynx Kit.podspec.json' --verbose",
+            command,
+        )
+        self.assertIn(
+            " --sources='trunk,private specs; echo injected'",
+            command,
+        )
+
+    def test_is_pod_version_published_ignores_decode_failure(self):
+        bad_encoding = UnicodeDecodeError(
+            'utf-8',
+            b'\xff',
+            0,
+            1,
+            'invalid start byte',
+        )
+
+        with mock.patch.object(helper, 'urlopen') as urlopen, \
+                mock.patch.object(helper.json, 'load', side_effect=bad_encoding):
+            urlopen.return_value.__enter__.return_value = object()
+
+            self.assertFalse(helper.is_pod_version_published('Lynx', '1.2.3'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Skip CocoaPods trunk publish when the pod version is already visible on trunk.
- Retry failed trunk pushes with exponential backoff.
- Treat timeout responses as success when trunk confirms the pod version is published after the failure.

## Verification

- `python3 -m py_compile tools/ios_tools/cocoapods_publish_helper.py tools/ios_tools/cocoapods_publish_helper_test.py`
- `python3 tools/ios_tools/cocoapods_publish_helper_test.py`
- `git diff --check -- tools/ios_tools/cocoapods_publish_helper.py tools/ios_tools/cocoapods_publish_helper_test.py`