### PR TITLE
[Feature][XElement][Android] Add video element support

### DIFF
--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -131,6 +131,7 @@ dependencies {
     implementation project(':LynxXElement:Refresh')
     implementation project(':LynxXElement:BlurView')
     implementation project(':LynxXElement:WebView')
+    implementation project(':LynxXElement:Video')
 
     kapt project(':LynxProcessor')
     compileOnly project(':LynxProcessor')

--- a/explorer/android/settings.gradle
+++ b/explorer/android/settings.gradle
@@ -66,6 +66,8 @@ include ':LynxXElement:BlurView'
 project(":LynxXElement:BlurView").projectDir = new File(rootProject.projectDir, '../../platform/android/lynx_xelement/lynx_xelement_blur_view')
 include ':LynxXElement:WebView'
 project(":LynxXElement:WebView").projectDir = new File(rootProject.projectDir, '../../platform/android/lynx_xelement/lynx_xelement_webview')
+include ':LynxXElement:Video'
+project(":LynxXElement:Video").projectDir = new File(rootProject.projectDir, '../../platform/android/lynx_xelement/lynx_xelement_video')
 
 include ':ServiceAPI'
 project(':ServiceAPI').projectDir = new File(rootProject.projectDir, '../../platform/android/service_api')

--- a/platform/android/lynx_xelement/lynx_xelement/build.gradle
+++ b/platform/android/lynx_xelement/lynx_xelement/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation project(':LynxXElement:Markdown')
     implementation project(':LynxXElement:BlurView')
     implementation project(':LynxXElement:WebView')
+    implementation project(':LynxXElement:Video')
     implementation 'io.github.scwang90:refresh-layout-kernel:3.0.0-alpha'
     compileOnly project(":LynxAndroid")
     compileOnly project(":LynxProcessor")

--- a/platform/android/lynx_xelement/lynx_xelement/src/main/java/com/lynx/xelement/LynxUIVideoAutoRegistry.kt
+++ b/platform/android/lynx_xelement/lynx_xelement/src/main/java/com/lynx/xelement/LynxUIVideoAutoRegistry.kt
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.xelement
+
+import com.lynx.tasm.behavior.LynxBehavior
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.LynxGeneratorName
+import com.lynx.xelement.video.LynxUIVideo
+
+@LynxGeneratorName(packageName = "com.lynx.xelement")
+@LynxBehavior(tagName = ["video"], isCreateAsync = false)
+open class LynxUIVideoAutoRegistry(context: LynxContext) : LynxUIVideo(context) {}

--- a/platform/android/lynx_xelement/lynx_xelement_video/build.gradle
+++ b/platform/android/lynx_xelement/lynx_xelement_video/build.gradle
@@ -1,0 +1,43 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply from: file("../ext.gradle")
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion min_sdk_version
+        targetSdkVersion target_sdk_version
+        versionCode 1
+        versionName "1.0"
+        consumerProguardFiles 'consumer-rules.pro'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation("androidx.media3:media3-exoplayer:1.0.2") {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    implementation("androidx.media3:media3-ui:1.0.2") {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    implementation 'com.google.guava:guava:31.1-android'
+    compileOnly 'androidx.annotation:annotation:1.1.0'
+}

--- a/platform/android/lynx_xelement/lynx_xelement_video/src/main/AndroidManifest.xml
+++ b/platform/android/lynx_xelement/lynx_xelement_video/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.lynx.xelement.video">
+</manifest>

--- a/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxUIVideo.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxUIVideo.kt
@@ -1,0 +1,522 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.xelement.video
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import com.lynx.react.bridge.Callback
+import com.lynx.react.bridge.JavaOnlyMap
+import com.lynx.react.bridge.ReadableMap
+import com.lynx.react.bridge.ReadableType
+import com.lynx.tasm.behavior.LynxBehavior
+import com.lynx.tasm.behavior.LynxContext
+import com.lynx.tasm.behavior.LynxGeneratorName
+import com.lynx.tasm.behavior.LynxProp
+import com.lynx.tasm.behavior.LynxUIMethod
+import com.lynx.tasm.behavior.LynxUIMethodConstants
+import com.lynx.tasm.behavior.ui.LynxUI
+import com.lynx.tasm.event.LynxDetailEvent
+import java.util.concurrent.ConcurrentLinkedQueue
+
+@LynxGeneratorName(packageName = "com.lynx.xelement.video")
+@LynxBehavior(tagName = ["video"], isCreateAsync = false)
+open class LynxUIVideo(context: LynxContext, params: Any?) : LynxUI<View>(context, params), LynxVideoPlayable.Callback {
+
+    constructor(context: LynxContext) : this(context, null)
+
+    companion object {
+        private const val DEFAULT_TIME_UPDATE_INTERVAL_SEC = 0.33f
+        private const val MAX_SAFE_SEEK_POSITION_SEC = Long.MAX_VALUE / 1000.0
+    }
+
+    private var mPlayable: LynxVideoPlayable? = null
+    private var mMode: String = "queue"
+    private var mSrc: String? = null
+    private var mTimeUpdateIntervalSec: Float = DEFAULT_TIME_UPDATE_INTERVAL_SEC
+    private var mDurationMs: Long = 0
+    private var mHasPlaybackStarted = false
+    private var mHasPlaybackEnded = false
+    private var mIsTimeUpdateActive = false
+
+    private val mHandler = Handler(Looper.getMainLooper())
+    private val mTimeUpdateRunnable = object : Runnable {
+        override fun run() {
+            mHandler.removeCallbacks(this)
+            if (!shouldPollTimeUpdate()) {
+                return
+            }
+            dispatchTimeUpdate()
+            if (shouldPollTimeUpdate()) {
+                mHandler.postDelayed(this, timeUpdateDelayMs())
+            }
+        }
+    }
+
+    // UIMethod scheduling
+    private data class UIMethodRequest(
+        val method: String,
+        val params: ReadableMap,
+        val callback: Callback?
+    )
+
+    private sealed class RequestExecutionResult {
+        object WaitForEvent : RequestExecutionResult()
+        data class Finished(
+            val code: Int,
+            val msg: String? = null,
+            val shouldDispatchErrorEvent: Boolean = false
+        ) : RequestExecutionResult()
+    }
+
+    private val mPendingQueue = ConcurrentLinkedQueue<UIMethodRequest>()
+    private var mLatestPending: UIMethodRequest? = null
+    private var mIsExecuting = false
+    private var mCurrentRequest: UIMethodRequest? = null
+
+    override fun createView(context: Context): View {
+        val videoView = LynxVideoView(context)
+        videoView.setCallback(this)
+        mPlayable = videoView
+        return videoView.getPlayerView()
+    }
+
+    override fun onNodeReady() {
+        super.onNodeReady()
+    }
+
+    override fun destroy() {
+        cancelPendingSerialRequests("request canceled by destroy")
+        mHandler.removeCallbacksAndMessages(null)
+        stopTimeUpdatePolling()
+        mPlayable?.release()
+        mPlayable = null
+        super.destroy()
+    }
+
+    // --- LynxProps ---
+
+    @LynxProp(name = "src")
+    fun setSrc(src: String?) {
+        mSrc = src
+        mIsTimeUpdateActive = false
+        mHasPlaybackStarted = false
+        mHasPlaybackEnded = false
+        stopTimeUpdatePolling()
+        cancelPendingSerialRequests("request canceled by src change")
+        mPlayable?.setSrc(src)
+    }
+
+    @LynxProp(name = "loop", defaultBoolean = false)
+    fun setLoop(loop: Boolean) {
+        mPlayable?.setLoop(loop)
+    }
+
+    @LynxProp(name = "volume", defaultFloat = 1.0f)
+    fun setVolume(volume: Float) {
+        mPlayable?.setVolume(volume.coerceIn(0f, 1f))
+    }
+
+    @LynxProp(name = "muted", defaultBoolean = false)
+    fun setMuted(muted: Boolean) {
+        mPlayable?.setMuted(muted)
+    }
+
+    @LynxProp(name = "speed", defaultFloat = 1.0f)
+    fun setSpeed(speed: Float) {
+        mPlayable?.setSpeed(speed.coerceIn(0.1f, 2.0f))
+    }
+
+    @LynxProp(name = "object-fit")
+    fun setObjectFit(objectFit: String?) {
+        mPlayable?.setObjectFit(objectFit)
+    }
+
+    @LynxProp(name = "mode")
+    fun setMode(mode: String?) {
+        mMode = mode ?: "queue"
+    }
+
+    @LynxProp(name = "timeupdate-interval", defaultFloat = 0.33f)
+    fun setTimeUpdateInterval(interval: Float) {
+        if (interval > 0f) {
+            mTimeUpdateIntervalSec = interval
+        }
+    }
+
+    // --- LynxUIMethods ---
+
+    @LynxUIMethod
+    fun play(params: ReadableMap?, callback: Callback?) {
+        dispatchRequest("play", params, callback)
+    }
+
+    @LynxUIMethod
+    fun pause(params: ReadableMap?, callback: Callback?) {
+        dispatchRequest("pause", params, callback)
+    }
+
+    @LynxUIMethod
+    fun stop(params: ReadableMap?, callback: Callback?) {
+        dispatchRequest("stop", params, callback)
+    }
+
+    @LynxUIMethod
+    fun seek(params: ReadableMap?, callback: Callback?) {
+        dispatchRequest("seek", params, callback)
+    }
+
+    // --- UIMethod scheduling ---
+
+    private fun dispatchRequest(method: String, params: ReadableMap?, callback: Callback?) {
+        dispatchRequest(UIMethodRequest(method, params ?: JavaOnlyMap(), callback))
+    }
+
+    private fun dispatchRequest(request: UIMethodRequest) {
+        when (mMode) {
+            "direct" -> executeDirectRequest(request)
+            "latest" -> {
+                if (mIsExecuting) {
+                    mLatestPending = request
+                } else {
+                    executeRequest(request)
+                }
+            }
+            else -> { // queue
+                if (mIsExecuting) {
+                    mPendingQueue.offer(request)
+                } else {
+                    executeRequest(request)
+                }
+            }
+        }
+    }
+
+    private fun executeRequest(request: UIMethodRequest) {
+        mIsExecuting = true
+        mCurrentRequest = request
+        when (val result = performRequest(request)) {
+            is RequestExecutionResult.Finished -> finishRequest(result)
+            RequestExecutionResult.WaitForEvent -> {
+                // Serial modes complete when the matching player event is dispatched.
+            }
+        }
+    }
+
+    private fun executeDirectRequest(request: UIMethodRequest) {
+        when (val result = performRequest(request)) {
+            is RequestExecutionResult.Finished -> {
+                invokeRequestCallback(request, result.code, result.msg)
+                dispatchErrorEventIfNeeded(result)
+            }
+            RequestExecutionResult.WaitForEvent -> {
+                invokeRequestCallback(request, LynxUIMethodConstants.SUCCESS)
+            }
+        }
+    }
+
+    private fun performRequest(request: UIMethodRequest): RequestExecutionResult =
+        when (request.method) {
+            "play" -> doPlay()
+            "pause" -> doPause()
+            "stop" -> doStop()
+            "seek" -> doSeek(request)
+            else -> RequestExecutionResult.Finished(
+                LynxUIMethodConstants.METHOD_NOT_FOUND,
+                "method not found"
+            )
+        }
+
+    private fun doPlay(): RequestExecutionResult {
+        val playable = mPlayable ?: return RequestExecutionResult.Finished(
+            LynxUIMethodConstants.INVALID_STATE_ERROR,
+            "video view is not ready"
+        )
+        if (playable.isPlaying()) {
+            activateTimeUpdatePolling()
+            return RequestExecutionResult.Finished(LynxUIMethodConstants.SUCCESS)
+        }
+        if (mSrc.isNullOrEmpty()) {
+            return RequestExecutionResult.Finished(
+                LynxUIMethodConstants.OPERATION_ERROR,
+                "missing video source",
+                shouldDispatchErrorEvent = true
+            )
+        }
+        playable.play()
+        return RequestExecutionResult.WaitForEvent
+    }
+
+    private fun doPause(): RequestExecutionResult {
+        val playable = mPlayable ?: return RequestExecutionResult.Finished(
+            LynxUIMethodConstants.INVALID_STATE_ERROR,
+            "video view is not ready"
+        )
+        if (!playable.isPlaying()) {
+            return RequestExecutionResult.Finished(LynxUIMethodConstants.SUCCESS)
+        }
+        playable.pause()
+        return RequestExecutionResult.WaitForEvent
+    }
+
+    private fun doStop(): RequestExecutionResult {
+        val playable = mPlayable ?: return RequestExecutionResult.Finished(
+            LynxUIMethodConstants.INVALID_STATE_ERROR,
+            "video view is not ready"
+        )
+        playable.stop()
+        return RequestExecutionResult.WaitForEvent
+    }
+
+    private fun doSeek(request: UIMethodRequest): RequestExecutionResult {
+        val playable = mPlayable ?: return RequestExecutionResult.Finished(
+            LynxUIMethodConstants.INVALID_STATE_ERROR,
+            "video view is not ready"
+        )
+        if (!request.params.hasKey("position")) {
+            return RequestExecutionResult.Finished(
+                LynxUIMethodConstants.PARAM_INVALID,
+                "missing position param"
+            )
+        }
+        if (!isNumericParam(request.params, "position")) {
+            return RequestExecutionResult.Finished(
+                LynxUIMethodConstants.PARAM_INVALID,
+                "position param must be a number"
+            )
+        }
+        val positionSec = LynxVideoReadableMapUtils.getNumberAsDouble(
+            request.params,
+            "position"
+        )
+        val durationSec = playable.getDuration() / 1000.0
+        if (positionSec.isNaN() || positionSec.isInfinite() ||
+            positionSec < 0 || positionSec > MAX_SAFE_SEEK_POSITION_SEC ||
+            (durationSec > 0 && positionSec > durationSec)) {
+            return RequestExecutionResult.Finished(
+                LynxUIMethodConstants.PARAM_INVALID,
+                "position out of range"
+            )
+        }
+        playable.seek((positionSec * 1000.0).toLong())
+        return RequestExecutionResult.Finished(LynxUIMethodConstants.SUCCESS)
+    }
+
+    private fun isNumericParam(params: ReadableMap, name: String): Boolean =
+        when (params.getType(name)) {
+            ReadableType.Int, ReadableType.Long, ReadableType.Number -> true
+            else -> false
+        }
+
+    private fun finishRequest(code: Int, msg: String? = null) {
+        mCurrentRequest?.let { invokeRequestCallback(it, code, msg) }
+        mCurrentRequest = null
+        mIsExecuting = false
+
+        when (mMode) {
+            "latest" -> {
+                mLatestPending?.let {
+                    mLatestPending = null
+                    executeRequest(it)
+                }
+            }
+            "direct" -> {} // nothing pending
+            else -> { // queue
+                mPendingQueue.poll()?.let { executeRequest(it) }
+            }
+        }
+    }
+
+    private fun cancelPendingSerialRequests(msg: String) {
+        val currentRequest = mCurrentRequest
+        val latestRequest = mLatestPending
+        val pendingRequests = mutableListOf<UIMethodRequest>()
+        while (true) {
+            val pendingRequest = mPendingQueue.poll() ?: break
+            pendingRequests.add(pendingRequest)
+        }
+
+        mCurrentRequest = null
+        mLatestPending = null
+        mIsExecuting = false
+
+        currentRequest?.let {
+            invokeRequestCallback(it, LynxUIMethodConstants.OPERATION_ERROR, msg)
+        }
+        pendingRequests.forEach {
+            invokeRequestCallback(it, LynxUIMethodConstants.OPERATION_ERROR, msg)
+        }
+        latestRequest?.let {
+            invokeRequestCallback(it, LynxUIMethodConstants.OPERATION_ERROR, msg)
+        }
+    }
+
+    private fun finishRequest(result: RequestExecutionResult.Finished) {
+        finishRequest(result.code, result.msg)
+        dispatchErrorEventIfNeeded(result)
+    }
+
+    private fun invokeRequestCallback(
+        request: UIMethodRequest,
+        code: Int,
+        msg: String? = null
+    ) {
+        request.callback?.invoke(code, buildFinishResponse(code, msg))
+    }
+
+    private fun dispatchErrorEventIfNeeded(result: RequestExecutionResult.Finished) {
+        if (result.shouldDispatchErrorEvent) {
+            dispatchErrorEvent(result.code, result.msg ?: defaultErrorMessage(result.code))
+        }
+    }
+
+    private fun buildFinishResponse(code: Int, msg: String?): JavaOnlyMap {
+        val response = JavaOnlyMap()
+        val success = code == LynxUIMethodConstants.SUCCESS
+        response["success"] = success
+        if (!success) {
+            response["msg"] = msg ?: defaultErrorMessage(code)
+            response["errorCode"] = code
+        }
+        return response
+    }
+
+    private fun defaultErrorMessage(code: Int): String =
+        when (code) {
+            LynxUIMethodConstants.METHOD_NOT_FOUND -> "method not found"
+            LynxUIMethodConstants.PARAM_INVALID -> "parameter invalid"
+            LynxUIMethodConstants.INVALID_STATE_ERROR -> "invalid state"
+            LynxUIMethodConstants.OPERATION_ERROR -> "operation error"
+            else -> "request failed"
+        }
+
+    // --- LynxVideoPlayable.Callback ---
+
+    override fun onFirstFrame(durationMs: Long) {
+        mDurationMs = durationMs
+        val event = LynxDetailEvent(sign, "firstframe")
+        event.addDetail("duration", durationMs / 1000f)
+        mContext?.eventEmitter?.sendCustomEvent(event)
+    }
+
+    override fun onPlaying() {
+        activateTimeUpdatePolling()
+        val requestToFinish = mCurrentRequest?.takeIf { it.method == "play" }
+        mContext?.eventEmitter?.sendCustomEvent(LynxDetailEvent(sign, "playing"))
+        finishRequestAfterEvent(requestToFinish)
+    }
+
+    override fun onPaused() {
+        dispatchTimeUpdate()
+        mIsTimeUpdateActive = false
+        val requestToFinish = mCurrentRequest?.takeIf { it.method == "pause" }
+        mContext?.eventEmitter?.sendCustomEvent(LynxDetailEvent(sign, "paused"))
+        finishRequestAfterEvent(requestToFinish)
+    }
+
+    override fun onStopped() {
+        dispatchTimeUpdate()
+        mIsTimeUpdateActive = false
+        mHasPlaybackStarted = false
+        mHasPlaybackEnded = false
+        val requestToFinish = mCurrentRequest?.takeIf { it.method == "stop" }
+        mContext?.eventEmitter?.sendCustomEvent(LynxDetailEvent(sign, "stopped"))
+        finishRequestAfterEvent(requestToFinish)
+    }
+
+    private fun finishRequestAfterEvent(request: UIMethodRequest?) {
+        if (request == null) {
+            return
+        }
+        mHandler.post {
+            if (mCurrentRequest === request) {
+                finishRequest(LynxUIMethodConstants.SUCCESS)
+            }
+        }
+    }
+
+    override fun onTimeUpdate(currentMs: Long, durationMs: Long) {
+        // Handled by polling
+    }
+
+    override fun onEnded() {
+        dispatchTimeUpdate()
+        mIsTimeUpdateActive = false
+        mHasPlaybackEnded = true
+        stopTimeUpdatePolling()
+        mContext?.eventEmitter?.sendCustomEvent(LynxDetailEvent(sign, "ended"))
+    }
+
+    override fun onLooped() {
+        mContext?.eventEmitter?.sendCustomEvent(LynxDetailEvent(sign, "looped"))
+    }
+
+    override fun onError(errorCode: Int, errorMsg: String) {
+        mIsTimeUpdateActive = false
+        stopTimeUpdatePolling()
+        if (mCurrentRequest != null) {
+            finishRequest(LynxUIMethodConstants.OPERATION_ERROR, errorMsg)
+        }
+        dispatchErrorEvent(errorCode, errorMsg)
+    }
+
+    private fun dispatchErrorEvent(errorCode: Int, errorMsg: String) {
+        val event = LynxDetailEvent(sign, "error")
+        event.addDetail("errorCode", errorCode)
+        event.addDetail("errorMsg", errorMsg)
+        mContext?.eventEmitter?.sendCustomEvent(event)
+    }
+
+    override fun onBuffering(bufferedMs: Long) {
+        val event = LynxDetailEvent(sign, "buffering")
+        event.addDetail("buffering", bufferedMs / 1000f)
+        mContext?.eventEmitter?.sendCustomEvent(event)
+    }
+
+    // --- TimeUpdate Polling ---
+
+    private fun activateTimeUpdatePolling() {
+        mIsTimeUpdateActive = true
+        mHasPlaybackStarted = true
+        mHasPlaybackEnded = false
+        startTimeUpdatePolling()
+    }
+
+    private fun startTimeUpdatePolling() {
+        stopTimeUpdatePolling()
+        if (shouldPollTimeUpdate()) {
+            mHandler.postDelayed(mTimeUpdateRunnable, timeUpdateDelayMs())
+        }
+    }
+
+    private fun stopTimeUpdatePolling() {
+        mHandler.removeCallbacks(mTimeUpdateRunnable)
+    }
+
+    private fun dispatchTimeUpdate() {
+        val playable = mPlayable ?: return
+        if (!shouldPollTimeUpdate()) {
+            return
+        }
+        val current = playable.getCurrentPosition()
+        val duration = playable.getDuration()
+        if (duration > 0) {
+            val event = LynxDetailEvent(sign, "timeupdate")
+            event.addDetail("current", current / 1000f)
+            event.addDetail("duration", duration / 1000f)
+            mContext?.eventEmitter?.sendCustomEvent(event)
+        }
+    }
+
+    private fun timeUpdateDelayMs(): Long =
+        (normalizeTimeUpdateIntervalSec(mTimeUpdateIntervalSec) * 1000).toLong().coerceAtLeast(1L)
+
+    private fun shouldPollTimeUpdate(): Boolean =
+        mPlayable != null && mIsTimeUpdateActive && mHasPlaybackStarted && !mHasPlaybackEnded
+
+    private fun normalizeTimeUpdateIntervalSec(interval: Float): Float =
+        if (interval > 0f) interval else DEFAULT_TIME_UPDATE_INTERVAL_SEC
+}

--- a/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoPlayable.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoPlayable.kt
@@ -1,0 +1,38 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.xelement.video
+
+interface LynxVideoPlayable {
+    fun setSrc(src: String?)
+    fun setLoop(loop: Boolean)
+    fun setVolume(volume: Float)
+    fun setMuted(muted: Boolean)
+    fun setSpeed(speed: Float)
+    fun setObjectFit(objectFit: String?)
+
+    fun play()
+    fun pause()
+    fun stop()
+    fun seek(positionMs: Long)
+
+    fun getDuration(): Long
+    fun getCurrentPosition(): Long
+    fun isPlaying(): Boolean
+
+    fun setCallback(callback: Callback?)
+    fun release()
+
+    interface Callback {
+        fun onFirstFrame(durationMs: Long)
+        fun onPlaying()
+        fun onPaused()
+        fun onStopped()
+        fun onTimeUpdate(currentMs: Long, durationMs: Long)
+        fun onEnded()
+        fun onLooped()
+        fun onError(errorCode: Int, errorMsg: String)
+        fun onBuffering(bufferedMs: Long)
+    }
+}

--- a/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoReadableMapUtils.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoReadableMapUtils.kt
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.xelement.video
+
+import com.lynx.react.bridge.ReadableMap
+import com.lynx.react.bridge.ReadableType
+
+internal object LynxVideoReadableMapUtils {
+    fun getNumberAsDouble(params: ReadableMap, name: String): Double =
+        when (params.getType(name)) {
+            ReadableType.Int -> params.getInt(name).toDouble()
+            ReadableType.Long -> params.getLong(name).toDouble()
+            ReadableType.Number -> params.getDouble(name, Double.NaN)
+            else -> Double.NaN
+        }
+}

--- a/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoView.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_video/src/main/java/com/lynx/xelement/video/LynxVideoView.kt
@@ -1,0 +1,365 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.xelement.video
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+
+class LynxVideoView(context: Context) : LynxVideoPlayable {
+
+    private val playerView: PlayerView = PlayerView(context)
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val player: ExoPlayer
+    @Volatile
+    private var callback: LynxVideoPlayable.Callback? = null
+    private var loop: Boolean = false
+    private var volume: Float = 1.0f
+    private var muted: Boolean = false
+    private var speed: Float = 1.0f
+    private var objectFit: String? = "contain"
+    private var currentSrc: String? = null
+    private var hasFiredFirstFrame: Boolean = false
+    private var isExplicitlyStopped: Boolean = false
+    private var isBuffering: Boolean = false
+    private var suppressNextPlayingForLoop: Boolean = false
+    private var suppressNextPaused: Boolean = false
+    @Volatile
+    private var isReleased: Boolean = false
+    @Volatile
+    private var cachedDurationMs: Long = 0
+    @Volatile
+    private var cachedCurrentPositionMs: Long = 0
+    @Volatile
+    private var cachedIsPlaying: Boolean = false
+    private val playerListener: Player.Listener by lazy { createPlayerListener() }
+
+    private fun isOnMainThread(): Boolean = Looper.myLooper() == mainHandler.looper
+
+    private fun runOnMainThread(allowAfterRelease: Boolean = false, action: () -> Unit) {
+        if (!allowAfterRelease && isReleased) {
+            return
+        }
+        if (isOnMainThread()) {
+            if (allowAfterRelease || !isReleased) {
+                action()
+            }
+            return
+        }
+        mainHandler.post {
+            if (allowAfterRelease || !isReleased) {
+                action()
+            }
+        }
+    }
+
+    private fun notifyCallback(action: LynxVideoPlayable.Callback.() -> Unit) {
+        runOnMainThread {
+            callback?.action()
+        }
+    }
+
+    private fun refreshPlaybackSnapshot() {
+        cachedDurationMs = player.duration.coerceAtLeast(0)
+        cachedCurrentPositionMs = player.currentPosition.coerceAtLeast(0)
+        cachedIsPlaying = player.isPlaying && player.playbackState != Player.STATE_ENDED
+    }
+
+    private fun <T> readPlayerState(cachedValue: T, read: () -> T): T =
+        if (!isReleased && isOnMainThread()) {
+            read()
+        } else {
+            cachedValue
+        }
+
+    private fun createPlayerListener(): Player.Listener = object : Player.Listener {
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            if (isReleased) {
+                return
+            }
+            refreshPlaybackSnapshot()
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    if (isBuffering) {
+                        isBuffering = false
+                    }
+                }
+                Player.STATE_ENDED -> {
+                    if (loop) {
+                        notifyCallback { onLooped() }
+                        suppressNextPlayingForLoop = true
+                        suppressNextPaused = true
+                        player.seekTo(0)
+                        player.play()
+                        refreshPlaybackSnapshot()
+                    } else {
+                        notifyCallback { onEnded() }
+                    }
+                }
+                Player.STATE_BUFFERING -> {
+                    isBuffering = true
+                    val bufferedMs = if (player.bufferedPosition == C.TIME_UNSET) {
+                        player.currentPosition
+                    } else {
+                        player.bufferedPosition
+                    }
+                    notifyCallback { onBuffering(bufferedMs.coerceAtLeast(0)) }
+                }
+            }
+        }
+
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isReleased) {
+                return
+            }
+            refreshPlaybackSnapshot()
+            if (isPlaying) {
+                if (suppressNextPlayingForLoop) {
+                    suppressNextPlayingForLoop = false
+                    return
+                }
+                notifyCallback { onPlaying() }
+            } else {
+                if (suppressNextPaused) {
+                    suppressNextPaused = false
+                } else if (!isExplicitlyStopped && player.playbackState != Player.STATE_ENDED) {
+                    notifyCallback { onPaused() }
+                }
+            }
+        }
+
+        override fun onPlayerError(error: PlaybackException) {
+            if (isReleased) {
+                return
+            }
+            val errorMsg = error.message ?: "Unknown playback error"
+            notifyCallback { onError(error.errorCode, errorMsg) }
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int
+        ) {
+            if (isReleased) {
+                return
+            }
+            if (reason == Player.DISCONTINUITY_REASON_SEEK) {
+                // Seek completed
+            }
+        }
+
+        override fun onRenderedFirstFrame() {
+            if (isReleased) {
+                return
+            }
+            refreshPlaybackSnapshot()
+            if (!hasFiredFirstFrame) {
+                hasFiredFirstFrame = true
+                val durationMs = cachedDurationMs
+                notifyCallback { onFirstFrame(durationMs) }
+            }
+        }
+    }
+
+    init {
+        val audioAttributes = AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
+            .build()
+
+        val renderersFactory = DefaultRenderersFactory(context)
+            .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
+
+        player = ExoPlayer.Builder(context, renderersFactory)
+            .setLooper(mainHandler.looper)
+            .setAudioAttributes(audioAttributes, true)
+            .build()
+
+        runOnMainThread {
+            playerView.player = player
+            playerView.useController = false
+            applyObjectFit()
+            applyVolume()
+            applySpeed()
+            player.addListener(playerListener)
+            refreshPlaybackSnapshot()
+        }
+    }
+
+    fun getPlayerView(): View = playerView
+
+    override fun setSrc(src: String?) {
+        runOnMainThread {
+            currentSrc = src
+            hasFiredFirstFrame = false
+            isExplicitlyStopped = false
+            suppressNextPlayingForLoop = false
+            suppressNextPaused = suppressNextPaused || player.isPlaying
+            player.pause()
+            player.stop()
+            player.clearMediaItems()
+            cachedCurrentPositionMs = 0
+            if (src.isNullOrEmpty()) {
+                refreshPlaybackSnapshot()
+                return@runOnMainThread
+            }
+            val mediaItem = MediaItem.fromUri(src)
+            player.setMediaItem(mediaItem)
+            player.prepare()
+            refreshPlaybackSnapshot()
+        }
+    }
+
+    override fun setLoop(loop: Boolean) {
+        runOnMainThread {
+            this.loop = loop
+            // Always use REPEAT_MODE_OFF and handle looping manually in onPlaybackStateChanged
+            // so that STATE_ENDED fires and we can dispatch onEnded / onLooped events.
+            player.repeatMode = Player.REPEAT_MODE_OFF
+        }
+    }
+
+    override fun setVolume(volume: Float) {
+        runOnMainThread {
+            this.volume = volume.coerceIn(0f, 1f)
+            applyVolume()
+        }
+    }
+
+    override fun setMuted(muted: Boolean) {
+        runOnMainThread {
+            this.muted = muted
+            applyVolume()
+        }
+    }
+
+    private fun applyVolume() {
+        val effectiveVolume = if (muted) 0f else volume
+        player.volume = effectiveVolume
+    }
+
+    override fun setSpeed(speed: Float) {
+        runOnMainThread {
+            this.speed = speed.coerceIn(0.1f, 2.0f)
+            applySpeed()
+        }
+    }
+
+    private fun applySpeed() {
+        player.setPlaybackSpeed(speed)
+    }
+
+    override fun setObjectFit(objectFit: String?) {
+        runOnMainThread {
+            this.objectFit = objectFit
+            applyObjectFit()
+        }
+    }
+
+    private fun applyObjectFit() {
+        playerView.resizeMode = when (objectFit) {
+            "cover" -> AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+            "fill" -> AspectRatioFrameLayout.RESIZE_MODE_FILL
+            else -> AspectRatioFrameLayout.RESIZE_MODE_FIT
+        }
+    }
+
+    override fun play() {
+        runOnMainThread {
+            isExplicitlyStopped = false
+            val src = currentSrc
+            if (player.mediaItemCount == 0 && !src.isNullOrEmpty()) {
+                val mediaItem = MediaItem.fromUri(src)
+                player.setMediaItem(mediaItem)
+                player.prepare()
+            } else if (player.playbackState == Player.STATE_ENDED) {
+                player.seekTo(0)
+            }
+            player.play()
+            refreshPlaybackSnapshot()
+        }
+    }
+
+    override fun pause() {
+        runOnMainThread {
+            player.pause()
+            refreshPlaybackSnapshot()
+        }
+    }
+
+    override fun stop() {
+        runOnMainThread {
+            isExplicitlyStopped = true
+            suppressNextPaused = suppressNextPaused || player.isPlaying
+            player.stop()
+            player.clearMediaItems()
+            cachedCurrentPositionMs = 0
+            refreshPlaybackSnapshot()
+            notifyCallback { onStopped() }
+        }
+    }
+
+    override fun seek(positionMs: Long) {
+        runOnMainThread {
+            val targetPositionMs = positionMs.coerceAtLeast(0)
+            player.seekTo(targetPositionMs)
+            cachedCurrentPositionMs = targetPositionMs
+        }
+    }
+
+    override fun getDuration(): Long =
+        readPlayerState(cachedDurationMs) {
+            player.duration.coerceAtLeast(0).also { cachedDurationMs = it }
+        }
+
+    override fun getCurrentPosition(): Long =
+        readPlayerState(cachedCurrentPositionMs) {
+            player.currentPosition.coerceAtLeast(0).also { cachedCurrentPositionMs = it }
+        }
+
+    override fun isPlaying(): Boolean =
+        readPlayerState(cachedIsPlaying) {
+            (player.isPlaying && player.playbackState != Player.STATE_ENDED).also {
+                cachedIsPlaying = it
+            }
+        }
+
+    override fun setCallback(callback: LynxVideoPlayable.Callback?) {
+        if (callback == null) {
+            this.callback = null
+        }
+        runOnMainThread {
+            this.callback = callback
+        }
+    }
+
+    @Synchronized
+    override fun release() {
+        if (isReleased) {
+            return
+        }
+        isReleased = true
+        callback = null
+        runOnMainThread(allowAfterRelease = true) {
+            player.removeListener(playerListener)
+            playerView.player = null
+            player.clearVideoSurface()
+            player.stop()
+            player.clearMediaItems()
+            player.release()
+        }
+    }
+}

--- a/platform/android/settings.gradle
+++ b/platform/android/settings.gradle
@@ -51,6 +51,8 @@ include ':LynxXElement:BlurView'
 project(":LynxXElement:BlurView").projectDir = new File(rootProject.projectDir, './lynx_xelement/lynx_xelement_blur_view')
 include ':LynxXElement:WebView'
 project(":LynxXElement:WebView").projectDir = new File(rootProject.projectDir, './lynx_xelement/lynx_xelement_webview')
+include ':LynxXElement:Video'
+project(":LynxXElement:Video").projectDir = new File(rootProject.projectDir, './lynx_xelement/lynx_xelement_video')
 
 include ':ServiceAPI'
 project(':ServiceAPI').projectDir = new File(rootProject.projectDir, './service_api')

--- a/platform/specs/lynx_video_element_spec.md
+++ b/platform/specs/lynx_video_element_spec.md
@@ -19,7 +19,7 @@ Lynx needs an open source `<video>` element for video playback. For now, this sp
   - `direct`: Execute immediately without waiting for the callback for previous operation to be dispatched.
   - `latest`: If the callback for previous operation has not been dispatched, keep only the latest pending operation and overwrite earlier pending operations.
   Defaults to `queue`.
-- `timeupdate-interval`: Minimum dispatch interval for the `bindtimeupdate` event, in seconds. Defaults to `0.33`.
+- `timeupdate-interval`: Minimum dispatch interval for the `bindtimeupdate` event, in seconds. Defaults to `0.33`. Values greater than `0` are valid and should be honored as the requested dispatch interval; implementations must not impose a larger positive engineering lower bound on valid values. Values less than or equal to `0` are invalid and should be ignored, keeping the previous valid interval. If no valid interval has been accepted yet, the default interval remains active.
 
 ### UIMethods
 
@@ -34,7 +34,14 @@ Lynx needs an open source `<video>` element for video playback. For now, this sp
 - `bindplaying`: Fired when video playback starts. This fires for the first playback and when playback resumes after a pause. It does not fire again when looping automatically restarts playback from the beginning.
 - `bindpaused`: Fired when video playback pauses.
 - `bindstopped`: Fired only when video playback is stopped by the `stop` method.
-- `bindtimeupdate`: Fired when the playback position updates. Parameters are `current` and `duration`, both in seconds.
+- `bindtimeupdate`: Fired when the playback position updates, aligned with Web `<video>` `timeupdate` semantics. Parameters are `current` and `duration`, both in seconds. The event is driven by playback position changes, not by node lifetime:
+  - It must not fire before playback has actually started.
+  - During normal playback, it may fire repeatedly, throttled by `timeupdate-interval`.
+  - In the steady `paused` state, it must not fire periodically. Entering pause may dispatch one final position update before `bindpaused` if the current position changed.
+  - In the steady `stopped` state, it must not fire periodically. Because Web `<video>` does not define a `stop()` method, Lynx treats `stop` as a playback stop/reset operation; an implementation may dispatch one final position update before `bindstopped` if stopping changes the current position.
+  - Seeking or otherwise changing the playback position while paused may dispatch `bindtimeupdate` for that position change, but must not restart periodic `bindtimeupdate` dispatch unless playback resumes.
+  - When playback reaches the end, an implementation may dispatch the final position update before `bindended`; after `bindended`, it must not dispatch more `bindtimeupdate` events until playback starts again.
+  - Changing `src` or entering an error state stops periodic `bindtimeupdate` dispatch for the previous playback.
 - `bindended`: Fired when video playback fully ends. This does not fire when `loop = true`.
 - `bindlooped`: Fired at the end of each loop iteration. When `loop = true`, it fires each time playback reaches the end and before playback automatically returns to the beginning. It does not fire when `loop = false`.
 - `binderror`: Fired when a video playback error occurs. Parameters are `errorCode` and `errorMsg`. Keep these values as consistent as possible across the three platforms.

--- a/testing/integration_test/demo_pages/pnpm-lock.yaml
+++ b/testing/integration_test/demo_pages/pnpm-lock.yaml
@@ -55,6 +55,23 @@ importers:
       '@lynx-js/rspeedy': 0.9.3
       '@types/react': 18.3.18
       prettier: 3.4.2
+  
+  video:
+    specifiers:
+      '@lynx-js/qrcode-rsbuild-plugin': ^0.3.3
+      '@lynx-js/react': 0.105.0
+      '@lynx-js/react-rsbuild-plugin': 0.9.8
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': ^18.3.2
+      prettier: 3.4.2
+    dependencies:
+      '@lynx-js/react': 0.105.0_@types+react@18.3.18
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin': 0.3.3
+      '@lynx-js/react-rsbuild-plugin': 0.9.8_@lynx-js+react@0.105.0
+      '@lynx-js/rspeedy': 0.9.3
+      '@types/react': 18.3.18
+      prettier: 3.4.2
 
 packages:
 
@@ -562,6 +579,7 @@ packages:
     resolution: {integrity: sha512-xleG9XJp6BoURNhSrbz9Wnig2I3xQxKj3Sk/MynPYXMGVBF9wUbgUpvrdIlm5wenwxGpLftpPdXkI9bkf6+5JQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -570,6 +588,7 @@ packages:
     resolution: {integrity: sha512-P27mxcL0cu5wBDFjoQrvRIpisraoA+hmVuOoeCvC/FT7aUIfLNzt94eCLZqAtZ7J7kNFoDXgJwCx3gAf1D0JdA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -578,6 +597,7 @@ packages:
     resolution: {integrity: sha512-vDXC/29U26uYaSNJ9wttdykz+VPU6qbpBMHjS6aQWtp3kUYnI3w11f4HvzZYr9c1UbfQBFemljBuz/3elQPrNQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
@@ -586,6 +606,7 @@ packages:
     resolution: {integrity: sha512-utNCoMVmveoGxVuswugsKpyToP5wAk/8tN5CiuWgNsnYc8szFfXEENJet1x1YmxB8C+TqqbiNpsgwba5ckNFdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
@@ -910,7 +931,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001715
       electron-to-chromium: 1.5.109
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3_browserslist@4.24.4
@@ -951,13 +972,9 @@ packages:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.24.4
-      caniuse-lite: 1.0.30001692
+      caniuse-lite: 1.0.30001715
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
-    dev: true
-
-  /caniuse-lite/1.0.30001692:
-    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
     dev: true
 
   /caniuse-lite/1.0.30001715:

--- a/testing/integration_test/demo_pages/pnpm-workspace.yaml
+++ b/testing/integration_test/demo_pages/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'dom-focus'
   - 'event'
   - 'input_insert_text'
+  - 'video'

--- a/testing/integration_test/demo_pages/video/index.css
+++ b/testing/integration_test/demo_pages/video/index.css
@@ -1,0 +1,72 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  background-color: #f5f5f5;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 12px;
+  text-align: center;
+}
+
+.video {
+  width: 100%;
+  height: 180px;
+  background-color: #000000;
+  margin-bottom: 8px;
+}
+
+.status {
+  font-size: 14px;
+  text-align: center;
+  margin-bottom: 6px;
+  color: #333;
+}
+
+.time {
+  font-size: 12px;
+  text-align: center;
+  margin-bottom: 6px;
+  color: #666;
+}
+
+.controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  margin-bottom: 8px;
+}
+
+.button {
+  background-color: #007aff;
+  padding: 6px 8px;
+  border-radius: 4px;
+  min-width: 76px;
+  align-items: center;
+}
+
+.button text {
+  color: #fff;
+  font-size: 12px;
+}
+
+.log {
+  font-size: 12px;
+  color: #666;
+  margin-top: 6px;
+  padding: 6px;
+  background-color: #eee;
+  border-radius: 4px;
+}
+
+.result {
+  font-size: 14px;
+  text-align: center;
+  margin-top: 8px;
+  padding: 6px;
+  background-color: #e0ffe0;
+  border-radius: 4px;
+}

--- a/testing/integration_test/demo_pages/video/index.tsx
+++ b/testing/integration_test/demo_pages/video/index.tsx
@@ -1,0 +1,660 @@
+import { useState, useCallback, useRef } from '@lynx-js/react';
+import { root } from '@lynx-js/react';
+import './index.css';
+
+const PRIMARY_VIDEO_URL = 'https://www.w3schools.com/html/mov_bbb.mp4';
+const SECONDARY_VIDEO_URL =
+  'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4';
+const INVALID_VIDEO_URL = 'https://www.w3schools.com/html/not-found-video.mp4';
+
+type EventName =
+  | 'firstframe'
+  | 'playing'
+  | 'paused'
+  | 'stopped'
+  | 'timeupdate'
+  | 'ended'
+  | 'looped'
+  | 'error'
+  | 'buffering';
+
+type EventCounts = Record<EventName, number>;
+
+const createEventCounts = (): EventCounts => ({
+  firstframe: 0,
+  playing: 0,
+  paused: 0,
+  stopped: 0,
+  timeupdate: 0,
+  ended: 0,
+  looped: 0,
+  error: 0,
+  buffering: 0,
+});
+
+export function VideoDemo() {
+  const [src, setSrc] = useState(PRIMARY_VIDEO_URL);
+  const [srcLabel, setSrcLabel] = useState('primary');
+  const [status, setStatus] = useState('ready');
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [eventLog, setEventLog] = useState<string[]>([]);
+  const [callbackLog, setCallbackLog] = useState<string[]>([]);
+  const [signalLog, setSignalLog] = useState<string[]>([]);
+  const [eventCounts, setEventCounts] = useState<EventCounts>(
+    createEventCounts()
+  );
+  const [loop, setLoop] = useState(false);
+  const [volume, setVolume] = useState(1);
+  const [muted, setMuted] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const [objectFit, setObjectFit] = useState('contain');
+  const [mode, setMode] = useState('queue');
+  const [timeUpdateInterval, setTimeUpdateInterval] = useState(0.5);
+  const [loopedSeen, setLoopedSeen] = useState(false);
+  const [firstFrameDuration, setFirstFrameDuration] = useState(0);
+  const [lastError, setLastError] = useState('none');
+  const [lastBuffering, setLastBuffering] = useState(0);
+  const [minTimeUpdateDelta, setMinTimeUpdateDelta] = useState(0);
+  const lastTimeUpdateMs = useRef(0);
+
+  const appendLog = useCallback(
+    (
+      setter: (updater: (prev: string[]) => string[]) => void,
+      entry: string
+    ) => {
+      setter((prev) => [...prev.slice(-19), entry]);
+    },
+    []
+  );
+
+  const pushEvent = useCallback(
+    (name: EventName, detail?: string) => {
+      setEventCounts((prev) => ({
+        ...prev,
+        [name]: prev[name] + 1,
+      }));
+      appendLog(setEventLog, `${name}${detail ? ':' + detail : ''}`);
+      if (name !== 'timeupdate' && name !== 'buffering') {
+        appendLog(setSignalLog, `event:${name}`);
+      }
+    },
+    [appendLog]
+  );
+
+  const pushCallback = useCallback(
+    (name: string, detail?: string) => {
+      appendLog(setCallbackLog, `${name}${detail ? ':' + detail : ''}`);
+      appendLog(setSignalLog, `callback:${name}${detail ? ':' + detail : ''}`);
+    },
+    [appendLog]
+  );
+
+  const clearSignals = useCallback(() => {
+    setEventCounts(createEventCounts());
+    setEventLog([]);
+    setCallbackLog([]);
+    setSignalLog([]);
+    setLoopedSeen(false);
+    setLastError('none');
+    setLastBuffering(0);
+    setMinTimeUpdateDelta(0);
+    lastTimeUpdateMs.current = 0;
+  }, []);
+
+  const handleFirstFrame = (e: any) => {
+    const eventDuration = e.detail.duration || 0;
+    setDuration(eventDuration);
+    setFirstFrameDuration(eventDuration);
+    pushEvent('firstframe', eventDuration.toFixed(1));
+    setStatus('ready');
+  };
+
+  const handlePlaying = () => {
+    pushEvent('playing');
+    setStatus('playing');
+  };
+
+  const handlePaused = () => {
+    pushEvent('paused');
+    setStatus('paused');
+  };
+
+  const handleStopped = () => {
+    pushEvent('stopped');
+    setStatus('stopped');
+    setCurrentTime(0);
+  };
+
+  const handleTimeUpdate = (e: any) => {
+    const current = e.detail.current || 0;
+    const eventDuration = e.detail.duration || 0;
+    const now = Date.now();
+    if (lastTimeUpdateMs.current > 0) {
+      const delta = now - lastTimeUpdateMs.current;
+      setMinTimeUpdateDelta((prev) =>
+        prev === 0 ? delta : Math.min(prev, delta)
+      );
+    }
+    lastTimeUpdateMs.current = now;
+    setCurrentTime(current);
+    setDuration(eventDuration);
+    pushEvent('timeupdate', current.toFixed(1));
+  };
+
+  const handleEnded = () => {
+    pushEvent('ended');
+    setStatus('ended');
+  };
+
+  const handleLooped = () => {
+    setLoopedSeen(true);
+    pushEvent('looped');
+  };
+
+  const handleError = (e: any) => {
+    const code = e.detail.errorCode;
+    const msg = e.detail.errorMsg || 'unknown';
+    setLastError(`${code}:${msg}`);
+    pushEvent('error', `${code}`);
+    setStatus('error');
+  };
+
+  const handleBuffering = (e: any) => {
+    const buffering = e.detail.buffering || 0;
+    setLastBuffering(buffering);
+    pushEvent('buffering', buffering.toFixed(1));
+  };
+
+  const formatCallbackResult = (result: any) => {
+    if (result == null) {
+      return 'empty';
+    }
+    const payload =
+      typeof result === 'object' && result !== null && result.data
+        ? result.data
+        : result;
+    if (payload == null) {
+      return 'empty';
+    }
+    if (typeof payload !== 'object') {
+      return `${payload}`;
+    }
+    const parts = [];
+    if (typeof payload.success !== 'undefined') {
+      parts.push(`success=${payload.success}`);
+    }
+    if (typeof payload.errorCode !== 'undefined') {
+      parts.push(`errorCode=${payload.errorCode}`);
+    }
+    if (typeof payload.msg !== 'undefined') {
+      parts.push(`msg=${payload.msg}`);
+    }
+    if (parts.length > 0) {
+      return parts.join(',');
+    }
+    try {
+      return JSON.stringify(payload);
+    } catch {
+      return `${payload}`;
+    }
+  };
+
+  const invokeMethod = (method: string, params?: object | null) => {
+    lynx
+      .createSelectorQuery()
+      .select('#test-video')
+      .invoke({
+        method,
+        params: params === undefined ? {} : params,
+        success: (res: any) =>
+          pushCallback(`${method}_ok`, formatCallbackResult(res)),
+        fail: (err: any) =>
+          pushCallback(`${method}_fail`, formatCallbackResult(err)),
+      })
+      .exec();
+  };
+
+  const invokeBurst = (methods: Array<[string, object?]>) => {
+    clearSignals();
+    setTimeout(() => {
+      methods.forEach(([method, params]) => invokeMethod(method, params));
+    }, 0);
+  };
+
+  const selectSource = (label: string, url: string) => {
+    clearSignals();
+    setSrcLabel(label);
+    setSrc(url);
+    setStatus(label === 'empty' ? 'empty' : 'loading');
+    setCurrentTime(0);
+    setDuration(0);
+    setFirstFrameDuration(0);
+  };
+
+  const playThenSelectSource = (label: string, url: string) => {
+    clearSignals();
+    setTimeout(() => {
+      invokeMethod('play');
+      setSrcLabel(label);
+      setSrc(url);
+      setStatus(label === 'empty' ? 'empty' : 'loading');
+      setCurrentTime(0);
+      setDuration(0);
+      setFirstFrameDuration(0);
+    }, 0);
+  };
+
+  const playPauseThenSelectSource = (label: string, url: string) => {
+    clearSignals();
+    setTimeout(() => {
+      invokeMethod('play');
+      invokeMethod('pause');
+      setSrcLabel(label);
+      setSrc(url);
+      setStatus(label === 'empty' ? 'empty' : 'loading');
+      setCurrentTime(0);
+      setDuration(0);
+      setFirstFrameDuration(0);
+    }, 0);
+  };
+
+  const attrState =
+    `src=${srcLabel};loop=${loop};volume=${volume.toFixed(1)};` +
+    `muted=${muted};speed=${speed.toFixed(1)};fit=${objectFit};` +
+    `mode=${mode};requestedInterval=${timeUpdateInterval.toFixed(1)}`;
+
+  return (
+    <scroll-view className="root" scroll-y>
+      <text className="title">Video E2E Demo</text>
+
+      <video
+        id="test-video"
+        lynx-test-tag="test-video"
+        className="video"
+        src={src}
+        loop={loop}
+        volume={volume}
+        muted={muted}
+        speed={speed}
+        object-fit={objectFit}
+        mode={mode}
+        timeupdate-interval={timeUpdateInterval}
+        bindfirstframe={handleFirstFrame}
+        bindplaying={handlePlaying}
+        bindpaused={handlePaused}
+        bindstopped={handleStopped}
+        bindtimeupdate={handleTimeUpdate}
+        bindended={handleEnded}
+        bindlooped={handleLooped}
+        binderror={handleError}
+        bindbuffering={handleBuffering}
+      />
+
+      <text lynx-test-tag="status-text" className="status">
+        {status}
+      </text>
+
+      <text lynx-test-tag="attr-state" className="status">
+        {attrState}
+      </text>
+
+      <text lynx-test-tag="interval-state" className="time">
+        {timeUpdateInterval.toFixed(3)}
+      </text>
+
+      <text lynx-test-tag="time-text" className="time">
+        {currentTime.toFixed(1)} / {duration.toFixed(1)}
+      </text>
+
+      <text lynx-test-tag="firstframe-duration" className="time">
+        {firstFrameDuration.toFixed(1)}
+      </text>
+
+      <text lynx-test-tag="last-error" className="time">
+        {lastError}
+      </text>
+
+      <text lynx-test-tag="last-buffering" className="time">
+        {lastBuffering.toFixed(1)}
+      </text>
+
+      <text lynx-test-tag="min-timeupdate-delta" className="time">
+        {minTimeUpdateDelta}
+      </text>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-clear-signals"
+          className="button"
+          bindtap={clearSignals}
+        >
+          <text>Clear</text>
+        </view>
+        <view
+          lynx-test-tag="btn-play"
+          className="button"
+          bindtap={() => invokeMethod('play')}
+        >
+          <text>Play</text>
+        </view>
+        <view
+          lynx-test-tag="btn-play-null-params"
+          className="button"
+          bindtap={() => invokeMethod('play', null)}
+        >
+          <text>Play Null</text>
+        </view>
+        <view
+          lynx-test-tag="btn-pause"
+          className="button"
+          bindtap={() => invokeMethod('pause')}
+        >
+          <text>Pause</text>
+        </view>
+        <view
+          lynx-test-tag="btn-stop"
+          className="button"
+          bindtap={() => invokeMethod('stop')}
+        >
+          <text>Stop</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-seek-start"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: 0 })}
+        >
+          <text>Seek 0s</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: 2 })}
+        >
+          <text>Seek 2s</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-near-end"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: 9.5 })}
+        >
+          <text>Near End</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-out-of-range"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: 99 })}
+        >
+          <text>Seek Bad</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-missing-position"
+          className="button"
+          bindtap={() => invokeMethod('seek')}
+        >
+          <text>Seek Missing</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-null-params"
+          className="button"
+          bindtap={() => invokeMethod('seek', null)}
+        >
+          <text>Seek Null</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-string-position"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: 'bad' })}
+        >
+          <text>Seek Text</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-src-primary"
+          className="button"
+          bindtap={() => selectSource('primary', PRIMARY_VIDEO_URL)}
+        >
+          <text>Src A</text>
+        </view>
+        <view
+          lynx-test-tag="btn-src-secondary"
+          className="button"
+          bindtap={() => selectSource('secondary', SECONDARY_VIDEO_URL)}
+        >
+          <text>Src B</text>
+        </view>
+        <view
+          lynx-test-tag="btn-src-invalid"
+          className="button"
+          bindtap={() => selectSource('invalid', INVALID_VIDEO_URL)}
+        >
+          <text>Src Bad</text>
+        </view>
+        <view
+          lynx-test-tag="btn-src-empty"
+          className="button"
+          bindtap={() => selectSource('empty', '')}
+        >
+          <text>Src Empty</text>
+        </view>
+        <view
+          lynx-test-tag="btn-play-then-src-empty"
+          className="button"
+          bindtap={() => playThenSelectSource('empty', '')}
+        >
+          <text>Play Empty</text>
+        </view>
+        <view
+          lynx-test-tag="btn-play-pause-then-src-empty"
+          className="button"
+          bindtap={() => playPauseThenSelectSource('empty', '')}
+        >
+          <text>Play Pause Empty</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-loop-on"
+          className="button"
+          bindtap={() => setLoop(true)}
+        >
+          <text>Loop On</text>
+        </view>
+        <view
+          lynx-test-tag="btn-loop-off"
+          className="button"
+          bindtap={() => setLoop(false)}
+        >
+          <text>Loop Off</text>
+        </view>
+        <view
+          lynx-test-tag="btn-muted-on"
+          className="button"
+          bindtap={() => setMuted(true)}
+        >
+          <text>Mute</text>
+        </view>
+        <view
+          lynx-test-tag="btn-muted-off"
+          className="button"
+          bindtap={() => setMuted(false)}
+        >
+          <text>Unmute</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-volume-low"
+          className="button"
+          bindtap={() => setVolume(0.3)}
+        >
+          <text>Vol 0.3</text>
+        </view>
+        <view
+          lynx-test-tag="btn-volume-high"
+          className="button"
+          bindtap={() => setVolume(1)}
+        >
+          <text>Vol 1</text>
+        </view>
+        <view
+          lynx-test-tag="btn-speed-half"
+          className="button"
+          bindtap={() => setSpeed(0.5)}
+        >
+          <text>0.5x</text>
+        </view>
+        <view
+          lynx-test-tag="btn-speed-normal"
+          className="button"
+          bindtap={() => setSpeed(1)}
+        >
+          <text>1x</text>
+        </view>
+        <view
+          lynx-test-tag="btn-speed-double"
+          className="button"
+          bindtap={() => setSpeed(2)}
+        >
+          <text>2x</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-object-contain"
+          className="button"
+          bindtap={() => setObjectFit('contain')}
+        >
+          <text>Contain</text>
+        </view>
+        <view
+          lynx-test-tag="btn-object-cover"
+          className="button"
+          bindtap={() => setObjectFit('cover')}
+        >
+          <text>Cover</text>
+        </view>
+        <view
+          lynx-test-tag="btn-object-fill"
+          className="button"
+          bindtap={() => setObjectFit('fill')}
+        >
+          <text>Fill</text>
+        </view>
+        <view
+          lynx-test-tag="btn-timeupdate-slow"
+          className="button"
+          bindtap={() => setTimeUpdateInterval(1)}
+        >
+          <text>1s Tick</text>
+        </view>
+        <view
+          lynx-test-tag="btn-timeupdate-zero"
+          className="button"
+          bindtap={() => setTimeUpdateInterval(0)}
+        >
+          <text>Invalid 0s</text>
+        </view>
+        <view
+          lynx-test-tag="btn-timeupdate-fast"
+          className="button"
+          bindtap={() => setTimeUpdateInterval(0.001)}
+        >
+          <text>Fast Tick</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-mode-queue"
+          className="button"
+          bindtap={() => setMode('queue')}
+        >
+          <text>Queue</text>
+        </view>
+        <view
+          lynx-test-tag="btn-mode-direct"
+          className="button"
+          bindtap={() => setMode('direct')}
+        >
+          <text>Direct</text>
+        </view>
+        <view
+          lynx-test-tag="btn-mode-latest"
+          className="button"
+          bindtap={() => setMode('latest')}
+        >
+          <text>Latest</text>
+        </view>
+        <view
+          lynx-test-tag="btn-burst-play-stop"
+          className="button"
+          bindtap={() => invokeBurst([['play'], ['stop']])}
+        >
+          <text>Play Stop</text>
+        </view>
+      </view>
+
+      <view className="controls">
+        <view
+          lynx-test-tag="btn-burst-play-pause-stop"
+          className="button"
+          bindtap={() => invokeBurst([['play'], ['pause'], ['stop']])}
+        >
+          <text>Play Pause Stop</text>
+        </view>
+        <view
+          lynx-test-tag="btn-method-unknown"
+          className="button"
+          bindtap={() => invokeMethod('unknownVideoMethod')}
+        >
+          <text>Unknown</text>
+        </view>
+      </view>
+
+      <text lynx-test-tag="event-counts" className="log">
+        {`firstframe=${eventCounts.firstframe};playing=${eventCounts.playing};` +
+          `paused=${eventCounts.paused};stopped=${eventCounts.stopped};` +
+          `timeupdate=${eventCounts.timeupdate};ended=${eventCounts.ended};` +
+          `looped=${eventCounts.looped};error=${eventCounts.error};` +
+          `buffering=${eventCounts.buffering}`}
+      </text>
+
+      <text lynx-test-tag="event-log" className="log">
+        {eventLog.join(' | ')}
+      </text>
+
+      <text lynx-test-tag="callback-log" className="log">
+        {callbackLog.join(' | ')}
+      </text>
+
+      <text lynx-test-tag="signal-log" className="log">
+        {signalLog.join(' | ')}
+      </text>
+
+      <text lynx-test-tag="looped-state" className="result">
+        {loopedSeen ? 'looped' : 'pending'}
+      </text>
+
+      <text lynx-test-tag="auto-result" className="result">
+        {status === 'playing' ||
+        status === 'paused' ||
+        status === 'ended' ||
+        status === 'stopped' ||
+        status === 'error'
+          ? 'success'
+          : 'pending'}
+      </text>
+    </scroll-view>
+  );
+}
+
+root.render(<VideoDemo />);

--- a/testing/integration_test/demo_pages/video/lynx.config.mjs
+++ b/testing/integration_test/demo_pages/video/lynx.config.mjs
@@ -1,0 +1,13 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from "@lynx-js/rspeedy";
+import { pluginReactLynx } from "@lynx-js/react-rsbuild-plugin";
+import { pluginQRCode } from "@lynx-js/qrcode-rsbuild-plugin";
+export default defineConfig({
+  source: {
+    entry: "./index.tsx",
+  },
+  plugins: [pluginReactLynx(), pluginQRCode()],
+});

--- a/testing/integration_test/demo_pages/video/package.json
+++ b/testing/integration_test/demo_pages/video/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@demo_pages/video",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "rspeedy build",
+    "build:dev": "rspeedy build --mode=development",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "@lynx-js/react": "0.105.0"
+  },
+  "devDependencies": {
+    "@lynx-js/react-rsbuild-plugin": "0.9.8",
+    "@lynx-js/rspeedy": "0.9.3",
+    "@types/react": "^18.3.2",
+    "prettier": "3.4.2",
+    "@lynx-js/qrcode-rsbuild-plugin": "^0.3.3"
+  }
+}

--- a/testing/integration_test/test_script/android_test/xelement.py
+++ b/testing/integration_test/test_script/android_test/xelement.py
@@ -1,0 +1,27 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+search_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(search_path)
+
+from lib.android.test import LynxTest
+from case_sets.xelement.runner import run
+
+
+class xelementTest(LynxTest):
+    timeout = 1800
+
+    def run_test(self, test=None):
+        if test is None:
+            test = self
+        test.start_step("--------Test: start to test xelement;-------")
+        run(test=test)
+
+
+if __name__ == "__main__":
+    xelementTest.debug_run()

--- a/testing/integration_test/test_script/case_sets/xelement/VideoAttributes.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoAttributes.py
@@ -1,0 +1,129 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+from case_sets.xelement import video_utils
+
+config = {
+    "type": "custom",
+    "path": "automation/video/main",
+    "platform": "android",
+}
+
+
+def run(test):
+    lynxview = video_utils.get_lynxview(test)
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready")
+
+    test.start_step("--------Test1: Test volume and muted attrs;-------")
+    video_utils.click(lynxview, "btn-volume-low")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "volume=0.3")
+    video_utils.click(lynxview, "btn-muted-on")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "muted=true")
+    video_utils.click(lynxview, "btn-muted-off")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "muted=false")
+    video_utils.click(lynxview, "btn-volume-high")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "volume=1.0")
+
+    test.start_step("--------Test2: Test object-fit attrs with screenshots;-------")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    video_utils.click(lynxview, "btn-object-contain")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "fit=contain")
+    video_utils.capture_screenshot(test, lynxview, "fit_contain")
+    video_utils.click(lynxview, "btn-object-cover")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "fit=cover")
+    video_utils.capture_screenshot(test, lynxview, "fit_cover")
+    video_utils.click(lynxview, "btn-object-fill")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "fit=fill")
+    video_utils.capture_screenshot(test, lynxview, "fit_fill")
+
+    test.start_step("--------Test3: Test speed attr affects playback progress;-------")
+    video_utils.click(lynxview, "btn-pause")
+    video_utils.wait_for_text(test, lynxview, "status-text", "paused")
+    video_utils.click(lynxview, "btn-speed-half")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "speed=0.5")
+    video_utils.click(lynxview, "btn-seek-start")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    time.sleep(2.5)
+    slow_time = video_utils.parse_current_time(
+        video_utils.get_text(lynxview, "time-text"))
+
+    video_utils.click(lynxview, "btn-pause")
+    video_utils.wait_for_text(test, lynxview, "status-text", "paused")
+    video_utils.click(lynxview, "btn-speed-double")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "speed=2.0")
+    video_utils.click(lynxview, "btn-seek-start")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    time.sleep(2.5)
+    fast_time = video_utils.parse_current_time(
+        video_utils.get_text(lynxview, "time-text"))
+    if fast_time < 3.0 or fast_time <= slow_time + 1.5:
+        raise AssertionError("speed=2.0 should advance faster than speed=0.5; "
+                             "slow=%s fast=%s" % (slow_time, fast_time))
+
+    test.start_step("--------Test4: Test timeupdate interval attr;-------")
+    video_utils.click(lynxview, "btn-pause")
+    video_utils.wait_for_text(test, lynxview, "status-text", "paused")
+    video_utils.click(lynxview, "btn-speed-normal")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "speed=1.0")
+    video_utils.click(lynxview, "btn-timeupdate-slow")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "requestedInterval=1.0")
+    video_utils.click(lynxview, "btn-seek-start")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    video_utils.wait_for_count_at_least(test, lynxview, "timeupdate", 3,
+                                        timeout=8)
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "min-timeupdate-delta",
+        lambda text: float(text) >= 0.85,
+        "timeupdate interval should be close to 1 second",
+        timeout=3,
+    )
+
+    test.start_step("--------Test5: Test invalid timeupdate interval keeps previous valid value;-------")
+    video_utils.click(lynxview, "btn-pause")
+    video_utils.wait_for_text(test, lynxview, "status-text", "paused")
+    video_utils.click(lynxview, "btn-timeupdate-zero")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "requestedInterval=0.0")
+    video_utils.click(lynxview, "btn-seek-start")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    time.sleep(4.2)
+    video_utils.assert_count_at_most(lynxview, "timeupdate", 5)
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "min-timeupdate-delta",
+        lambda text: float(text) >= 0.85,
+        "invalid timeupdate interval should keep the previous valid interval",
+        timeout=3,
+    )
+
+    test.start_step("--------Test6: Test tiny positive timeupdate interval is accepted;-------")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.click(lynxview, "btn-timeupdate-fast")
+    video_utils.wait_for_text(test, lynxview, "interval-state", "0.001")
+    video_utils.click(lynxview, "btn-seek-start")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    time.sleep(1.2)
+    fast_count = video_utils.parse_count(
+        video_utils.get_text(lynxview, "event-counts"), "timeupdate")
+    if fast_count < 30:
+        raise AssertionError("tiny positive timeupdate interval should not be "
+                             "clamped to a large engineering lower bound; "
+                             "count=%s" % fast_count)

--- a/testing/integration_test/test_script/case_sets/xelement/VideoBasic.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoBasic.py
@@ -1,0 +1,151 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+from case_sets.xelement import video_utils
+
+config = {
+    "type": "custom",
+    "path": "automation/video/main",
+    "platform": "android",
+}
+
+
+def run(test):
+    lynxview = video_utils.get_lynxview(test)
+
+    test.start_step("--------Test1: Wait for video ready;-------")
+    status_view = lynxview.get_by_test_tag("status-text")
+    test.wait_for_equal("Video not ready", status_view, "text", "ready")
+    video_utils.wait_for_count_at_least(test, lynxview, "firstframe", 1)
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "firstframe-duration",
+        lambda text: float(text) > 0,
+        "firstframe duration should be reported",
+    )
+    video_utils.click(lynxview, "btn-clear-signals")
+    time.sleep(1.2)
+    video_utils.assert_count_equals(lynxview, "timeupdate", 0)
+    time.sleep(2)
+    video_utils.capture_screenshot(test, lynxview, "ready")
+
+    test.start_step("--------Test2: Test play;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    test.wait_for_equal("Play failed", status_view, "text", "playing")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "play_ok")
+    video_utils.wait_for_count_at_least(test, lynxview, "playing", 1)
+    video_utils.wait_for_count_at_least(test, lynxview, "timeupdate", 1)
+    time.sleep(3)
+
+    test.start_step("--------Test3: Test pause;-------")
+    video_utils.click(lynxview, "btn-pause")
+    test.wait_for_equal("Pause failed", status_view, "text", "paused")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "pause_ok")
+    video_utils.wait_for_count_at_least(test, lynxview, "paused", 1)
+    video_utils.click(lynxview, "btn-clear-signals")
+    time.sleep(1.2)
+    video_utils.assert_count_equals(lynxview, "timeupdate", 0)
+    time.sleep(2)
+
+    test.start_step("--------Test4: Test seek;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "seek_ok")
+    time.sleep(1.2)
+    video_utils.assert_count_equals(lynxview, "timeupdate", 0)
+    video_utils.click(lynxview, "btn-play")
+    test.wait_for_equal("Play after seek failed", status_view, "text",
+                        "playing")
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "time-text",
+        lambda text: 2 <= video_utils.parse_current_time(text) < 6,
+        "play after seek should continue from seek position",
+        timeout=5,
+    )
+
+    test.start_step("--------Test5: Test stop;-------")
+    video_utils.click(lynxview, "btn-stop")
+    test.wait_for_equal("Stop failed", status_view, "text", "stopped")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "stop_ok")
+    video_utils.wait_for_count_at_least(test, lynxview, "stopped", 1)
+    video_utils.click(lynxview, "btn-clear-signals")
+    time.sleep(1.2)
+    video_utils.assert_count_equals(lynxview, "timeupdate", 0)
+    time.sleep(2)
+    video_utils.capture_screenshot(test, lynxview, "stopped")
+
+    test.start_step("--------Test6: Test play after stop;-------")
+    video_utils.click(lynxview, "btn-play")
+    test.wait_for_equal("Play after stop failed", status_view, "text", "playing")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "play_ok")
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "time-text",
+        lambda text: 0 < video_utils.parse_current_time(text) < 5,
+        "play after stop should restart from the beginning",
+        timeout=5,
+    )
+    time.sleep(2)
+
+    test.start_step("--------Test7: Test play after ended;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-near-end")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "seek_ok")
+    test.wait_for_equal("Video did not reach ended state", status_view, "text",
+                        "ended", timeout=8)
+    video_utils.wait_for_count_at_least(test, lynxview, "ended", 1)
+    video_utils.assert_count_equals(lynxview, "looped", 0)
+    video_utils.click(lynxview, "btn-clear-signals")
+    time.sleep(1.2)
+    video_utils.assert_count_equals(lynxview, "timeupdate", 0)
+    video_utils.click(lynxview, "btn-play")
+    test.wait_for_equal("Play after ended failed", status_view, "text",
+                        "playing", timeout=5)
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "play_ok")
+    video_utils.wait_for_count_at_least(test, lynxview, "playing", 1)
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "time-text",
+        lambda text: 0 < video_utils.parse_current_time(text) < 5,
+        "play after ended should restart from the beginning",
+        timeout=5,
+    )
+    time.sleep(2)
+
+    test.start_step("--------Test8: Test loop on;-------")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-loop-on")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "loop=true")
+    time.sleep(1)
+
+    test.start_step("--------Test9: Test play to end with loop;-------")
+    video_utils.click(lynxview, "btn-play")
+    test.wait_for_equal("Loop play failed", status_view, "text", "playing")
+    video_utils.click(lynxview, "btn-seek-near-end")
+    looped_state = lynxview.get_by_test_tag("looped-state")
+    test.wait_for_equal("Loop event not observed", looped_state, "text",
+                        "looped", timeout=15)
+    video_utils.wait_for_count_at_least(test, lynxview, "looped", 1)
+    video_utils.assert_count_equals(lynxview, "ended", 0)
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "time-text",
+        lambda text: 0 < video_utils.parse_current_time(text) < 5,
+        "loop playback should continue from the beginning",
+        timeout=5,
+    )
+    video_utils.capture_screenshot(test, lynxview, "loop")

--- a/testing/integration_test/test_script/case_sets/xelement/VideoBoundary.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoBoundary.py
@@ -1,0 +1,147 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import time
+
+from case_sets.xelement import video_utils
+
+
+def assert_failed_callback(lynxview, method, msg=None):
+    video_utils.assert_text_contains(lynxview, "callback-log",
+                                     "%s_fail" % method)
+    video_utils.assert_text_contains(lynxview, "callback-log",
+                                     "success=false")
+    video_utils.assert_text_contains(lynxview, "callback-log",
+                                     "errorCode=")
+    if msg:
+        video_utils.assert_text_contains(lynxview, "callback-log",
+                                         "msg=%s" % msg)
+
+
+def assert_bridge_failed_callback(lynxview, method, code):
+    video_utils.assert_text_contains(lynxview, "callback-log",
+                                     "%s_fail" % method)
+    video_utils.assert_text_contains(lynxview, "callback-log",
+                                     '"code":%s' % code)
+
+
+config = {
+    "type": "custom",
+    "path": "automation/video/main",
+    "platform": "android",
+}
+
+
+def run(test):
+    lynxview = video_utils.get_lynxview(test)
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready")
+
+    test.start_step("--------Test1: Switching src stops previous playback;-------")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    video_utils.click(lynxview, "btn-src-secondary")
+    video_utils.wait_for_count_at_least(test, lynxview, "buffering", 1,
+                                        timeout=10)
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready",
+                              timeout=20)
+    video_utils.wait_for_contains(test, lynxview, "attr-state",
+                                  "src=secondary")
+    video_utils.wait_for_count_at_least(test, lynxview, "firstframe", 1)
+    video_utils.capture_screenshot(test, lynxview, "src_secondary")
+
+    test.start_step("--------Test2: Invalid src dispatches error;-------")
+    video_utils.click(lynxview, "btn-src-invalid")
+    video_utils.wait_for_text(test, lynxview, "status-text", "error",
+                              timeout=20)
+    video_utils.wait_for_count_at_least(test, lynxview, "error", 1)
+    video_utils.wait_until(
+        test,
+        lynxview,
+        "last-error",
+        lambda text: text != "none" and ":" in text,
+        "invalid src should report error details",
+    )
+
+    test.start_step("--------Test3: Empty src makes play callback fail;-------")
+    video_utils.click(lynxview, "btn-src-empty")
+    video_utils.wait_for_text(test, lynxview, "status-text", "empty")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play")
+    video_utils.wait_for_text(test, lynxview, "status-text", "error")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "play_fail")
+    assert_failed_callback(lynxview, "play", "missing video source")
+    video_utils.wait_for_count_at_least(test, lynxview, "error", 1)
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "stop_ok")
+
+    test.start_step(
+        "--------Test4: Src switch cancels in-flight serial method;-------")
+    video_utils.click(lynxview, "btn-src-primary")
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready",
+                              timeout=20)
+    video_utils.click(lynxview, "btn-mode-queue")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "mode=queue")
+    video_utils.click(lynxview, "btn-play-pause-then-src-empty")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "play_fail", timeout=10)
+    assert_failed_callback(lynxview, "play",
+                           "request canceled by src change")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "pause_fail", timeout=10)
+    assert_failed_callback(lynxview, "pause",
+                           "request canceled by src change")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "stop_ok")
+
+    test.start_step("--------Test5: Seek failure callbacks;-------")
+    video_utils.click(lynxview, "btn-src-primary")
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready",
+                              timeout=20)
+    time.sleep(1)
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-out-of-range")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "position out of range")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-missing-position")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "missing position param")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-null-params")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "missing position param")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-string-position")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek",
+                           "position param must be a number")
+
+    test.start_step(
+        "--------Test6: Null params and unknown method callbacks;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-play-null-params")
+    video_utils.wait_for_text(test, lynxview, "status-text", "playing")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "play_ok")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "success=true")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-method-unknown")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "unknownVideoMethod_fail")
+    assert_bridge_failed_callback(lynxview, "unknownVideoMethod", 3)

--- a/testing/integration_test/test_script/case_sets/xelement/VideoModes.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoModes.py
@@ -1,0 +1,73 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+from case_sets.xelement import video_utils
+
+config = {
+    "type": "custom",
+    "path": "automation/video/main",
+    "platform": "android",
+}
+
+
+def run(test):
+    lynxview = video_utils.get_lynxview(test)
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready")
+
+    test.start_step("--------Test1: Queue mode executes all operations in order;-------")
+    video_utils.click(lynxview, "btn-mode-queue")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "mode=queue")
+    video_utils.click(lynxview, "btn-burst-play-pause-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped",
+                              timeout=15)
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "stop_ok")
+    video_utils.assert_text_order(
+        lynxview,
+        "callback-log",
+        ["play_ok", "pause_ok", "stop_ok"],
+    )
+    video_utils.assert_text_order(
+        lynxview,
+        "signal-log",
+        [
+            "event:playing",
+            "callback:play_ok",
+            "event:paused",
+            "callback:pause_ok",
+            "event:stopped",
+            "callback:stop_ok",
+        ],
+    )
+
+    test.start_step("--------Test2: Latest mode keeps only latest pending operation;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-mode-latest")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "mode=latest")
+    video_utils.click(lynxview, "btn-burst-play-pause-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped",
+                              timeout=15)
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "stop_ok")
+    video_utils.assert_text_not_contains(lynxview, "callback-log", "pause_ok")
+
+    test.start_step("--------Test3: Direct mode executes without queue waiting;-------")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-mode-direct")
+    video_utils.wait_for_contains(test, lynxview, "attr-state", "mode=direct")
+    video_utils.click(lynxview, "btn-burst-play-stop")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "play_ok")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "stop_ok")
+    video_utils.assert_text_order(
+        lynxview,
+        "callback-log",
+        ["play_ok", "stop_ok"],
+    )
+
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "seek_ok")
+    video_utils.click(lynxview, "btn-stop")
+    video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
+    video_utils.wait_for_contains(test, lynxview, "callback-log", "stop_ok")
+    video_utils.capture_screenshot(test, lynxview, "mode_direct")

--- a/testing/integration_test/test_script/case_sets/xelement/__init__.py
+++ b/testing/integration_test/test_script/case_sets/xelement/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.

--- a/testing/integration_test/test_script/case_sets/xelement/runner.py
+++ b/testing/integration_test/test_script/case_sets/xelement/runner.py
@@ -1,0 +1,20 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2024 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+from lynx_e2e.api.config import settings
+sys.path.append(settings.PROJECT_ROOT)
+
+from lib.test_runner.case_set import CaseSet
+from lib.test_runner.test_runner import TestRunner
+from lib.test_runner.plugins.devtool_connect_plugin import DevtoolConnectPlugin
+
+def run(test):
+    runner = TestRunner(test)
+    runner.add_plugin(DevtoolConnectPlugin(test))
+    runner.add_case(CaseSet(case_set_path=os.path.dirname(__file__)))
+    runner.run_test()

--- a/testing/integration_test/test_script/case_sets/xelement/video_utils.py
+++ b/testing/integration_test/test_script/case_sets/xelement/video_utils.py
@@ -1,0 +1,155 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import re
+import time
+
+from lynx_e2e.api.config import settings
+from lynx_e2e.api.logger import EnumLogLevel
+from lynx_e2e.api.lynx_view import LynxView
+
+
+def get_lynxview(test):
+    return test.app.get_lynxview("lynxview", LynxView)
+
+
+def refresh_document_tree(lynxview):
+    driver = lynxview.get_lynx_driver()
+    if hasattr(driver, "_document_tree"):
+        driver._document_tree = None
+
+
+def get_text(lynxview, tag):
+    refresh_document_tree(lynxview)
+    element = lynxview.get_by_test_tag(tag)
+    if hasattr(element, "text"):
+        return element.text
+    return element.get_attribute("text")
+
+
+def click(lynxview, tag):
+    lynxview.get_by_test_tag(tag).click()
+
+
+def wait_for_text(test, lynxview, tag, expected, timeout=20):
+    return wait_until(
+        test,
+        lynxview,
+        tag,
+        lambda text: text == expected,
+        "%s should be %s" % (tag, expected),
+        timeout=timeout,
+    )
+
+
+def wait_until(test, lynxview, tag, predicate, message, timeout=20):
+    deadline = time.time() + timeout
+    last_text = ""
+    while time.time() < deadline:
+        last_text = get_text(lynxview, tag)
+        if predicate(last_text):
+            return last_text
+        time.sleep(0.2)
+    capture_screenshot(test, lynxview, "wait_failure")
+    last_text = get_text(lynxview, tag)
+    if predicate(last_text):
+        return last_text
+    raise AssertionError("%s. Last %s text: %s" % (message, tag, last_text))
+
+
+def wait_for_contains(test, lynxview, tag, expected, timeout=20):
+    return wait_until(
+        test,
+        lynxview,
+        tag,
+        lambda text: expected in text,
+        "%s should contain %s" % (tag, expected),
+        timeout=timeout,
+    )
+
+
+def assert_text_contains(lynxview, tag, expected):
+    text = get_text(lynxview, tag)
+    if expected not in text:
+        raise AssertionError("%s should contain %s, got %s" %
+                             (tag, expected, text))
+
+
+def assert_text_not_contains(lynxview, tag, unexpected):
+    text = get_text(lynxview, tag)
+    if unexpected in text:
+        raise AssertionError("%s should not contain %s, got %s" %
+                             (tag, unexpected, text))
+
+
+def assert_text_order(lynxview, tag, expected_entries):
+    text = get_text(lynxview, tag)
+    cursor = -1
+    for entry in expected_entries:
+        next_index = text.find(entry, cursor + 1)
+        if next_index < 0:
+            raise AssertionError("%s missing %s after index %s: %s" %
+                                 (tag, entry, cursor, text))
+        cursor = next_index
+
+
+def wait_for_count_at_least(test, lynxview, key, expected, timeout=10):
+    return wait_until(
+        test,
+        lynxview,
+        "event-counts",
+        lambda text: parse_count(text, key) >= expected,
+        "%s count should be at least %s" % (key, expected),
+        timeout=timeout,
+    )
+
+
+def assert_count_equals(lynxview, key, expected):
+    text = get_text(lynxview, "event-counts")
+    actual = parse_count(text, key)
+    if actual != expected:
+        raise AssertionError("%s count expected %s, got %s in %s" %
+                             (key, expected, actual, text))
+
+
+def assert_count_at_most(lynxview, key, expected):
+    text = get_text(lynxview, "event-counts")
+    actual = parse_count(text, key)
+    if actual > expected:
+        raise AssertionError("%s count expected at most %s, got %s in %s" %
+                             (key, expected, actual, text))
+
+
+def parse_count(counts_text, key):
+    match = re.search(r"(^|;)%s=(\d+)" % re.escape(key), counts_text)
+    if not match:
+        raise AssertionError("Missing %s in event counts: %s" %
+                             (key, counts_text))
+    return int(match.group(2))
+
+
+def parse_current_time(time_text):
+    match = re.match(r"([0-9]+(?:\.[0-9]+)?) /", time_text)
+    if not match:
+        raise AssertionError("Unexpected time text: %s" % time_text)
+    return float(match.group(1))
+
+
+def capture_screenshot(test, lynxview, suffix):
+    screenshot_dir = os.path.join(settings.PROJECT_ROOT, "screenshots",
+                                  test.platform)
+    os.makedirs(screenshot_dir, exist_ok=True)
+    case = test.current_case
+    image_name = "%s%s_%s.png" % (case.image_prefix, case.name, suffix)
+    image_path = os.path.join(screenshot_dir, image_name)
+    lynxview.screenshot(image_path)
+    test.log_record("video screenshot: %s" % suffix,
+                    EnumLogLevel.INFO,
+                    attachments={
+                        "test_img": image_path,
+                        "case_name": case.name,
+                    })
+    return image_path


### PR DESCRIPTION
Add a dedicated Android `LynxXElement:Video` module backed by Media3, including `video` element registration, PlayerView-based rendering, play/pause/stop/seek UI methods, configurable playback props, and event callbacks for first frame, playing, paused, stopped, timeupdate, ended, looped, buffering, and error states.

Add an integration demo plus Android E2E cases that exercise playback controls and loop behavior.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
