### PR TITLE
[Infra] Fix habitat script not interrupt after an error

### DIFF
--- a/.github/actions/windows-common-deps/action.yml
+++ b/.github/actions/windows-common-deps/action.yml
@@ -113,9 +113,9 @@ runs:
       working-directory: lynx
       run: |
         if ([string]::IsNullOrEmpty("${{ inputs.target }}")) {
-            powershell.exe -Command "& .\tools\hab.ps1 sync ."
+            .\tools\hab.ps1 sync .
         } else {
-            powershell.exe -Command "& .\tools\hab.ps1 sync . --target ${{ inputs.target }}"
+            .\tools\hab.ps1 sync . --target ${{ inputs.target }}
         }
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       env:

--- a/dependencies/DEPS
+++ b/dependencies/DEPS
@@ -2,6 +2,7 @@ import os
 import platform
 import zipfile
 
+
 system = platform.system().lower()
 machine = platform.machine().lower()
 machine = "x86_64" if machine == "amd64" else machine

--- a/tools/hab.ps1
+++ b/tools/hab.ps1
@@ -23,8 +23,9 @@ else {
     $HABITAT_DOWNLOAD_URL = "${HABITAT_RELEASE_BASE_URL}/download/$HABITAT_VERSION/hab.exe"
 }
 
-$HABITAT_CACHE_DIR = "${HOME}\.habitat_cache\hab"
-$HABITAT_BIN = "${HABITAT_CACHE_DIR}\hab-${HABITAT_VERSION}.exe"
+$HABITAT_HOME = python -c "import os; import tempfile; print(os.path.join(os.environ.get('HOME', tempfile.gettempdir()), '.habitat_cache'))"
+$HABITAT_CACHE_DIR = Join-Path $HABITAT_HOME "hab"
+$HABITAT_BIN = Join-Path $HABITAT_CACHE_DIR "hab-${HABITAT_VERSION}.exe"
 
 function install() {
     if (-Not (Test-Path -Path $HABITAT_CACHE_DIR)) {


### PR DESCRIPTION
Not to call it via powershell.exe

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
