### PR TITLE
[Feature][Video] Add iOS video element implementation and coverage

### DIFF
--- a/platform/darwin/ios/lynx_xelement/BUILD.gn
+++ b/platform/darwin/ios/lynx_xelement/BUILD.gn
@@ -46,6 +46,7 @@ podspec_target("XElement_podspec") {
       "SVG",
       "Refresh",
       "Markdown",
+      "Video",
       "Behavior",
     ]
   }
@@ -59,6 +60,7 @@ podspec_target("XElement_podspec") {
     ":Refresh",
     ":SVG",
     ":ScrollCoordinator",
+    ":Video",
     ":ViewPager",
     ":WebView",
   ]
@@ -188,6 +190,26 @@ subspec_target("WebView") {
   dependency = lynx_dependency
 }
 
+subspec_target("Video") {
+  sources = [
+    "video/LynxUIVideo.h",
+    "video/LynxUIVideo.m",
+    "video/LynxVideoDefines.h",
+    "video/LynxVideoOperationScheduler.h",
+    "video/LynxVideoOperationScheduler.m",
+    "video/LynxVideoView.h",
+    "video/LynxVideoView.m",
+  ]
+  public_header_files = [
+    "video/LynxUIVideo.h",
+    "video/LynxVideoDefines.h",
+    "video/LynxVideoOperationScheduler.h",
+    "video/LynxVideoView.h",
+  ]
+  frameworks = [ "AVFoundation" ]
+  dependency = lynx_dependency
+}
+
 subspec_target("SVG") {
   sources = [
     "svg/LynxSVGView.h",
@@ -282,6 +304,8 @@ subspec_target("Behavior") {
     "behavior/LynxUIScrollCoordinatorAutoRegistry.m",
     "behavior/LynxUITextAreaAutoRegistry.h",
     "behavior/LynxUITextAreaAutoRegistry.m",
+    "behavior/LynxUIVideoAutoRegistry.h",
+    "behavior/LynxUIVideoAutoRegistry.m",
     "behavior/LynxUIViewPagerAutoRegistry.h",
     "behavior/LynxUIViewPagerAutoRegistry.m",
     "behavior/LynxUIWebViewAutoRegistry.h",
@@ -297,6 +321,7 @@ subspec_target("Behavior") {
     "behavior/LynxUIViewPagerAutoRegistry.h",
     "behavior/LynxUISVGAutoRegistry.h",
     "behavior/LynxUITextAreaAutoRegistry.h",
+    "behavior/LynxUIVideoAutoRegistry.h",
     "behavior/LynxUIWebViewAutoRegistry.h",
   ]
 
@@ -308,6 +333,7 @@ subspec_target("Behavior") {
     "XElement/Overlay",
     "XElement/ScrollCoordinator",
     "XElement/ViewPager",
+    "XElement/Video",
     "XElement/WebView",
     "XElement/SVG",
     "XElement/Refresh",

--- a/platform/darwin/ios/lynx_xelement/behavior/LynxUIVideoAutoRegistry.h
+++ b/platform/darwin/ios/lynx_xelement/behavior/LynxUIVideoAutoRegistry.h
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Foundation/Foundation.h>
+#import <XElement/LynxUIVideo.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LynxUIVideoAutoRegistry : LynxUIVideo
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/ios/lynx_xelement/behavior/LynxUIVideoAutoRegistry.m
+++ b/platform/darwin/ios/lynx_xelement/behavior/LynxUIVideoAutoRegistry.m
@@ -1,0 +1,12 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Lynx/LynxComponentRegistry.h>
+#import <XElement/LynxUIVideoAutoRegistry.h>
+
+@implementation LynxUIVideoAutoRegistry
+
+LYNX_LAZY_REGISTER_UI("video")
+
+@end

--- a/platform/darwin/ios/lynx_xelement/video/LynxUIVideo.h
+++ b/platform/darwin/ios/lynx_xelement/video/LynxUIVideo.h
@@ -1,0 +1,24 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Lynx/LynxUI.h>
+#import <Lynx/LynxUIMethodProcessor.h>
+#import <XElement/LynxVideoDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LynxUIVideo : LynxUI <LynxVideoPlayableDelegate>
+
+@property(nonatomic, strong, readonly) UIView<LynxVideoPlayable> *videoView;
+
+- (UIView<LynxVideoPlayable> *)createVideoView;
+
+- (void)play:(NSDictionary *)params withResult:(LynxUIMethodCallbackBlock)callback;
+- (void)pause:(NSDictionary *)params withResult:(LynxUIMethodCallbackBlock)callback;
+- (void)stop:(NSDictionary *)params withResult:(LynxUIMethodCallbackBlock)callback;
+- (void)seek:(NSDictionary *)params withResult:(LynxUIMethodCallbackBlock)callback;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/ios/lynx_xelement/video/LynxUIVideo.m
+++ b/platform/darwin/ios/lynx_xelement/video/LynxUIVideo.m
@@ -1,0 +1,438 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <AVFoundation/AVFoundation.h>
+#import <Lynx/LynxEvent.h>
+#import <Lynx/LynxEventEmitter.h>
+#import <Lynx/LynxLog.h>
+#import <Lynx/LynxPropsProcessor.h>
+#import <XElement/LynxUIVideo.h>
+#import <XElement/LynxVideoOperationScheduler.h>
+#import <XElement/LynxVideoView.h>
+#import <stdint.h>
+
+static NSString *const kLynxVideoSourceChangeCancelMessage = @"request canceled by src change";
+static const NSTimeInterval kLynxVideoMaxSeekPosition =
+    (NSTimeInterval)INT64_MAX / (NSTimeInterval)NSEC_PER_SEC;
+
+static BOOL LynxVideoIsRepresentableSeekPosition(NSTimeInterval position) {
+  return isfinite(position) && position <= kLynxVideoMaxSeekPosition;
+}
+
+@interface LynxVideoPendingOperation : NSObject
+@property(nonatomic, copy, nullable) LynxUIMethodCallbackBlock callback;
+@property(nonatomic, copy, nullable) LynxVideoOperationCompletion completion;
+@property(nonatomic, assign) BOOL completed;
+@end
+
+@implementation LynxVideoPendingOperation
+@end
+
+@interface LynxUIVideo ()
+@property(nonatomic, strong, readwrite) UIView<LynxVideoPlayable> *videoView;
+@property(nonatomic, strong) LynxVideoOperationScheduler *operationScheduler;
+@property(nonatomic, strong) NSMutableArray<LynxVideoPendingOperation *> *pendingPlayOperations;
+@property(nonatomic, strong) NSMutableArray<LynxVideoPendingOperation *> *pendingStopOperations;
+@end
+
+@implementation LynxUIVideo
+
+- (UIView *)createView {
+  self.operationScheduler = [[LynxVideoOperationScheduler alloc] init];
+  self.pendingPlayOperations = [NSMutableArray array];
+  self.pendingStopOperations = [NSMutableArray array];
+  self.videoView = [self createVideoView];
+  self.videoView.delegate = self;
+  self.videoView.loop = NO;
+  self.videoView.volume = 1.0;
+  self.videoView.muted = NO;
+  self.videoView.speed = 1.0;
+  self.videoView.objectFit = LynxVideoObjectFitContain;
+  self.videoView.timeUpdateInterval = 0.33;
+  return self.videoView;
+}
+
+- (UIView<LynxVideoPlayable> *)createVideoView {
+  return [[LynxVideoView alloc] init];
+}
+
+LYNX_PROP_SETTER("src", setSrc, NSString *) {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    NSString *srcCopy = [value copy];
+    [self dispatchOnMainThread:^{
+      [weakSelf setSrc:srcCopy requestReset:requestReset];
+    }];
+    return;
+  }
+  [self cancelPendingOperationsWithMessage:kLynxVideoSourceChangeCancelMessage];
+  self.videoView.src = value ?: @"";
+}
+
+LYNX_PROP_SETTER("loop", setLoop, BOOL) { self.videoView.loop = value; }
+
+LYNX_PROP_SETTER("volume", setVolume, CGFloat) {
+  self.videoView.volume = MIN(1.0, MAX(0.0, value));
+}
+
+LYNX_PROP_SETTER("muted", setMuted, BOOL) { self.videoView.muted = value; }
+
+LYNX_PROP_SETTER("speed", setSpeed, CGFloat) { self.videoView.speed = MIN(2.0, MAX(0.1, value)); }
+
+LYNX_PROP_SETTER("object-fit", setObjectFit, NSString *) {
+  self.videoView.objectFit = [self objectFitFromString:value];
+}
+
+LYNX_PROP_SETTER("mode", setMode, NSString *) {
+  self.operationScheduler.mode = [self operationModeFromString:value];
+}
+
+LYNX_PROP_SETTER("timeupdate-interval", setTimeUpdateInterval, CGFloat) {
+  if (value > 0) {
+    self.videoView.timeUpdateInterval = value;
+  }
+}
+
+LYNX_UI_METHOD(play) {
+  LynxVideoPendingOperation *operation = [self pendingOperationWithCallback:callback];
+  __weak typeof(self) weakSelf = self;
+  [self.operationScheduler enqueueOperationWithName:@"play"
+      executor:^(LynxVideoOperationCompletion completion) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+          completion();
+          return;
+        }
+        [strongSelf executePlayWithOperation:operation completion:completion];
+      }
+      cancelHandler:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf finishPendingOperation:operation
+                                      code:kUIMethodOperationError
+                                      data:kLynxVideoSourceChangeCancelMessage];
+      }];
+}
+
+LYNX_UI_METHOD(pause) {
+  LynxVideoPendingOperation *operation = [self pendingOperationWithCallback:callback];
+  __weak typeof(self) weakSelf = self;
+  [self.operationScheduler enqueueOperationWithName:@"pause"
+      executor:^(LynxVideoOperationCompletion completion) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+          completion();
+          return;
+        }
+        operation.completion = completion;
+        [strongSelf.videoView pause];
+        [strongSelf finishPendingOperation:operation code:kUIMethodSuccess data:nil];
+      }
+      cancelHandler:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf finishPendingOperation:operation
+                                      code:kUIMethodOperationError
+                                      data:kLynxVideoSourceChangeCancelMessage];
+      }];
+}
+
+LYNX_UI_METHOD(stop) {
+  LynxVideoPendingOperation *operation = [self pendingOperationWithCallback:callback];
+  __weak typeof(self) weakSelf = self;
+  [self.operationScheduler enqueueOperationWithName:@"stop"
+      executor:^(LynxVideoOperationCompletion completion) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+          completion();
+          return;
+        }
+        operation.completion = completion;
+        [strongSelf.pendingStopOperations addObject:operation];
+        [strongSelf.videoView stop];
+      }
+      cancelHandler:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf finishPendingOperation:operation
+                                      code:kUIMethodOperationError
+                                      data:kLynxVideoSourceChangeCancelMessage];
+      }];
+}
+
+LYNX_UI_METHOD(seek) {
+  NSNumber *position = [params isKindOfClass:[NSDictionary class]] ? params[@"position"] : nil;
+  if (!position) {
+    [self invokeCallback:callback code:kUIMethodParamInvalid data:@"missing position param"];
+    return;
+  }
+  if (![position isKindOfClass:[NSNumber class]]) {
+    [self invokeCallback:callback
+                    code:kUIMethodParamInvalid
+                    data:@"position param must be a number"];
+    return;
+  }
+
+  LynxVideoPendingOperation *operation = [self pendingOperationWithCallback:callback];
+  __weak typeof(self) weakSelf = self;
+  [self.operationScheduler enqueueOperationWithName:@"seek"
+      executor:^(LynxVideoOperationCompletion completion) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+          completion();
+          return;
+        }
+        operation.completion = completion;
+        NSTimeInterval targetPosition = position.doubleValue;
+        if (![strongSelf validateSeekPosition:targetPosition]) {
+          [strongSelf finishPendingOperation:operation
+                                        code:kUIMethodParamInvalid
+                                        data:@"position out of range"];
+          return;
+        }
+        [strongSelf.videoView seekTo:position.doubleValue
+                          completion:^(BOOL success, NSString *_Nullable errorMsg) {
+                            [strongSelf finishPendingOperation:operation
+                                                          code:success ? kUIMethodSuccess
+                                                                       : kUIMethodOperationError
+                                                          data:success ? nil : errorMsg];
+                          }];
+      }
+      cancelHandler:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        [strongSelf finishPendingOperation:operation
+                                      code:kUIMethodOperationError
+                                      data:kLynxVideoSourceChangeCancelMessage];
+      }];
+}
+
+- (LynxVideoPendingOperation *)pendingOperationWithCallback:(LynxUIMethodCallbackBlock)callback {
+  LynxVideoPendingOperation *operation = [[LynxVideoPendingOperation alloc] init];
+  operation.callback = callback;
+  return operation;
+}
+
+- (BOOL)validateSeekPosition:(NSTimeInterval)position {
+  NSTimeInterval duration = self.videoView.duration;
+  if (!LynxVideoIsRepresentableSeekPosition(position) || position < 0 ||
+      (duration > 0 && position > duration)) {
+    return NO;
+  }
+  return YES;
+}
+
+- (void)executePlayWithOperation:(LynxVideoPendingOperation *)operation
+                      completion:(LynxVideoOperationCompletion)completion {
+  operation.completion = completion;
+  if (self.videoView.src.length == 0) {
+    [self dispatchErrorWithCode:LynxVideoErrorInvalidSource message:@"missing video source"];
+    [self finishPendingOperation:operation
+                            code:kUIMethodOperationError
+                            data:@"missing video source"];
+    return;
+  }
+
+  [self ensurePlaybackAudioSession];
+  if (self.videoView.isPlaying) {
+    [self finishPendingOperation:operation code:kUIMethodSuccess data:nil];
+    return;
+  }
+
+  [self.pendingPlayOperations addObject:operation];
+  [self.videoView play];
+}
+
+- (void)ensurePlaybackAudioSession {
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  if (![session.category isEqualToString:AVAudioSessionCategoryPlayback]) {
+    NSError *error = nil;
+    if (![session setCategory:AVAudioSessionCategoryPlayback error:&error]) {
+      LLogWarn(@"[LynxVideo] Failed to set AVAudioSession category to Playback: %@", error);
+    }
+  }
+}
+
+- (LynxVideoObjectFit)objectFitFromString:(NSString *)value {
+  if ([value isEqualToString:@"cover"]) {
+    return LynxVideoObjectFitCover;
+  }
+  if ([value isEqualToString:@"fill"]) {
+    return LynxVideoObjectFitFill;
+  }
+  return LynxVideoObjectFitContain;
+}
+
+- (LynxVideoOperationMode)operationModeFromString:(NSString *)value {
+  if ([value isEqualToString:@"direct"]) {
+    return LynxVideoOperationModeDirect;
+  }
+  if ([value isEqualToString:@"latest"]) {
+    return LynxVideoOperationModeLatest;
+  }
+  return LynxVideoOperationModeQueue;
+}
+
+- (void)invokeCallback:(LynxUIMethodCallbackBlock)callback code:(int)code data:(id)data {
+  if (callback) {
+    BOOL success = code == kUIMethodSuccess;
+    id payload = data;
+    if (success && !payload) {
+      payload = @{@"success" : @YES};
+    } else if (!success) {
+      payload = @{@"success" : @NO, @"errorCode" : @(code), @"msg" : data ?: @"request failed"};
+    }
+    callback(code, payload);
+  }
+}
+
+- (void)finishPendingOperation:(LynxVideoPendingOperation *)operation code:(int)code data:(id)data {
+  if (!operation || operation.completed) {
+    return;
+  }
+  operation.completed = YES;
+  [self invokeCallback:operation.callback code:code data:data];
+  if (operation.completion) {
+    operation.completion();
+  }
+}
+
+- (void)finishPendingPlayOperationsWithCode:(int)code data:(id)data {
+  NSArray<LynxVideoPendingOperation *> *operations = [self.pendingPlayOperations copy];
+  [self.pendingPlayOperations removeAllObjects];
+  for (LynxVideoPendingOperation *operation in operations) {
+    [self finishPendingOperation:operation code:code data:data];
+  }
+}
+
+- (void)finishPendingStopOperationsWithCode:(int)code data:(id)data {
+  NSArray<LynxVideoPendingOperation *> *operations = [self.pendingStopOperations copy];
+  [self.pendingStopOperations removeAllObjects];
+  for (LynxVideoPendingOperation *operation in operations) {
+    [self finishPendingOperation:operation code:code data:data];
+  }
+}
+
+- (void)cancelPendingOperationsWithMessage:(NSString *)message {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    NSString *messageCopy = [message copy];
+    [self dispatchOnMainThread:^{
+      [weakSelf cancelPendingOperationsWithMessage:messageCopy];
+    }];
+    return;
+  }
+  [self.operationScheduler cancelAllOperations];
+  [self finishPendingPlayOperationsWithCode:kUIMethodOperationError data:message];
+  [self finishPendingStopOperationsWithCode:kUIMethodOperationError data:message];
+}
+
+- (void)sendEventWithName:(NSString *)name detail:(nullable NSDictionary *)detail {
+  [self.context.eventEmitter sendCustomEvent:[[LynxDetailEvent alloc] initWithName:name
+                                                                        targetSign:[self sign]
+                                                                            detail:detail ?: @{}]];
+}
+
+- (void)dispatchErrorWithCode:(NSInteger)errorCode message:(NSString *)errorMsg {
+  [self sendEventWithName:@"error"
+                   detail:@{
+                     @"errorCode" : @(errorCode),
+                     @"errorMsg" : errorMsg ?: @"unknown video error"
+                   }];
+}
+
+- (void)dispatchOnMainThread:(dispatch_block_t)block {
+  if (!block) {
+    return;
+  }
+  if ([NSThread isMainThread]) {
+    block();
+    return;
+  }
+  dispatch_async(dispatch_get_main_queue(), block);
+}
+
+#pragma mark - LynxVideoPlayableDelegate
+
+- (void)playableDidLoadFirstFrame:(id<LynxVideoPlayable>)playable
+                         duration:(NSTimeInterval)duration {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"firstframe" detail:@{@"duration" : @(duration)}];
+  }];
+}
+
+- (void)playableDidStartPlaying:(id<LynxVideoPlayable>)playable {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"playing" detail:nil];
+    [strongSelf finishPendingPlayOperationsWithCode:kUIMethodSuccess data:nil];
+  }];
+}
+
+- (void)playableDidPause:(id<LynxVideoPlayable>)playable {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"paused" detail:nil];
+  }];
+}
+
+- (void)playableDidStop:(id<LynxVideoPlayable>)playable {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"stopped" detail:nil];
+    [strongSelf finishPendingStopOperationsWithCode:kUIMethodSuccess data:nil];
+  }];
+}
+
+- (void)playableDidEnd:(id<LynxVideoPlayable>)playable {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"ended" detail:nil];
+  }];
+}
+
+- (void)playableDidLoop:(id<LynxVideoPlayable>)playable {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"looped" detail:nil];
+  }];
+}
+
+- (void)playable:(id<LynxVideoPlayable>)playable
+    didUpdateTime:(NSTimeInterval)current
+         duration:(NSTimeInterval)duration {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"timeupdate"
+                           detail:@{
+                             @"current" : @(current),
+                             @"duration" : @(duration)
+                           }];
+  }];
+}
+
+- (void)playable:(id<LynxVideoPlayable>)playable didUpdateBuffering:(NSTimeInterval)buffering {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf sendEventWithName:@"buffering" detail:@{@"buffering" : @(buffering)}];
+  }];
+}
+
+- (void)playable:(id<LynxVideoPlayable>)playable
+    didFailWithCode:(NSInteger)errorCode
+            message:(NSString *)errorMsg {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf dispatchErrorWithCode:errorCode message:errorMsg];
+    [strongSelf finishPendingPlayOperationsWithCode:kUIMethodOperationError data:errorMsg];
+  }];
+}
+
+@end

--- a/platform/darwin/ios/lynx_xelement/video/LynxVideoDefines.h
+++ b/platform/darwin/ios/lynx_xelement/video/LynxVideoDefines.h
@@ -1,0 +1,62 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, LynxVideoObjectFit) {
+  LynxVideoObjectFitContain = 0,
+  LynxVideoObjectFitCover,
+  LynxVideoObjectFitFill,
+};
+
+typedef NS_ENUM(NSInteger, LynxVideoErrorCode) {
+  LynxVideoErrorInvalidSource = -1,
+  LynxVideoErrorOperation = -2,
+};
+
+@protocol LynxVideoPlayable;
+
+@protocol LynxVideoPlayableDelegate <NSObject>
+
+- (void)playableDidLoadFirstFrame:(id<LynxVideoPlayable>)playable duration:(NSTimeInterval)duration;
+- (void)playableDidStartPlaying:(id<LynxVideoPlayable>)playable;
+- (void)playableDidPause:(id<LynxVideoPlayable>)playable;
+- (void)playableDidStop:(id<LynxVideoPlayable>)playable;
+- (void)playableDidEnd:(id<LynxVideoPlayable>)playable;
+- (void)playableDidLoop:(id<LynxVideoPlayable>)playable;
+- (void)playable:(id<LynxVideoPlayable>)playable
+    didUpdateTime:(NSTimeInterval)current
+         duration:(NSTimeInterval)duration;
+- (void)playable:(id<LynxVideoPlayable>)playable didUpdateBuffering:(NSTimeInterval)buffering;
+- (void)playable:(id<LynxVideoPlayable>)playable
+    didFailWithCode:(NSInteger)errorCode
+            message:(NSString *)errorMsg;
+
+@end
+
+@protocol LynxVideoPlayable <NSObject>
+
+@property(nonatomic, weak, nullable) id<LynxVideoPlayableDelegate> delegate;
+@property(nonatomic, copy, nullable) NSString *src;
+@property(nonatomic, assign) BOOL loop;
+@property(nonatomic, assign) CGFloat volume;
+@property(nonatomic, assign) BOOL muted;
+@property(nonatomic, assign) CGFloat speed;
+@property(nonatomic, assign) LynxVideoObjectFit objectFit;
+@property(nonatomic, assign) NSTimeInterval timeUpdateInterval;
+@property(nonatomic, assign, readonly) NSTimeInterval duration;
+@property(nonatomic, assign, readonly, getter=isPlaying) BOOL playing;
+
+- (void)play;
+- (void)pause;
+- (void)stop;
+- (void)seekTo:(NSTimeInterval)position
+    completion:(void (^)(BOOL success, NSString *_Nullable errorMsg))completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/ios/lynx_xelement/video/LynxVideoOperationScheduler.h
+++ b/platform/darwin/ios/lynx_xelement/video/LynxVideoOperationScheduler.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, LynxVideoOperationMode) {
+  LynxVideoOperationModeQueue = 0,
+  LynxVideoOperationModeDirect,
+  LynxVideoOperationModeLatest,
+};
+
+typedef void (^LynxVideoOperationCompletion)(void);
+typedef void (^LynxVideoOperationExecutor)(LynxVideoOperationCompletion completion);
+typedef void (^LynxVideoOperationCancelHandler)(void);
+
+@interface LynxVideoOperationScheduler : NSObject
+
+// Main-thread owned. Callers should invoke scheduler APIs from the main thread
+// so operation ordering and callbacks remain deterministic.
+@property(nonatomic, assign) LynxVideoOperationMode mode;
+
+- (void)enqueueOperationWithName:(NSString *)name executor:(LynxVideoOperationExecutor)executor;
+- (void)enqueueOperationWithName:(NSString *)name
+                        executor:(LynxVideoOperationExecutor)executor
+                   cancelHandler:(nullable LynxVideoOperationCancelHandler)cancelHandler;
+- (void)cancelAllOperations;
+// Clears scheduler state without invoking cancel handlers. Use cancelAllOperations
+// when callers need queued/current operation callbacks to be notified.
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/ios/lynx_xelement/video/LynxVideoOperationScheduler.m
+++ b/platform/darwin/ios/lynx_xelement/video/LynxVideoOperationScheduler.m
@@ -1,0 +1,177 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <XElement/LynxVideoOperationScheduler.h>
+
+@interface LynxVideoOperation : NSObject
+@property(nonatomic, copy) NSString *name;
+@property(nonatomic, copy) LynxVideoOperationExecutor executor;
+@property(nonatomic, copy, nullable) LynxVideoOperationCancelHandler cancelHandler;
+@end
+
+@implementation LynxVideoOperation
+@end
+
+@interface LynxVideoOperationScheduler ()
+@property(nonatomic, assign) BOOL running;
+@property(nonatomic, strong) NSMutableArray<LynxVideoOperation *> *queue;
+@property(nonatomic, strong, nullable) LynxVideoOperation *latestOperation;
+@property(nonatomic, strong, nullable) LynxVideoOperation *currentOperation;
+@end
+
+@implementation LynxVideoOperationScheduler
+@synthesize mode = _mode;
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _mode = LynxVideoOperationModeQueue;
+    _queue = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)enqueueOperationWithName:(NSString *)name executor:(LynxVideoOperationExecutor)executor {
+  [self enqueueOperationWithName:name executor:executor cancelHandler:nil];
+}
+
+- (void)enqueueOperationWithName:(NSString *)name
+                        executor:(LynxVideoOperationExecutor)executor
+                   cancelHandler:(nullable LynxVideoOperationCancelHandler)cancelHandler {
+  if (!executor) {
+    return;
+  }
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf enqueueOperationWithName:name executor:executor cancelHandler:cancelHandler];
+    });
+    return;
+  }
+
+  LynxVideoOperation *operation = [[LynxVideoOperation alloc] init];
+  operation.name = name ?: @"";
+  operation.executor = executor;
+  operation.cancelHandler = cancelHandler;
+
+  if (self.mode == LynxVideoOperationModeDirect) {
+    operation.executor(^{
+    });
+    return;
+  }
+
+  if (self.mode == LynxVideoOperationModeLatest && self.running) {
+    LynxVideoOperation *previousLatestOperation = self.latestOperation;
+    if (previousLatestOperation.cancelHandler) {
+      previousLatestOperation.cancelHandler();
+    }
+    self.latestOperation = operation;
+    return;
+  }
+
+  [self.queue addObject:operation];
+  [self startNextOperationIfNeeded];
+}
+
+- (void)reset {
+  if (![NSThread isMainThread]) {
+    NSAssert(NO, @"LynxVideoOperationScheduler reset must be called on main thread.");
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf reset];
+    });
+    return;
+  }
+
+  [self.queue removeAllObjects];
+  self.latestOperation = nil;
+  self.currentOperation = nil;
+  self.running = NO;
+}
+
+- (void)cancelAllOperations {
+  if (![NSThread isMainThread]) {
+    NSAssert(NO, @"LynxVideoOperationScheduler cancelAllOperations must be called on main thread.");
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf cancelAllOperations];
+    });
+    return;
+  }
+
+  NSMutableArray<LynxVideoOperation *> *operations = [NSMutableArray array];
+  if (self.currentOperation) {
+    [operations addObject:self.currentOperation];
+  }
+  [operations addObjectsFromArray:self.queue];
+  if (self.latestOperation) {
+    [operations addObject:self.latestOperation];
+  }
+
+  [self reset];
+
+  for (LynxVideoOperation *operation in operations) {
+    if (operation.cancelHandler) {
+      operation.cancelHandler();
+    }
+  }
+}
+
+- (LynxVideoOperationMode)mode {
+  if (![NSThread isMainThread]) {
+    NSAssert(NO, @"LynxVideoOperationScheduler mode must be read on main thread.");
+  }
+  return _mode;
+}
+
+- (void)setMode:(LynxVideoOperationMode)mode {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      weakSelf.mode = mode;
+    });
+    return;
+  }
+  _mode = mode;
+}
+
+- (void)startNextOperationIfNeeded {
+  if (self.running) {
+    return;
+  }
+
+  LynxVideoOperation *operation = nil;
+  if (self.mode == LynxVideoOperationModeLatest && self.latestOperation) {
+    operation = self.latestOperation;
+    self.latestOperation = nil;
+  } else if (self.queue.count > 0) {
+    operation = self.queue.firstObject;
+    [self.queue removeObjectAtIndex:0];
+  }
+
+  if (!operation) {
+    return;
+  }
+
+  self.running = YES;
+  self.currentOperation = operation;
+  __block BOOL completed = NO;
+  __weak typeof(self) weakSelf = self;
+  operation.executor(^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (!strongSelf || completed) {
+        return;
+      }
+      if (strongSelf.currentOperation != operation) {
+        return;
+      }
+      completed = YES;
+      strongSelf.currentOperation = nil;
+      strongSelf.running = NO;
+      [strongSelf startNextOperationIfNeeded];
+    });
+  });
+}
+
+@end

--- a/platform/darwin/ios/lynx_xelement/video/LynxVideoView.h
+++ b/platform/darwin/ios/lynx_xelement/video/LynxVideoView.h
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <XElement/LynxVideoDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LynxVideoView : UIView <LynxVideoPlayable>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/platform/darwin/ios/lynx_xelement/video/LynxVideoView.m
+++ b/platform/darwin/ios/lynx_xelement/video/LynxVideoView.m
@@ -1,0 +1,660 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <AVFoundation/AVFoundation.h>
+#import <XElement/LynxVideoView.h>
+#import <stdint.h>
+
+static void *kLynxVideoItemStatusContext = &kLynxVideoItemStatusContext;
+static void *kLynxVideoLoadedRangesContext = &kLynxVideoLoadedRangesContext;
+static void *kLynxVideoLayerReadyContext = &kLynxVideoLayerReadyContext;
+static void *kLynxVideoTimeControlStatusContext = &kLynxVideoTimeControlStatusContext;
+static const NSTimeInterval kLynxVideoMaxSeekPosition =
+    (NSTimeInterval)INT64_MAX / (NSTimeInterval)NSEC_PER_SEC;
+
+static BOOL LynxVideoIsRepresentableSeekPosition(NSTimeInterval position) {
+  return isfinite(position) && position <= kLynxVideoMaxSeekPosition;
+}
+
+@interface LynxVideoView ()
+@property(nonatomic, strong) AVPlayer *player;
+@property(nonatomic, strong, nullable) AVPlayerItem *playerItem;
+@property(nonatomic, strong, nullable) id timeObserver;
+@property(nonatomic, assign) BOOL observingLayer;
+@property(nonatomic, assign) BOOL observingPlayer;
+@property(nonatomic, assign) BOOL observingItem;
+@property(nonatomic, assign) BOOL firstFrameDispatched;
+@property(nonatomic, assign, getter=isPlaying) BOOL playing;
+@property(nonatomic, assign) BOOL playbackEnded;
+@end
+
+@implementation LynxVideoView
+
+@synthesize delegate = _delegate;
+@synthesize src = _src;
+@synthesize loop = _loop;
+@synthesize volume = _volume;
+@synthesize muted = _muted;
+@synthesize speed = _speed;
+@synthesize objectFit = _objectFit;
+@synthesize timeUpdateInterval = _timeUpdateInterval;
+
++ (Class)layerClass {
+  return [AVPlayerLayer class];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    _volume = 1.0;
+    _speed = 1.0;
+    _objectFit = LynxVideoObjectFitContain;
+    _timeUpdateInterval = 0.33;
+    self.clipsToBounds = YES;
+    [self.playerLayer addObserver:self
+                       forKeyPath:@"readyForDisplay"
+                          options:NSKeyValueObservingOptionNew
+                          context:kLynxVideoLayerReadyContext];
+    _observingLayer = YES;
+    [self applyObjectFit];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self clearCurrentItem];
+  [self clearTimeObserver];
+  if (self.observingPlayer) {
+    [self.player removeObserver:self forKeyPath:@"timeControlStatus"];
+    self.observingPlayer = NO;
+  }
+  if (self.observingLayer) {
+    [self.playerLayer removeObserver:self forKeyPath:@"readyForDisplay"];
+    self.observingLayer = NO;
+  }
+}
+
+- (AVPlayerLayer *)playerLayer {
+  return (AVPlayerLayer *)self.layer;
+}
+
+- (void)dispatchOnMainThread:(dispatch_block_t)block {
+  if (!block) {
+    return;
+  }
+  if ([NSThread isMainThread]) {
+    block();
+    return;
+  }
+  dispatch_async(dispatch_get_main_queue(), block);
+}
+
+- (NSTimeInterval)duration {
+  CMTime duration = self.playerItem.duration;
+  if (!CMTIME_IS_NUMERIC(duration) || CMTIME_IS_INDEFINITE(duration)) {
+    return 0;
+  }
+  Float64 seconds = CMTimeGetSeconds(duration);
+  return isfinite(seconds) ? seconds : 0;
+}
+
+- (void)setSrc:(NSString *)src {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    NSString *srcCopy = [src copy];
+    [self dispatchOnMainThread:^{
+      weakSelf.src = srcCopy;
+    }];
+    return;
+  }
+  if ((_src == src) || [_src isEqualToString:src]) {
+    return;
+  }
+  _src = [src copy];
+  [self loadSource:_src];
+}
+
+- (void)setLoop:(BOOL)loop {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.loop = loop;
+    }];
+    return;
+  }
+  _loop = loop;
+}
+
+- (void)setVolume:(CGFloat)volume {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.volume = volume;
+    }];
+    return;
+  }
+  _volume = MIN(1.0, MAX(0.0, volume));
+  [self applyAudioState];
+}
+
+- (void)setMuted:(BOOL)muted {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.muted = muted;
+    }];
+    return;
+  }
+  _muted = muted;
+  [self applyAudioState];
+}
+
+- (void)setSpeed:(CGFloat)speed {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.speed = speed;
+    }];
+    return;
+  }
+  _speed = MIN(2.0, MAX(0.1, speed));
+  if (self.isPlaying) {
+    self.player.rate = _speed;
+  }
+}
+
+- (void)setObjectFit:(LynxVideoObjectFit)objectFit {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.objectFit = objectFit;
+    }];
+    return;
+  }
+  _objectFit = objectFit;
+  [self applyObjectFit];
+}
+
+- (void)setTimeUpdateInterval:(NSTimeInterval)timeUpdateInterval {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      weakSelf.timeUpdateInterval = timeUpdateInterval;
+    }];
+    return;
+  }
+  if (timeUpdateInterval <= 0) {
+    return;
+  }
+  _timeUpdateInterval = timeUpdateInterval;
+  [self resetTimeObserverIfNeeded];
+}
+
+- (void)play {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      [weakSelf play];
+    }];
+    return;
+  }
+  if (!self.playerItem) {
+    [self notifyErrorWithCode:LynxVideoErrorInvalidSource message:@"invalid video source"];
+    return;
+  }
+  if (self.playerItem.status == AVPlayerItemStatusFailed) {
+    [self notifyErrorWithCode:LynxVideoErrorOperation
+                      message:self.playerItem.error.localizedDescription ?: @"video load failed"];
+    return;
+  }
+  if (self.playbackEnded) {
+    self.playbackEnded = NO;
+    __weak typeof(self) weakSelf = self;
+    [self.player seekToTime:kCMTimeZero
+            toleranceBefore:kCMTimeZero
+             toleranceAfter:kCMTimeZero
+          completionHandler:^(BOOL finished) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) {
+              return;
+            }
+            [strongSelf dispatchOnMainThread:^{
+              if (!finished) {
+                [strongSelf notifyErrorWithCode:LynxVideoErrorOperation message:@"seek failed"];
+                return;
+              }
+              [strongSelf.player playImmediatelyAtRate:strongSelf.speed];
+              if (strongSelf.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+                [strongSelf notifyPlayingIfNeeded];
+              }
+            }];
+          }];
+    return;
+  }
+  [self.player playImmediatelyAtRate:self.speed];
+  if (self.player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+    [self notifyPlayingIfNeeded];
+  }
+}
+
+- (void)pause {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      [weakSelf pause];
+    }];
+    return;
+  }
+  BOOL shouldNotify = self.isPlaying || self.player.rate != 0;
+  [self.player pause];
+  if (shouldNotify) {
+    self.playing = NO;
+    [self notifyPaused];
+  }
+}
+
+- (void)stop {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      [weakSelf stop];
+    }];
+    return;
+  }
+  if (!self.player) {
+    self.playing = NO;
+    self.playbackEnded = NO;
+    [self notifyStopped];
+    return;
+  }
+  [self.player pause];
+  self.playing = NO;
+  self.playbackEnded = NO;
+  AVPlayerItem *itemAtStop = self.player.currentItem;
+  if (!itemAtStop) {
+    [self notifyStopped];
+    return;
+  }
+  __weak typeof(self) weakSelf = self;
+  [self.player seekToTime:kCMTimeZero
+          toleranceBefore:kCMTimeZero
+           toleranceAfter:kCMTimeZero
+        completionHandler:^(BOOL finished) {
+          __strong typeof(weakSelf) strongSelf = weakSelf;
+          if (!strongSelf || !finished || strongSelf.player.currentItem != itemAtStop) {
+            return;
+          }
+          [strongSelf notifyStopped];
+        }];
+}
+
+- (void)seekTo:(NSTimeInterval)position
+    completion:(void (^)(BOOL success, NSString *_Nullable errorMsg))completion {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      [weakSelf seekTo:position completion:completion];
+    }];
+    return;
+  }
+  if (!self.playerItem) {
+    if (completion) {
+      completion(NO, @"invalid video source");
+    }
+    return;
+  }
+
+  NSTimeInterval duration = self.duration;
+  if (!LynxVideoIsRepresentableSeekPosition(position) || position < 0 ||
+      (duration > 0 && position > duration)) {
+    if (completion) {
+      completion(NO, @"position out of range");
+    }
+    return;
+  }
+
+  BOOL shouldResume = self.isPlaying || self.player.rate != 0;
+  [self.player pause];
+  CMTime target = CMTimeMakeWithSeconds(position, NSEC_PER_SEC);
+  __weak typeof(self) weakSelf = self;
+  [self.player seekToTime:target
+          toleranceBefore:kCMTimeZero
+           toleranceAfter:kCMTimeZero
+        completionHandler:^(BOOL finished) {
+          __strong typeof(weakSelf) strongSelf = weakSelf;
+          if (!strongSelf) {
+            if (completion) {
+              dispatch_async(dispatch_get_main_queue(), ^{
+                completion(NO, @"seek failed");
+              });
+            }
+            return;
+          }
+          [strongSelf dispatchOnMainThread:^{
+            strongSelf.playbackEnded = NO;
+            if (finished && shouldResume) {
+              [strongSelf.player playImmediatelyAtRate:strongSelf.speed];
+            }
+            if (completion) {
+              completion(finished, finished ? nil : @"seek failed");
+            }
+          }];
+        }];
+}
+
+- (void)loadSource:(NSString *)src {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    NSString *srcCopy = [src copy];
+    [self dispatchOnMainThread:^{
+      [weakSelf loadSource:srcCopy];
+    }];
+    return;
+  }
+  [self clearCurrentItem];
+  self.firstFrameDispatched = NO;
+  self.playing = NO;
+  self.playbackEnded = NO;
+  [self.player pause];
+
+  if (src.length == 0) {
+    [self.player replaceCurrentItemWithPlayerItem:nil];
+    return;
+  }
+
+  NSURL *url = [NSURL URLWithString:src];
+  if (![self isSupportedURL:url]) {
+    [self.player replaceCurrentItemWithPlayerItem:nil];
+    [self notifyErrorWithCode:LynxVideoErrorInvalidSource message:@"invalid video source"];
+    return;
+  }
+
+  AVPlayerItem *item = [AVPlayerItem playerItemWithURL:url];
+  self.playerItem = item;
+  [self observeCurrentItem];
+  [self ensurePlayer];
+  [self.player replaceCurrentItemWithPlayerItem:item];
+  [self resetTimeObserverIfNeeded];
+}
+
+- (BOOL)isSupportedURL:(NSURL *)url {
+  NSString *scheme = url.scheme.lowercaseString;
+  return url && ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"]) &&
+         url.host.length > 0;
+}
+
+- (void)ensurePlayer {
+  if (self.player) {
+    return;
+  }
+  self.player = [[AVPlayer alloc] init];
+  self.player.actionAtItemEnd = AVPlayerActionAtItemEndPause;
+  [self.player addObserver:self
+                forKeyPath:@"timeControlStatus"
+                   options:NSKeyValueObservingOptionNew
+                   context:kLynxVideoTimeControlStatusContext];
+  self.observingPlayer = YES;
+  self.playerLayer.player = self.player;
+  [self applyAudioState];
+}
+
+- (void)observeCurrentItem {
+  if (!self.playerItem || self.observingItem) {
+    return;
+  }
+  [self.playerItem addObserver:self
+                    forKeyPath:@"status"
+                       options:NSKeyValueObservingOptionNew
+                       context:kLynxVideoItemStatusContext];
+  [self.playerItem addObserver:self
+                    forKeyPath:@"loadedTimeRanges"
+                       options:NSKeyValueObservingOptionNew
+                       context:kLynxVideoLoadedRangesContext];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(playerItemDidPlayToEnd:)
+                                               name:AVPlayerItemDidPlayToEndTimeNotification
+                                             object:self.playerItem];
+  self.observingItem = YES;
+}
+
+- (void)clearCurrentItem {
+  if (!self.playerItem || !self.observingItem) {
+    self.playerItem = nil;
+    return;
+  }
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:AVPlayerItemDidPlayToEndTimeNotification
+                                                object:self.playerItem];
+  [self.playerItem removeObserver:self forKeyPath:@"status"];
+  [self.playerItem removeObserver:self forKeyPath:@"loadedTimeRanges"];
+  self.observingItem = NO;
+  self.playerItem = nil;
+}
+
+- (void)resetTimeObserverIfNeeded {
+  if (!self.player) {
+    return;
+  }
+  [self clearTimeObserver];
+  __weak typeof(self) weakSelf = self;
+  CMTime interval = CMTimeMakeWithSeconds(self.timeUpdateInterval, NSEC_PER_SEC);
+  self.timeObserver = [self.player addPeriodicTimeObserverForInterval:interval
+                                                                queue:dispatch_get_main_queue()
+                                                           usingBlock:^(CMTime time) {
+                                                             __strong typeof(weakSelf) strongSelf =
+                                                                 weakSelf;
+                                                             [strongSelf dispatchTimeUpdate:time];
+                                                           }];
+}
+
+- (void)clearTimeObserver {
+  if (self.timeObserver && self.player) {
+    [self.player removeTimeObserver:self.timeObserver];
+  }
+  self.timeObserver = nil;
+}
+
+- (void)applyAudioState {
+  self.player.volume = self.muted ? 0 : self.volume;
+  self.player.muted = self.muted;
+}
+
+- (void)applyObjectFit {
+  switch (self.objectFit) {
+    case LynxVideoObjectFitCover:
+      self.playerLayer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+      break;
+    case LynxVideoObjectFitFill:
+      self.playerLayer.videoGravity = AVLayerVideoGravityResize;
+      break;
+    case LynxVideoObjectFitContain:
+    default:
+      self.playerLayer.videoGravity = AVLayerVideoGravityResizeAspect;
+      break;
+  }
+}
+
+- (void)dispatchTimeUpdate:(CMTime)time {
+  if (!self.playerItem || !self.isPlaying) {
+    return;
+  }
+  Float64 current = CMTimeGetSeconds(time);
+  if (!isfinite(current)) {
+    current = 0;
+  }
+  NSTimeInterval duration = self.duration;
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.delegate playable:strongSelf didUpdateTime:current duration:duration];
+  }];
+}
+
+- (void)dispatchBufferingUpdate {
+  [self dispatchBufferingUpdateForItem:self.playerItem];
+}
+
+- (void)dispatchBufferingUpdateForItem:(AVPlayerItem *)item {
+  if (!item || item != self.playerItem) {
+    return;
+  }
+  NSTimeInterval bufferedEnd = 0;
+  for (NSValue *rangeValue in item.loadedTimeRanges) {
+    CMTimeRange range = [rangeValue CMTimeRangeValue];
+    Float64 end = CMTimeGetSeconds(CMTimeAdd(range.start, range.duration));
+    if (isfinite(end)) {
+      bufferedEnd = MAX(bufferedEnd, end);
+    }
+  }
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (item != strongSelf.playerItem) {
+      return;
+    }
+    [strongSelf.delegate playable:strongSelf didUpdateBuffering:bufferedEnd];
+  }];
+}
+
+- (void)dispatchFirstFrameIfNeeded {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (strongSelf.firstFrameDispatched || !strongSelf.playerLayer.readyForDisplay) {
+      return;
+    }
+    strongSelf.firstFrameDispatched = YES;
+    [strongSelf.delegate playableDidLoadFirstFrame:strongSelf duration:strongSelf.duration];
+  }];
+}
+
+- (void)notifyPlayingIfNeeded {
+  if (self.playing) {
+    return;
+  }
+  self.playing = YES;
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.delegate playableDidStartPlaying:strongSelf];
+  }];
+}
+
+- (void)notifyErrorWithCode:(NSInteger)code message:(NSString *)message {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.delegate playable:strongSelf
+                  didFailWithCode:code
+                          message:message ?: @"unknown video error"];
+  }];
+}
+
+- (void)notifyPaused {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.delegate playableDidPause:strongSelf];
+  }];
+}
+
+- (void)notifyStopped {
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    [strongSelf.delegate playableDidStop:strongSelf];
+  }];
+}
+
+- (void)playerItemDidPlayToEnd:(NSNotification *)notification {
+  AVPlayerItem *item = (AVPlayerItem *)notification.object;
+  if (item != self.playerItem) {
+    return;
+  }
+  __weak typeof(self) weakSelf = self;
+  [self dispatchOnMainThread:^{
+    __strong typeof(weakSelf) strongSelf = weakSelf;
+    if (item != strongSelf.playerItem) {
+      return;
+    }
+    strongSelf.playing = NO;
+    if (strongSelf.loop) {
+      strongSelf.playbackEnded = NO;
+      [strongSelf.delegate playableDidLoop:strongSelf];
+      [strongSelf.player seekToTime:kCMTimeZero
+                    toleranceBefore:kCMTimeZero
+                     toleranceAfter:kCMTimeZero
+                  completionHandler:^(BOOL finished) {
+                    __strong typeof(weakSelf) innerStrongSelf = weakSelf;
+                    [innerStrongSelf dispatchOnMainThread:^{
+                      if (!finished) {
+                        [innerStrongSelf notifyErrorWithCode:LynxVideoErrorOperation
+                                                     message:@"seek failed"];
+                        return;
+                      }
+                      innerStrongSelf.playbackEnded = NO;
+                      [innerStrongSelf.player playImmediatelyAtRate:innerStrongSelf.speed];
+                    }];
+                  }];
+    } else {
+      strongSelf.playbackEnded = YES;
+      [strongSelf.delegate playableDidEnd:strongSelf];
+    }
+  }];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context {
+  if (context == kLynxVideoItemStatusContext) {
+    AVPlayerItem *item = (AVPlayerItem *)object;
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (item != strongSelf.playerItem) {
+        return;
+      }
+      if (item.status == AVPlayerItemStatusFailed) {
+        [strongSelf notifyErrorWithCode:LynxVideoErrorOperation
+                                message:item.error.localizedDescription ?: @"video load failed"];
+      } else if (item.status == AVPlayerItemStatusReadyToPlay) {
+        [strongSelf dispatchFirstFrameIfNeeded];
+      }
+    }];
+    return;
+  }
+  if (context == kLynxVideoLoadedRangesContext) {
+    AVPlayerItem *item = (AVPlayerItem *)object;
+    [self dispatchBufferingUpdateForItem:item];
+    return;
+  }
+  if (context == kLynxVideoLayerReadyContext) {
+    [self dispatchFirstFrameIfNeeded];
+    return;
+  }
+  if (context == kLynxVideoTimeControlStatusContext) {
+    AVPlayer *player = (AVPlayer *)object;
+    __weak typeof(self) weakSelf = self;
+    [self dispatchOnMainThread:^{
+      __strong typeof(weakSelf) strongSelf = weakSelf;
+      if (player != strongSelf.player) {
+        return;
+      }
+      if (player.timeControlStatus == AVPlayerTimeControlStatusPlaying) {
+        [strongSelf notifyPlayingIfNeeded];
+      } else if (player.timeControlStatus ==
+                 AVPlayerTimeControlStatusWaitingToPlayAtSpecifiedRate) {
+        [strongSelf dispatchBufferingUpdate];
+      } else if (player.timeControlStatus == AVPlayerTimeControlStatusPaused &&
+                 strongSelf.isPlaying) {
+        strongSelf.playing = NO;
+        [strongSelf notifyPaused];
+      }
+    }];
+    return;
+  }
+  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
+@end

--- a/testing/integration_test/demo_pages/video/index.tsx
+++ b/testing/integration_test/demo_pages/video/index.tsx
@@ -259,6 +259,79 @@ export function VideoDemo() {
     }, 0);
   };
 
+  const seekThenSelectSource = (label: string, url: string) => {
+    clearSignals();
+    setTimeout(() => {
+      invokeMethod('seek', { position: 2 });
+      setSrcLabel(label);
+      setSrc(url);
+      setStatus(label === 'empty' ? 'empty' : 'loading');
+      setCurrentTime(0);
+      setDuration(0);
+      setFirstFrameDuration(0);
+    }, 0);
+  };
+
+  const automationActions: Record<string, () => void> = {
+    'btn-clear-signals': clearSignals,
+    'btn-play': () => invokeMethod('play'),
+    'btn-play-null-params': () => invokeMethod('play', null),
+    'btn-pause': () => invokeMethod('pause'),
+    'btn-stop': () => invokeMethod('stop'),
+    'btn-seek-start': () => invokeMethod('seek', { position: 0 }),
+    'btn-seek': () => invokeMethod('seek', { position: 2 }),
+    'btn-seek-near-end': () => invokeMethod('seek', { position: 9.5 }),
+    'btn-seek-out-of-range': () => invokeMethod('seek', { position: 99 }),
+    'btn-seek-missing-position': () => invokeMethod('seek'),
+    'btn-seek-null-params': () => invokeMethod('seek', null),
+    'btn-seek-string-position': () => invokeMethod('seek', { position: 'bad' }),
+    'btn-seek-nan-position': () =>
+      invokeMethod('seek', { position: Number.NaN }),
+    'btn-seek-infinite-position': () =>
+      invokeMethod('seek', { position: Number.POSITIVE_INFINITY }),
+    'btn-seek-huge-position': () =>
+      invokeMethod('seek', { position: Number.MAX_VALUE }),
+    'btn-src-primary': () => selectSource('primary', PRIMARY_VIDEO_URL),
+    'btn-src-secondary': () => selectSource('secondary', SECONDARY_VIDEO_URL),
+    'btn-src-invalid': () => selectSource('invalid', INVALID_VIDEO_URL),
+    'btn-src-empty': () => selectSource('empty', ''),
+    'btn-play-then-src-empty': () => playThenSelectSource('empty', ''),
+    'btn-play-pause-then-src-empty': () =>
+      playPauseThenSelectSource('empty', ''),
+    'btn-seek-then-src-empty': () => seekThenSelectSource('empty', ''),
+    'btn-loop-on': () => setLoop(true),
+    'btn-loop-off': () => setLoop(false),
+    'btn-muted-on': () => setMuted(true),
+    'btn-muted-off': () => setMuted(false),
+    'btn-volume-low': () => setVolume(0.3),
+    'btn-volume-high': () => setVolume(1),
+    'btn-speed-half': () => setSpeed(0.5),
+    'btn-speed-normal': () => setSpeed(1),
+    'btn-speed-double': () => setSpeed(2),
+    'btn-object-contain': () => setObjectFit('contain'),
+    'btn-object-cover': () => setObjectFit('cover'),
+    'btn-object-fill': () => setObjectFit('fill'),
+    'btn-timeupdate-slow': () => setTimeUpdateInterval(1),
+    'btn-timeupdate-zero': () => setTimeUpdateInterval(0),
+    'btn-timeupdate-fast': () => setTimeUpdateInterval(0.001),
+    'btn-mode-queue': () => setMode('queue'),
+    'btn-mode-direct': () => setMode('direct'),
+    'btn-mode-latest': () => setMode('latest'),
+    'btn-burst-play-stop': () => invokeBurst([['play'], ['stop']]),
+    'btn-burst-play-pause-stop': () =>
+      invokeBurst([['play'], ['pause'], ['stop']]),
+    'btn-method-unknown': () => invokeMethod('unknownVideoMethod'),
+  };
+
+  (globalThis as any).__videoE2EAction = (tag: string) => {
+    const action = automationActions[tag];
+    if (!action) {
+      return false;
+    }
+    action();
+    return true;
+  };
+
   const attrState =
     `src=${srcLabel};loop=${loop};volume=${volume.toFixed(1)};` +
     `muted=${muted};speed=${speed.toFixed(1)};fit=${objectFit};` +
@@ -411,6 +484,29 @@ export function VideoDemo() {
         >
           <text>Seek Text</text>
         </view>
+        <view
+          lynx-test-tag="btn-seek-nan-position"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: Number.NaN })}
+        >
+          <text>Seek NaN</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-infinite-position"
+          className="button"
+          bindtap={() =>
+            invokeMethod('seek', { position: Number.POSITIVE_INFINITY })
+          }
+        >
+          <text>Seek Inf</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-huge-position"
+          className="button"
+          bindtap={() => invokeMethod('seek', { position: Number.MAX_VALUE })}
+        >
+          <text>Seek Huge</text>
+        </view>
       </view>
 
       <view className="controls">
@@ -455,6 +551,13 @@ export function VideoDemo() {
           bindtap={() => playPauseThenSelectSource('empty', '')}
         >
           <text>Play Pause Empty</text>
+        </view>
+        <view
+          lynx-test-tag="btn-seek-then-src-empty"
+          className="button"
+          bindtap={() => seekThenSelectSource('empty', '')}
+        >
+          <text>Seek Empty</text>
         </view>
       </view>
 

--- a/testing/integration_test/test_script/case_sets/xelement/VideoAttributes.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoAttributes.py
@@ -10,7 +10,7 @@ from case_sets.xelement import video_utils
 config = {
     "type": "custom",
     "path": "automation/video/main",
-    "platform": "android",
+    "platform": ["android", "ios"],
 }
 
 
@@ -100,7 +100,7 @@ def run(test):
     video_utils.click(lynxview, "btn-clear-signals")
     video_utils.click(lynxview, "btn-play")
     video_utils.wait_for_text(test, lynxview, "status-text", "playing")
-    time.sleep(4.2)
+    time.sleep(3.6)
     video_utils.assert_count_at_most(lynxview, "timeupdate", 5)
     video_utils.wait_until(
         test,

--- a/testing/integration_test/test_script/case_sets/xelement/VideoBasic.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoBasic.py
@@ -10,7 +10,7 @@ from case_sets.xelement import video_utils
 config = {
     "type": "custom",
     "path": "automation/video/main",
-    "platform": "android",
+    "platform": ["android", "ios"],
 }
 
 

--- a/testing/integration_test/test_script/case_sets/xelement/VideoBoundary.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoBoundary.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import time
 
 from case_sets.xelement import video_utils
@@ -23,14 +24,18 @@ def assert_failed_callback(lynxview, method, msg=None):
 def assert_bridge_failed_callback(lynxview, method, code):
     video_utils.assert_text_contains(lynxview, "callback-log",
                                      "%s_fail" % method)
-    video_utils.assert_text_contains(lynxview, "callback-log",
-                                     '"code":%s' % code)
+    if os.environ.get("platform") == "ios":
+        video_utils.assert_text_contains(lynxview, "callback-log",
+                                         "method '%s' not found" % method)
+    else:
+        video_utils.assert_text_contains(lynxview, "callback-log",
+                                         '"code":%s' % code)
 
 
 config = {
     "type": "custom",
     "path": "automation/video/main",
-    "platform": "android",
+    "platform": ["android", "ios"],
 }
 
 
@@ -96,11 +101,31 @@ def run(test):
                                   "pause_fail", timeout=10)
     assert_failed_callback(lynxview, "pause",
                            "request canceled by src change")
+    time.sleep(1)
+    video_utils.assert_text_occurrences(lynxview, "callback-log",
+                                        "pause_fail", 1)
+    video_utils.assert_text_not_contains(lynxview, "callback-log",
+                                         "pause_ok")
     video_utils.click(lynxview, "btn-clear-signals")
     video_utils.click(lynxview, "btn-stop")
     video_utils.wait_for_text(test, lynxview, "status-text", "stopped")
     video_utils.wait_for_contains(test, lynxview, "callback-log",
                                   "stop_ok")
+
+    video_utils.click(lynxview, "btn-src-primary")
+    video_utils.wait_for_text(test, lynxview, "status-text", "ready",
+                              timeout=20)
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-then-src-empty")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail", timeout=10)
+    assert_failed_callback(lynxview, "seek",
+                           "request canceled by src change")
+    time.sleep(1)
+    video_utils.assert_text_occurrences(lynxview, "callback-log",
+                                        "seek_fail", 1)
+    video_utils.assert_text_not_contains(lynxview, "callback-log",
+                                         "seek_ok")
 
     test.start_step("--------Test5: Seek failure callbacks;-------")
     video_utils.click(lynxview, "btn-src-primary")
@@ -128,6 +153,21 @@ def run(test):
                                   "seek_fail")
     assert_failed_callback(lynxview, "seek",
                            "position param must be a number")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-nan-position")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "position out of range")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-infinite-position")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "position out of range")
+    video_utils.click(lynxview, "btn-clear-signals")
+    video_utils.click(lynxview, "btn-seek-huge-position")
+    video_utils.wait_for_contains(test, lynxview, "callback-log",
+                                  "seek_fail")
+    assert_failed_callback(lynxview, "seek", "position out of range")
 
     test.start_step(
         "--------Test6: Null params and unknown method callbacks;-------")

--- a/testing/integration_test/test_script/case_sets/xelement/VideoModes.py
+++ b/testing/integration_test/test_script/case_sets/xelement/VideoModes.py
@@ -8,7 +8,7 @@ from case_sets.xelement import video_utils
 config = {
     "type": "custom",
     "path": "automation/video/main",
-    "platform": "android",
+    "platform": ["android", "ios"],
 }
 
 

--- a/testing/integration_test/test_script/case_sets/xelement/video_utils.py
+++ b/testing/integration_test/test_script/case_sets/xelement/video_utils.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 import os
 import re
 import time
@@ -31,7 +32,29 @@ def get_text(lynxview, tag):
 
 
 def click(lynxview, tag):
+    if os.environ.get("platform") == "ios" and _invoke_ios_action(
+            lynxview, tag):
+        return
     lynxview.get_by_test_tag(tag).click()
+
+
+def _invoke_ios_action(lynxview, tag):
+    driver = lynxview.get_lynx_driver()
+    expression = (
+        "typeof globalThis.__videoE2EAction === 'function' && "
+        "globalThis.__videoE2EAction(%s)" % json.dumps(tag)
+    )
+    try:
+        result = driver._debugger.eval(expression, driver.get_session_id())
+    except Exception as e:
+        if hasattr(lynxview, "log"):
+            lynxview.log(
+                EnumLogLevel.WARNING,
+                "iOS action eval failed: tag=%s, expression=%s, error=%s" %
+                (tag, expression, e),
+            )
+        return False
+    return result.get("result", {}).get("value") is True
 
 
 def wait_for_text(test, lynxview, tag, expected, timeout=20):
@@ -83,6 +106,15 @@ def assert_text_not_contains(lynxview, tag, unexpected):
     if unexpected in text:
         raise AssertionError("%s should not contain %s, got %s" %
                              (tag, unexpected, text))
+
+
+def assert_text_occurrences(lynxview, tag, expected, count):
+    text = get_text(lynxview, tag)
+    actual = text.count(expected)
+    if actual != count:
+        raise AssertionError(
+            "%s should contain %s exactly %s times, got %s in %s" %
+            (tag, expected, count, actual, text))
 
 
 def assert_text_order(lynxview, tag, expected_entries):

--- a/testing/integration_test/test_script/ios_test/xelement.py
+++ b/testing/integration_test/test_script/ios_test/xelement.py
@@ -1,0 +1,27 @@
+# -*- coding: UTF-8 -*-
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+search_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(search_path)
+
+from case_sets.xelement.runner import run
+from lib.ios.test import LynxTest
+
+
+class xelementTest(LynxTest):
+    timeout = 1800
+
+    def run_test(self, test=None):
+        if test is None:
+            test = self
+        test.start_step("--------Test: start to test xelement;-------")
+        run(test=test)
+
+
+if __name__ == "__main__":
+    xelementTest.debug_run()


### PR DESCRIPTION
Enable the Lynx video XElement on iOS with native playback, registration, and operation scheduling support. Add JS typings, unit tests, and integration coverage so the video API is available and verifiable end to end.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
