### PR TITLE
[BugFix] Fix ArrayBuffer length conversion order

### DIFF
--- a/core/value_wrapper/value_wrapper_utils.cc
+++ b/core/value_wrapper/value_wrapper_utils.cc
@@ -338,9 +338,9 @@ std::unique_ptr<Value> ValueUtils::ConvertPiperArrayToPubValue(
         }
         result->PushValueToArray(std::move(sub_arr_result));
       } else if (o.isArrayBuffer(rt)) {
-        size_t length;
-        result->PushArrayBufferToArray(ConvertPiperToArrayBuffer(rt, o, length),
-                                       length);
+        size_t length = 0;
+        auto array_buffer = ConvertPiperToArrayBuffer(rt, o, length);
+        result->PushArrayBufferToArray(std::move(array_buffer), length);
       } else if (o.isFunction(rt)) {
         LOGW("not support function");
         result->PushNullToArray();
@@ -421,9 +421,9 @@ std::unique_ptr<Value> ValueUtils::ConvertPiperObjectToPubValue(
         }
         result->PushValueToMap(key, std::move(sub_arr_result));
       } else if (o.isArrayBuffer(rt)) {
-        size_t length;
-        result->PushArrayBufferToMap(
-            key, ConvertPiperToArrayBuffer(rt, o, length), length);
+        size_t length = 0;
+        auto array_buffer = ConvertPiperToArrayBuffer(rt, o, length);
+        result->PushArrayBufferToMap(key, std::move(array_buffer), length);
       } else if (o.isFunction(rt)) {
         LOGW("not support function");
         result->PushNullToMap(key);


### PR DESCRIPTION
## Summary

Fixes undefined behavior when converting nested `ArrayBuffer` values in pub value wrappers.

The previous code called `PushArrayBufferToArray/Map(ConvertPiperToArrayBuffer(..., length), length)`.
Since C++ does not guarantee function argument evaluation order, `length` can be read before
`ConvertPiperToArrayBuffer` writes it. On Windows clang-cl release builds this can crash during
native module argument conversion before the target native method body is entered.

Fixes #6890.

## Test

- Built Windows Explorer x64 release-with-symbols locally.
- Confirmed the minimal repro from #6890 crashes before this fix with `0xc0000005` in `memcpy`.
