### PR TITLE
[BugFix][iOS] Pin ffi for Ruby 2.7 bundle installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,5 @@
 source 'https://rubygems.org'
 gem "cocoapods", '1.11.3'
+
+# ffi 1.17.x arm64-darwin platform gems require Ruby >= 3.0.
+gem "ffi", "~> 1.16.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,7 @@ GEM
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
+    ffi (1.16.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -101,6 +102,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.11.3)
+  ffi (~> 1.16.3)
 
 BUNDLED WITH
    2.4.20


### PR DESCRIPTION
## Summary

Pin `ffi` to `~> 1.16.3` in the Ruby bundle used by the iOS CocoaPods setup.

## Root Cause

`ffi` was only pulled in transitively through `cocoapods -> cocoapods-core -> typhoeus -> ethon`, where `ethon` allows `ffi >= 1.15.0`. Because the lockfile did not contain an explicit `ffi` spec, Bundler could resolve the latest arm64 Darwin platform gem, `ffi-1.17.4-arm64-darwin`.

That platform gem requires Ruby `>= 3.0`, which breaks `./bundle_install.sh` in the current Ruby `2.7.8` environment before CocoaPods installation can continue.

## Changes

- Add an explicit `ffi ~> 1.16.3` dependency to `Gemfile`.
- Lock `ffi 1.16.3` in `Gemfile.lock`.

## Validation

- `bundle check`
- `SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install --local --path=/private/tmp/lynx-bundle-test-online`

The local install completed using `ffi 1.16.3`.