### PR TITLE
[BugFix][iOS] Suppress C99 designator diagnostics

### DIFF
--- a/platform/darwin/ios/lynx/BUILD.gn
+++ b/platform/darwin/ios/lynx/BUILD.gn
@@ -30,6 +30,7 @@ podspec_target("lynx_podspec") {
       "-Wextra",
       "-Wno-unused-parameter",
       "-Wno-missing-field-initializers",
+      "-Wno-c99-designator",
       "-Wshorten-64-to-32",
       "-fno-rtti",
     ]


### PR DESCRIPTION
## Summary
- Add `-Wno-c99-designator` to the generated Lynx iOS pod compiler flags in `platform/darwin/ios/lynx/BUILD.gn`.
- Keep the Xcode/CocoaPods Lynx build from failing on existing C99/GNU designated-initializer syntax when the warning is promoted by the build settings.
- Avoid source-local workarounds in `vm_context.cc` or `touch_event_handler.cc`; this is handled at the iOS pod build configuration layer.

## Root Cause
The iOS Xcode build path compiles Lynx pod sources with strict warning settings. Existing Lynx C++ code can trigger Clang's `-Wc99-designator` diagnostic, including the reported `touch_event_handler.cc` initializer case. The GN/CocoaPods-generated compiler flags for the Lynx iOS pod did not suppress this diagnostic, so the Xcode build could fail even though the source pattern is already accepted by the configured compiler.

## Validation
- Rebuilt LynxExplorer for iOS Simulator with a clean DerivedData directory.
- Verified the build succeeds with the source-level C99 changes reverted.
- Command used:

```sh
xcodebuild -workspace LynxExplorer.xcworkspace -scheme LynxExplorer -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/lynx-ios-deriveddata CODE_SIGNING_ALLOWED=NO -quiet build
```

## Impact
- iOS build configuration only.
- No runtime behavior change.
- Keeps the C99-designator suppression scoped to the generated Lynx iOS pod compiler flags.