### PR TITLE
[BugFix][iOS] Guard LynxViewGroup service hook

### DIFF
--- a/platform/darwin/common/lynx/public/service/LynxServiceModuleProtocol.h
+++ b/platform/darwin/common/lynx/public/service/LynxServiceModuleProtocol.h
@@ -12,8 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO(@nihao.royal): remove LynxServiceModuleProtocol;
 @protocol LynxServiceModuleProtocol <LynxServiceProtocol>
 
+@optional
 - (void)initLynxViewGroup:(LynxViewGroup *)lynxViewGroup;
 
+@required
 /**
  * @depreacted: No need to initialize global props by LynxService.
  */

--- a/platform/darwin/ios/lynx/LynxViewGroup.mm
+++ b/platform/darwin/ios/lynx/LynxViewGroup.mm
@@ -217,7 +217,10 @@
 
 - (void)setConfig:(LynxConfig *)config {
   [super setConfig:config];
-  [LynxService(LynxServiceModuleProtocol) initLynxViewGroup:self];
+  id<LynxServiceModuleProtocol> moduleService = LynxService(LynxServiceModuleProtocol);
+  if ([moduleService respondsToSelector:@selector(initLynxViewGroup:)]) {
+    [moduleService initLynxViewGroup:self];
+  }
 }
 
 - (void)registerModule:(nonnull Class<LynxModule>)module {


### PR DESCRIPTION
## Summary
- Make `initLynxViewGroup:` an optional hook on `LynxServiceModuleProtocol`.
- Guard the `LynxViewGroup` call with `respondsToSelector:` before invoking the hook.
- Preserve the existing required module-service methods by restoring `@required` after the optional hook.

## Root Cause
`initLynxViewGroup:` is a newer lifecycle hook, but `LynxServiceModuleProtocol` is implemented by downstream Swift services. Treating the hook as required breaks existing conformers such as SparklingMethod's module service, producing the Swift build error:

```text
Protocol requires function 'initLynxViewGroup' with type '(LynxViewGroup) -> Void'
```

The hook is only needed by services that actually handle `LynxViewGroup` setup, so Lynx should call it opportunistically instead of making every service implementation adopt it immediately.

## Validation
- Rebuilt LynxExplorer for iOS Simulator with Sparkling pods present.
- Confirmed the previous Swift protocol-conformance failure is gone.
- Command used:

```sh
xcodebuild -workspace LynxExplorer.xcworkspace -scheme LynxExplorer -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/lynx-ios-deriveddata CODE_SIGNING_ALLOWED=NO -quiet build
```

## Impact
- Restores source compatibility for existing `LynxServiceModuleProtocol` implementations.
- Services that implement `initLynxViewGroup:` still receive the hook.
- Services that do not implement it continue to build and run without an unrecognized selector call.