### PR TITLE
[Infra] auto-sync lynx_version from config.h during podspec generation.

### DIFF
--- a/explorer/darwin/ios/lynx_explorer/bundle_install.sh
+++ b/explorer/darwin/ios/lynx_explorer/bundle_install.sh
@@ -74,7 +74,7 @@ build_card_resources
 pushd $root_dir
 gn_root_dir=$(readlink -f $root_dir)
 echo "gn_root_dir: $gn_root_dir"
-generate_ios_podspec_cmd="python3 tools/ios_tools/generate_podspec_scripts_by_gn.py --root $gn_root_dir $enable_trace_param"
+generate_ios_podspec_cmd="python3 tools/ios_tools/generate_podspec_scripts_by_gn.py --root $gn_root_dir $enable_trace_param --enable-autosync-version"
 echo $generate_ios_podspec_cmd
 eval "$generate_ios_podspec_cmd"
 popd

--- a/tools/ios_tools/generate_podspec_scripts_by_gn.py
+++ b/tools/ios_tools/generate_podspec_scripts_by_gn.py
@@ -15,12 +15,27 @@ If the value of TARGET is not specified, all podspecs will be generated.
 import argparse
 import sys
 import os
+import re
 
 root_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.append(root_path)
 from tools_shared.ios_tools.generate_podspec_scripts_from_gn import generate_compile_products
 
-
+def get_max_lynx_version(config_h_path):
+    max_major, max_minor = -1, -1
+    pattern = re.compile(r'#define\s+LYNX_VERSION_(\d+)_(\d+)\s+tasm::V_\1_\2')
+    if not os.path.exists(config_h_path):
+        return None
+    with open(config_h_path, 'r') as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                major, minor = int(match.group(1)), int(match.group(2))
+                if (major, minor) > (max_major, max_minor):
+                    max_major, max_minor = major, minor
+    if max_major != -1:
+        return f"{max_major}.{max_minor}"
+    return None
 
 def main():
   parser = argparse.ArgumentParser()
@@ -28,6 +43,7 @@ def main():
   parser.add_argument('--target', type=str, required=False, help='The GN name of the podspec target you want to generate automatically')
   parser.add_argument('--is-debug', default=False, action='store_true', help='Whether to set the is_debug flag to true, which will be used by the gn script.')
   parser.add_argument('--enable-trace', default=False, action='store_true', help='Whether to set the enable_trace flag to true, which will be used by the gn script.')
+  parser.add_argument('--enable-autosync-version', default=False, action='store_true', help='Enable automatic sync of lynx_version from config.h to darwin.gni.')
   args = parser.parse_args()
 
   args.gn_args = f'use_xcode=true enable_testbench_replay=true enable_inspector=true \
@@ -37,7 +53,27 @@ def main():
   root_path = args.root
   args.target_exclude_patterns = []
 
-  return generate_compile_products(root_path, args)
+  darwin_gni_path = os.path.join(root_path, 'build_overrides', 'darwin.gni')
+  original_gni_content = None
+  
+  if args.enable_autosync_version:
+      config_h_path = os.path.join(root_path, 'core', 'renderer', 'tasm', 'config.h')
+      max_version = get_max_lynx_version(config_h_path)
+      
+      if max_version and os.path.exists(darwin_gni_path):
+          with open(darwin_gni_path, 'r') as f:
+              original_gni_content = f.read()
+          
+          new_gni_content = re.sub(r'(lynx_version\s*=\s*)"[^"]+"', r'\g<1>"' + max_version + '"', original_gni_content)
+          with open(darwin_gni_path, 'w') as f:
+              f.write(new_gni_content)
+
+  try:
+      return generate_compile_products(root_path, args)
+  finally:
+      if original_gni_content is not None:
+          with open(darwin_gni_path, 'w') as f:
+              f.write(original_gni_content)
 
 if __name__ == "__main__":
   sys.exit(main())


### PR DESCRIPTION
Dynamically parse the maximum lynxversion from config.h, and auto-sync lynx_version during podspec generation.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
