### PR TITLE
[Refactor][Library] Rename native library API markers

### DIFF
--- a/platform/android/api/lynx_android.api
+++ b/platform/android/api/lynx_android.api
@@ -3937,21 +3937,6 @@ public enum com::lynx::tasm::animation::keyframe::LynxKeyframeAnimator::LynxAnim
 public interface com::lynx::jsbridge::LynxAttribute {
 }
 
-public interface com::lynx::tasm::behavior::LynxAutolinkElement {
-  public String com.lynx.tasm.behavior.LynxAutolinkElement.name();
-  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.isCreateAsync() default false;
-  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.needProcessDirection() default false;
-  public boolean com.lynx.tasm.behavior.LynxAutolinkElement.supportFragmentLayerRender() default false;
-  public Class<? extends IRendererHost > com.lynx.tasm.behavior.LynxAutolinkElement.fragmentLayerRendererHost() default IRendererHost.class;
-}
-
-public interface com::lynx::jsbridge::LynxAutolinkNativeModule {
-  public String com.lynx.jsbridge.LynxAutolinkNativeModule.name();
-}
-
-public interface com::lynx::tasm::service::LynxAutolinkService {
-}
-
 public class com::lynx::tasm::behavior::ui::utils::LynxBackground : LynxDrawableManager< BackgroundDrawable > {
   public com.lynx.tasm.behavior.ui.utils.LynxBackground.LynxBackground(LynxContext context);
   public void com.lynx.tasm.behavior.ui.utils.LynxBackground.setBackgroundColor(int color);
@@ -5067,6 +5052,14 @@ public class com::lynx::devtoolwrapper::LynxDevToolUtils :  {
 }
 
 public class abstract com::lynx::tasm::behavior::ui::utils::LynxDrawableManager< T extends LayerDrawable :  {
+}
+
+public interface com::lynx::tasm::behavior::LynxElement {
+  public String com.lynx.tasm.behavior.LynxElement.name();
+  public boolean com.lynx.tasm.behavior.LynxElement.isCreateAsync() default false;
+  public boolean com.lynx.tasm.behavior.LynxElement.needProcessDirection() default false;
+  public boolean com.lynx.tasm.behavior.LynxElement.supportFragmentLayerRender() default false;
+  public Class<? extends IRendererHost > com.lynx.tasm.behavior.LynxElement.fragmentLayerRendererHost() default IRendererHost.class;
 }
 
 public class com::lynx::jsbridge::LynxEmbeddedModule : com.lynx.jsbridge.LynxContextModule {
@@ -6233,6 +6226,10 @@ public class com::lynx::tasm::base::LynxNativeMemoryTracer :  {
   public static void com.lynx.tasm.base.LynxNativeMemoryTracer.stopTracing();
 }
 
+public interface com::lynx::jsbridge::LynxNativeModule {
+  public String com.lynx.jsbridge.LynxNativeModule.name();
+}
+
 public class com::lynx::tasm::navigator::LynxNavigator :  {
   public static LynxNavigator com.lynx.tasm.navigator.LynxNavigator.inst();
   public LynxNavigator com.lynx.tasm.navigator.LynxNavigator.setSchemaInterceptor(LynxSchemaInterceptor interceptor);
@@ -6626,6 +6623,9 @@ public class com::lynx::tasm::event::LynxScrollEvent : com.lynx.tasm.event.LynxD
   public com.lynx.tasm.event.LynxScrollEvent.LynxScrollEvent(int tag, String type);
   public void com.lynx.tasm.event.LynxScrollEvent.setScrollParams(int left, int top, int contentHeight, int contentWidth, int x, int y);
   public static LynxScrollEvent com.lynx.tasm.event.LynxScrollEvent.createScrollEvent(int tag, String type);
+}
+
+public interface com::lynx::tasm::service::LynxService {
 }
 
 public class com::lynx::tasm::service::LynxServiceCenter :  {

--- a/platform/android/lynx_android/proguard-rules.pro
+++ b/platform/android/lynx_android/proguard-rules.pro
@@ -65,13 +65,13 @@
 -keep class * implements com.lynx.tasm.library.LynxLibraryProvider {
     *;
 }
--keep @com.lynx.tasm.behavior.LynxAutolinkElement class * {
+-keep @com.lynx.tasm.behavior.LynxElement class * {
     *;
 }
--keep @com.lynx.jsbridge.LynxAutolinkNativeModule class * {
+-keep @com.lynx.jsbridge.LynxNativeModule class * {
     *;
 }
--keep @com.lynx.tasm.service.LynxAutolinkService class * {
+-keep @com.lynx.tasm.service.LynxService class * {
     *;
 }
 

--- a/platform/android/lynx_android/src/main/java/com/lynx/jsbridge/LynxNativeModule.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/jsbridge/LynxNativeModule.java
@@ -12,6 +12,6 @@ import java.lang.annotation.Target;
 
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkNativeModule {
+public @interface LynxNativeModule {
   String name();
 }

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxElement.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/LynxElement.java
@@ -2,20 +2,21 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-package com.lynx.jsbridge;
+package com.lynx.tasm.behavior;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import com.lynx.tasm.behavior.render.IRendererHost;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-/**
- * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
- * LynxAutolinkNativeModule annotation.
- */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkNativeModule {
+public @interface LynxElement {
   String name();
+  boolean isCreateAsync() default false;
+  boolean needProcessDirection() default false;
+  boolean supportFragmentLayerRender() default false;
+  Class<? extends IRendererHost> fragmentLayerRendererHost() default IRendererHost.class;
 }

--- a/platform/android/lynx_processor/src/main/java/com/lynx/jsbridge/LynxNativeModule.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/jsbridge/LynxNativeModule.java
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-package com.lynx.tasm.service;
+package com.lynx.jsbridge;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -10,6 +10,12 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
+ * LynxNativeModule annotation.
+ */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkService {}
+public @interface LynxNativeModule {
+  String name();
+}

--- a/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxBehaviorProcessor.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxBehaviorProcessor.java
@@ -12,8 +12,8 @@ import static javax.tools.Diagnostic.Kind.WARNING;
 
 import androidx.annotation.Keep;
 import com.google.auto.service.AutoService;
-import com.lynx.tasm.behavior.LynxAutolinkElement;
 import com.lynx.tasm.behavior.LynxBehavior;
+import com.lynx.tasm.behavior.LynxElement;
 import com.lynx.tasm.behavior.LynxGeneratorName;
 import com.lynx.tasm.behavior.LynxShadowNode;
 import com.squareup.javapoet.ClassName;
@@ -73,7 +73,7 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
   public Set<String> getSupportedAnnotationTypes() {
     Set<String> types = new HashSet<>();
     types.add(LynxBehavior.class.getCanonicalName());
-    types.add(LynxAutolinkElement.class.getCanonicalName());
+    types.add(LynxElement.class.getCanonicalName());
     types.add(LynxShadowNode.class.getCanonicalName());
     types.add(LynxGeneratorName.class.getCanonicalName());
     return types;
@@ -129,13 +129,13 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
     }
 
     Set<? extends Element> elementAnnotatedClasses =
-        roundEnvironment.getElementsAnnotatedWith(LynxAutolinkElement.class);
+        roundEnvironment.getElementsAnnotatedWith(LynxElement.class);
     if (elementAnnotatedClasses != null) {
       for (Element element : elementAnnotatedClasses) {
         try {
           TypeElement classType = (TypeElement) element;
           ClassName className = ClassName.get(classType);
-          ClassInfo classInfo = parseAutolinkElementClass(className, classType);
+          ClassInfo classInfo = parseLynxElementClass(className, classType);
           if (packageName.isEmpty()) {
             packageName = className.packageName();
           }
@@ -339,13 +339,13 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
     return classInfo;
   }
 
-  private ClassInfo parseAutolinkElementClass(ClassName className, TypeElement typeElement) {
+  private ClassInfo parseLynxElementClass(ClassName className, TypeElement typeElement) {
     ClassInfo classInfo = new ClassInfo(className, typeElement);
-    classInfo.addAutolinkElementTag(typeElement);
-    classInfo.addAutolinkElementIsCreateAsync(typeElement);
-    classInfo.addAutolinkElementNeedProcessDirection(typeElement);
-    classInfo.addAutolinkElementSupportFragmentLayerRender(typeElement);
-    classInfo.addAutolinkElementFragmentLayerRendererHost(typeElement);
+    classInfo.addLynxElementTag(typeElement);
+    classInfo.addLynxElementIsCreateAsync(typeElement);
+    classInfo.addLynxElementNeedProcessDirection(typeElement);
+    classInfo.addLynxElementSupportFragmentLayerRender(typeElement);
+    classInfo.addLynxElementFragmentLayerRendererHost(typeElement);
     return classInfo;
   }
 
@@ -396,8 +396,8 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       tagName.addAll(Arrays.asList(annotation.tagName()));
     }
 
-    public void addAutolinkElementTag(Element element) {
-      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+    public void addLynxElementTag(Element element) {
+      LynxElement annotation = element.getAnnotation(LynxElement.class);
       tagName.add(annotation.name());
     }
 
@@ -406,8 +406,8 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       isCreateAsync = annotation.isCreateAsync();
     }
 
-    public void addAutolinkElementIsCreateAsync(Element element) {
-      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+    public void addLynxElementIsCreateAsync(Element element) {
+      LynxElement annotation = element.getAnnotation(LynxElement.class);
       isCreateAsync = annotation.isCreateAsync();
     }
 
@@ -416,8 +416,8 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       needProcessDirection = annotation.needProcessDirection();
     }
 
-    public void addAutolinkElementNeedProcessDirection(Element element) {
-      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+    public void addLynxElementNeedProcessDirection(Element element) {
+      LynxElement annotation = element.getAnnotation(LynxElement.class);
       needProcessDirection = annotation.needProcessDirection();
     }
 
@@ -426,8 +426,8 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       supportFragmentLayerRender = annotation.supportFragmentLayerRender();
     }
 
-    public void addAutolinkElementSupportFragmentLayerRender(Element element) {
-      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+    public void addLynxElementSupportFragmentLayerRender(Element element) {
+      LynxElement annotation = element.getAnnotation(LynxElement.class);
       supportFragmentLayerRender = annotation.supportFragmentLayerRender();
     }
 
@@ -447,8 +447,8 @@ public class LynxBehaviorProcessor extends AbstractProcessor {
       }
     }
 
-    public void addAutolinkElementFragmentLayerRendererHost(Element element) {
-      LynxAutolinkElement annotation = element.getAnnotation(LynxAutolinkElement.class);
+    public void addLynxElementFragmentLayerRendererHost(Element element) {
+      LynxElement annotation = element.getAnnotation(LynxElement.class);
       TypeMirror typeMirror = null;
       try {
         annotation.fragmentLayerRendererHost();

--- a/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxLibraryProcessor.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/processor/LynxLibraryProcessor.java
@@ -9,11 +9,11 @@ import static javax.tools.Diagnostic.Kind.ERROR;
 
 import androidx.annotation.Keep;
 import com.google.auto.service.AutoService;
-import com.lynx.jsbridge.LynxAutolinkNativeModule;
-import com.lynx.tasm.behavior.LynxAutolinkElement;
+import com.lynx.jsbridge.LynxNativeModule;
 import com.lynx.tasm.behavior.LynxBehavior;
+import com.lynx.tasm.behavior.LynxElement;
 import com.lynx.tasm.behavior.LynxGeneratorName;
-import com.lynx.tasm.service.LynxAutolinkService;
+import com.lynx.tasm.service.LynxService;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -59,9 +59,9 @@ public class LynxLibraryProcessor extends AbstractProcessor {
   public Set<String> getSupportedAnnotationTypes() {
     Set<String> annotations = new HashSet<>();
     annotations.add(LynxBehavior.class.getCanonicalName());
-    annotations.add(LynxAutolinkElement.class.getCanonicalName());
-    annotations.add(LynxAutolinkNativeModule.class.getCanonicalName());
-    annotations.add(LynxAutolinkService.class.getCanonicalName());
+    annotations.add(LynxElement.class.getCanonicalName());
+    annotations.add(LynxNativeModule.class.getCanonicalName());
+    annotations.add(LynxService.class.getCanonicalName());
     annotations.add(LynxGeneratorName.class.getCanonicalName());
     return annotations;
   }
@@ -119,7 +119,7 @@ public class LynxLibraryProcessor extends AbstractProcessor {
     for (Element element : roundEnv.getElementsAnnotatedWith(LynxBehavior.class)) {
       return ClassName.get((TypeElement) element).packageName();
     }
-    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkElement.class)) {
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxElement.class)) {
       return ClassName.get((TypeElement) element).packageName();
     }
     return "";
@@ -127,10 +127,9 @@ public class LynxLibraryProcessor extends AbstractProcessor {
 
   private List<ModuleInfo> getNativeModules(RoundEnvironment roundEnv) {
     List<ModuleInfo> modules = new ArrayList<>();
-    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkNativeModule.class)) {
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxNativeModule.class)) {
       TypeElement typeElement = (TypeElement) element;
-      LynxAutolinkNativeModule annotation =
-          typeElement.getAnnotation(LynxAutolinkNativeModule.class);
+      LynxNativeModule annotation = typeElement.getAnnotation(LynxNativeModule.class);
       modules.add(new ModuleInfo(annotation.name(), ClassName.get(typeElement)));
     }
     return modules;
@@ -138,7 +137,7 @@ public class LynxLibraryProcessor extends AbstractProcessor {
 
   private List<ClassName> getServices(RoundEnvironment roundEnv) {
     List<ClassName> services = new ArrayList<>();
-    for (Element element : roundEnv.getElementsAnnotatedWith(LynxAutolinkService.class)) {
+    for (Element element : roundEnv.getElementsAnnotatedWith(LynxService.class)) {
       services.add(ClassName.get((TypeElement) element));
     }
     return services;

--- a/platform/android/lynx_processor/src/main/java/com/lynx/tasm/behavior/LynxElement.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/tasm/behavior/LynxElement.java
@@ -6,17 +6,20 @@ package com.lynx.tasm.behavior;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import com.lynx.tasm.behavior.render.IRendererHost;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
+ * LynxElement annotation.
+ */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkElement {
+public @interface LynxElement {
   String name();
   boolean isCreateAsync() default false;
   boolean needProcessDirection() default false;
   boolean supportFragmentLayerRender() default false;
-  Class<? extends IRendererHost> fragmentLayerRendererHost() default IRendererHost.class;
+  Class<?> fragmentLayerRendererHost() default void.class;
 }

--- a/platform/android/lynx_processor/src/main/java/com/lynx/tasm/service/LynxService.java
+++ b/platform/android/lynx_processor/src/main/java/com/lynx/tasm/service/LynxService.java
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-package com.lynx.tasm.behavior;
+package com.lynx.tasm.service;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -12,14 +12,8 @@ import java.lang.annotation.Target;
 
 /**
  * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
- * LynxAutolinkElement annotation.
+ * LynxService annotation.
  */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkElement {
-  String name();
-  boolean isCreateAsync() default false;
-  boolean needProcessDirection() default false;
-  boolean supportFragmentLayerRender() default false;
-  Class<?> fragmentLayerRendererHost() default void.class;
-}
+public @interface LynxService {}

--- a/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxBehaviorProcessorTest.java
+++ b/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxBehaviorProcessorTest.java
@@ -109,13 +109,13 @@ public class LynxBehaviorProcessorTest {
   }
 
   @Test
-  public void testLynxAutolinkElementAnnotation() throws IOException {
+  public void testLynxElementAnnotation() throws IOException {
     JavaFileObject testClass = JavaFileObjects.forSourceString("com.test.TestElement",
         "package com.test;\n"
-            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxElement;\n"
             + "import com.lynx.tasm.behavior.LynxContext;\n"
             + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
-            + "@LynxAutolinkElement(name = \"test-element\", isCreateAsync = true)\n"
+            + "@LynxElement(name = \"test-element\", isCreateAsync = true)\n"
             + "public class TestElement extends LynxUI {\n"
             + "  public TestElement(LynxContext context) { super(context); }\n"
             + "}\n");
@@ -127,7 +127,7 @@ public class LynxBehaviorProcessorTest {
     assertTrue("Compilation should succeed", compilation.status() == Compilation.Status.SUCCESS);
 
     String source = getGeneratedSource(compilation, "com.test.BehaviorGenerator");
-    assertTrue("Should use LynxAutolinkElement name",
+    assertTrue("Should use LynxElement name",
         source.contains("new Behavior(\"test-element\", false, true, false)"));
   }
 
@@ -218,14 +218,14 @@ public class LynxBehaviorProcessorTest {
   }
 
   @Test
-  public void testAutolinkElementWithDefaultRendererHostSentinel() throws IOException {
+  public void testLynxElementWithDefaultRendererHostSentinel() throws IOException {
     JavaFileObject testClass = JavaFileObjects.forSourceString("com.test.TestElement",
         "package com.test;\n"
-            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxElement;\n"
             + "import com.lynx.tasm.behavior.LynxContext;\n"
             + "import com.lynx.tasm.behavior.render.IRendererHost;\n"
             + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
-            + "@LynxAutolinkElement(name = \"test\", supportFragmentLayerRender = true, "
+            + "@LynxElement(name = \"test\", supportFragmentLayerRender = true, "
             + "fragmentLayerRendererHost = IRendererHost.class)\n"
             + "public class TestElement extends LynxUI {\n"
             + "  public TestElement(LynxContext context) { super(context); }\n"

--- a/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxLibraryProcessorTest.java
+++ b/platform/android/lynx_processor/src/test/java/com/lynx/processor/LynxLibraryProcessorTest.java
@@ -98,23 +98,23 @@ public class LynxLibraryProcessorTest {
     JavaFileObject element = JavaFileObjects.forSourceString("com.lib.Button",
         "package com.lib;\n"
             + "import com.lynx.tasm.behavior.LynxContext;\n"
-            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxElement;\n"
             + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
-            + "@LynxAutolinkElement(name = \"button\")\n"
+            + "@LynxElement(name = \"button\")\n"
             + "public class Button extends LynxUI {\n"
             + "  public Button(LynxContext context) { super(context); }\n"
             + "}\n");
     JavaFileObject module = JavaFileObjects.forSourceString("com.lib.StorageModule",
         "package com.lib;\n"
             + "import com.lynx.jsbridge.LynxModule;\n"
-            + "import com.lynx.jsbridge.LynxAutolinkNativeModule;\n"
-            + "@LynxAutolinkNativeModule(name = \"NativeLocalStorage\")\n"
+            + "import com.lynx.jsbridge.LynxNativeModule;\n"
+            + "@LynxNativeModule(name = \"NativeLocalStorage\")\n"
             + "public class StorageModule extends LynxModule {}\n");
     JavaFileObject service = JavaFileObjects.forSourceString("com.lib.LogService",
         "package com.lib;\n"
             + "import com.lynx.tasm.service.IServiceProvider;\n"
-            + "import com.lynx.tasm.service.LynxAutolinkService;\n"
-            + "@LynxAutolinkService\n"
+            + "import com.lynx.tasm.service.LynxService;\n"
+            + "@LynxService\n"
             + "public class LogService implements IServiceProvider {}\n");
 
     Compilation compilation =
@@ -154,23 +154,23 @@ public class LynxLibraryProcessorTest {
     JavaFileObject element = JavaFileObjects.forSourceString("com.lib.Button",
         "package com.lib;\n"
             + "import com.lynx.tasm.behavior.LynxContext;\n"
-            + "import com.lynx.tasm.behavior.LynxAutolinkElement;\n"
+            + "import com.lynx.tasm.behavior.LynxElement;\n"
             + "import com.lynx.tasm.behavior.ui.LynxUI;\n"
-            + "@LynxAutolinkElement(name = \"button\")\n"
+            + "@LynxElement(name = \"button\")\n"
             + "public class Button extends LynxUI {\n"
             + "  public Button(LynxContext context) { super(context); }\n"
             + "}\n");
     JavaFileObject module = JavaFileObjects.forSourceString("com.lib.StorageModule",
         "package com.lib;\n"
             + "import com.lynx.jsbridge.LynxModule;\n"
-            + "import com.lynx.jsbridge.LynxAutolinkNativeModule;\n"
-            + "@LynxAutolinkNativeModule(name = \"NativeLocalStorage\")\n"
+            + "import com.lynx.jsbridge.LynxNativeModule;\n"
+            + "@LynxNativeModule(name = \"NativeLocalStorage\")\n"
             + "public class StorageModule extends LynxModule {}\n");
     JavaFileObject service = JavaFileObjects.forSourceString("com.lib.LogService",
         "package com.lib;\n"
             + "import com.lynx.tasm.service.IServiceProvider;\n"
-            + "import com.lynx.tasm.service.LynxAutolinkService;\n"
-            + "@LynxAutolinkService\n"
+            + "import com.lynx.tasm.service.LynxService;\n"
+            + "@LynxService\n"
             + "public class LogService implements IServiceProvider {}\n");
 
     Compilation compilation = javac()

--- a/platform/android/service_api/src/main/java/com/lynx/tasm/service/LynxService.java
+++ b/platform/android/service_api/src/main/java/com/lynx/tasm/service/LynxService.java
@@ -10,10 +10,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-/**
- * Compile-time mirror used by LynxProcessor. Keep this in sync with the public
- * LynxAutolinkService annotation.
- */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
-public @interface LynxAutolinkService {}
+public @interface LynxService {}

--- a/platform/darwin/common/lynx/public/module/LynxModule.h
+++ b/platform/darwin/common/lynx/public/module/LynxModule.h
@@ -18,8 +18,8 @@ typedef NSDictionary *_Nullable (^LynxMethodSessionBlock)(NSString *method, NSSt
                                                           NSString *invoke_session,
                                                           NSString *name_space);
 
-#if defined(__OBJC__) && !defined(LynxAutolinkNativeModule)
-#define LynxAutolinkNativeModule(module_name) class LynxAutolinkNativeModuleMarker;
+#if defined(__OBJC__) && !defined(LynxNativeModuleRegister)
+#define LynxNativeModuleRegister(module_name) class LynxNativeModuleRegisterMarker;
 #endif
 
 @protocol LynxModule <NSObject>

--- a/platform/darwin/ios/lynx/public/ui/LynxUI.h
+++ b/platform/darwin/ios/lynx/public/ui/LynxUI.h
@@ -16,8 +16,8 @@
 #import <Lynx/LynxUITarget.h>
 #import <Lynx/UIScrollView+Nested.h>
 
-#if defined(__OBJC__) && !defined(LynxAutolinkUI)
-#define LynxAutolinkUI(name) class LynxAutolinkUIMarker;
+#if defined(__OBJC__) && !defined(LynxUIRegister)
+#define LynxUIRegister(name) class LynxUIRegisterMarker;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/darwin/ios/lynx_service_api/ServiceAPI.h
+++ b/platform/darwin/ios/lynx_service_api/ServiceAPI.h
@@ -66,10 +66,6 @@ typedef struct {
   @end
 #endif
 
-#ifndef LynxAutolinkService
-#define LynxAutolinkService(clsName, protocolName) LynxServiceRegister(clsName, protocolName)
-#endif
-
 /**
  * Bind protocol and class, e.g., LYNX_SERVICE_BIND (LynxMonitorService,
  * LynxMonitorProtocol)

--- a/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
@@ -175,19 +175,15 @@ module Lynx
               components << ComponentInfo.new(:renderer_host, name.first, class_name)
             end
           end
-          content.scan(/@?LynxAutolinkUI\(\s*@?"([^"]+)"\s*\)\s*@implementation\s+([A-Za-z_][A-Za-z0-9_]*)/) do
+          content.scan(/@LynxUIRegister\(\s*@?"([^"]+)"\s*\)\s*@implementation\s+([A-Za-z_][A-Za-z0-9_]*)/) do
             |name, class_name|
             components << ComponentInfo.new(:ui, name, class_name)
           end
-          content.scan(/@?LynxAutolinkNativeModule\(\s*@?"([^"]+)"\s*\)\s*@(implementation|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/) do
+          content.scan(/@LynxNativeModuleRegister\(\s*@?"([^"]+)"\s*\)\s*@(implementation|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/) do
             |name, _declaration, class_name|
             components << ComponentInfo.new(:native_module, name, class_name)
           end
-          content.scan(/@?LynxAutolinkService\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/) do
-            |class_name, protocol_name|
-            components << ComponentInfo.new(:service, protocol_name, class_name)
-          end
-          content.scan(/@?LynxServiceRegister\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/) do
+          content.scan(/@LynxServiceRegister\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/) do
             |class_name, protocol_name|
             components << ComponentInfo.new(:service, protocol_name, class_name)
           end

--- a/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
@@ -25,7 +25,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       package_dir = write_library(dir, '@scope/demo-lib', 'DemoLib')
       File.write(File.join(package_dir, 'ios/DemoModule.m'), <<~OBJC)
         #import <Lynx/LynxModule.h>
-        @LynxAutolinkNativeModule("NativeLocalStorage")
+        @LynxNativeModuleRegister("NativeLocalStorage")
         @interface DemoModule : NSObject <LynxModule>
         @end
         @implementation DemoModule
@@ -34,8 +34,8 @@ class LynxLibraryAutolinkTest < Minitest::Test
       OBJC
       File.write(File.join(package_dir, 'ios/DemoUI.m'), <<~OBJC)
         #import <Lynx/LynxUI.h>
-        @LynxAutolinkUI("autolink-ui")
-        @implementation DemoAutolinkUI
+        @LynxUIRegister("marked-ui")
+        @implementation DemoMarkedUI
         @end
 
         @implementation DemoUI
@@ -49,7 +49,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       OBJC
       File.write(File.join(package_dir, 'ios/DemoService.m'), <<~OBJC)
         #import <LynxServiceAPI/ServiceAPI.h>
-        @LynxAutolinkService(DemoService, LynxDemoServiceProtocol)
+        @LynxServiceRegister(DemoService, LynxDemoServiceProtocol)
         @implementation DemoService
         @end
 
@@ -82,7 +82,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       assert_includes implementation,
                       '[config registerModule:NSClassFromString(@"DemoModule") withName:@"NativeLocalStorage"]'
       assert_includes implementation,
-                      '[config registerUI:NSClassFromString(@"DemoAutolinkUI") withName:@"autolink-ui"]'
+                      '[config registerUI:NSClassFromString(@"DemoMarkedUI") withName:@"marked-ui"]'
       assert_includes implementation,
                       '[config registerUI:NSClassFromString(@"DemoUI") withName:@"demo-ui"]'
       assert_includes implementation,
@@ -96,7 +96,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       package_dir = write_library(dir, 'demo-lib', 'DemoLib')
       File.write(File.join(package_dir, 'ios/OldModule.m'), <<~OBJC)
         #import <Lynx/LynxModule.h>
-        LynxNativeModule("OldModule")
+        LynxNativeModuleRegister("OldModule")
         @interface OldModule : NSObject <LynxModule>
         @end
       OBJC


### PR DESCRIPTION
## Summary
- Rename Android native library marker annotations to `LynxElement`, `LynxNativeModule`, and `LynxService`, including processor mirrors, proguard rules, API baseline, and processor tests.
- Rename Darwin marker macros to `LynxUIRegister` and `LynxNativeModuleRegister`, and use the existing `LynxServiceRegister` API for service registration.
- Update the CocoaPods library scanner and tests to recognize the new Darwin markers and require the `@` form to avoid matching non-annotation marker uses.

## Validation
- `PATH="$PWD/buildtools/llvm/bin:$PATH" python3 tools_shared/git_lynx.py check --checkers coding-style`
- `ruby -Itools/ios_tools/cocoapods-lynx-library/lib tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb`
- `cd platform/android && ./gradlew :LynxProcessor:test`
- `git diff --check`

## Notes
- `cd platform/android && ./gradlew :ServiceAPI:compileNoasanDebugJavaWithJavac` did not reach Java compilation because project configuration requires `out/android/gn_args/gn_args.json`.
- `cd platform/android && ./gradlew :LynxAndroid:compileNoasanDebugJavaWithJavac` did not reach Java compilation because the local `third_party/weak-node-api` package is missing `node_modules/@lynx-js/weak-node-api/shim`.