### PR TITLE
[Feature][Android] Use ILynxImageService for markdown image loading

### DIFF
--- a/platform/android/lynx_xelement/lynx_xelement_markdown/build.gradle
+++ b/platform/android/lynx_xelement/lynx_xelement_markdown/build.gradle
@@ -37,6 +37,4 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.appcompat:appcompat:1.0.0"
     compileOnly "org.lynxsdk.lynx:serval_markdown:0.1.1"
-    //remove this after.
-    compileOnly('com.facebook.fresco:fresco:1.10.0')
 }

--- a/platform/android/lynx_xelement/lynx_xelement_markdown/src/main/java/com/lynx/xelement/markdown/adaptor/LynxServalViewWrapper.java
+++ b/platform/android/lynx_xelement/lynx_xelement_markdown/src/main/java/com/lynx/xelement/markdown/adaptor/LynxServalViewWrapper.java
@@ -4,14 +4,50 @@
 package com.lynx.xelement.markdown.adaptor;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Handler;
+import android.os.Looper;
+import androidx.annotation.NonNull;
 import com.lynx.markdown.ServalMarkdownView;
 import com.lynx.tasm.behavior.shadow.ShadowNode;
+import java.util.HashMap;
+import java.util.Map;
 
 public class LynxServalViewWrapper extends ServalMarkdownView {
   protected final ShadowNode mShadowNode;
+  private final Handler mHandler = new Handler(Looper.getMainLooper());
+  private final Map<Drawable, String> mAnimatedDrawables = new HashMap<>();
+
   public LynxServalViewWrapper(Context context, ShadowNode shadowNode) {
     super(context);
     mShadowNode = shadowNode;
+  }
+
+  public void registerAnimatedDrawable(Drawable drawable, String url) {
+    mAnimatedDrawables.put(drawable, url);
+  }
+
+  public void unregisterAnimatedDrawable(Drawable drawable) {
+    mAnimatedDrawables.remove(drawable);
+  }
+
+  @Override
+  public void invalidateDrawable(@NonNull Drawable who) {
+    String url = mAnimatedDrawables.get(who);
+    if (url != null) {
+      onImageLoaded(url);
+    }
+  }
+
+  @Override
+  public void scheduleDrawable(@NonNull Drawable who, @NonNull Runnable what, long when) {
+    long delay = Math.max(0, when - android.os.SystemClock.uptimeMillis());
+    mHandler.postDelayed(what, delay);
+  }
+
+  @Override
+  public void unscheduleDrawable(@NonNull Drawable who, @NonNull Runnable what) {
+    mHandler.removeCallbacks(what);
   }
 
   @Override

--- a/platform/android/lynx_xelement/lynx_xelement_markdown/src/main/java/com/lynx/xelement/markdown/adaptor/MarkdownImageResource.java
+++ b/platform/android/lynx_xelement/lynx_xelement_markdown/src/main/java/com/lynx/xelement/markdown/adaptor/MarkdownImageResource.java
@@ -3,42 +3,41 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.xelement.markdown.adaptor;
 
-import android.graphics.Canvas;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Animatable;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.net.Uri;
 import android.text.TextUtils;
 import androidx.annotation.Nullable;
-import com.facebook.drawee.backends.pipeline.Fresco;
-import com.facebook.drawee.controller.BaseControllerListener;
-import com.facebook.drawee.drawable.ScalingUtils;
-import com.facebook.drawee.generic.GenericDraweeHierarchy;
-import com.facebook.drawee.generic.GenericDraweeHierarchyBuilder;
-import com.facebook.drawee.interfaces.DraweeController;
-import com.facebook.drawee.view.DraweeHolder;
-import com.facebook.imagepipeline.common.ResizeOptions;
-import com.facebook.imagepipeline.image.ImageInfo;
-import com.facebook.imagepipeline.request.ImageRequest;
-import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import com.lynx.tasm.behavior.LynxContext;
 import com.lynx.tasm.behavior.ui.image.ImageUrlRedirectUtils;
+import com.lynx.tasm.image.ImageContent;
+import com.lynx.tasm.image.model.ImageInfo;
+import com.lynx.tasm.image.model.ImageLoadListener;
+import com.lynx.tasm.image.model.ImageRequestInfo;
+import com.lynx.tasm.image.model.ImageRequestInfoBuilder;
+import com.lynx.tasm.service.ILynxImageService;
+import com.lynx.tasm.service.LynxServiceCenter;
 import com.lynx.tasm.utils.UIThreadUtils;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import org.json.JSONObject;
 
 public class MarkdownImageResource {
-  private static final ResizeOptions IMAGE_DOWNSAMPLE_SIZE = new ResizeOptions(1000, 1000);
+  private static final int IMAGE_DOWNSAMPLE_SIZE = 1000;
 
   private final String mSource;
   private final MarkdownResourceContext mHost;
   private final CountDownLatch mLoadLatch = new CountDownLatch(1);
-  private @Nullable DraweeHolder<GenericDraweeHierarchy> mDraweeHolder;
   private @Nullable Drawable mDrawable;
+  private @Nullable ImageContent mImageContent;
+  private @Nullable ImageRequestInfo mRequestInfo;
 
   public MarkdownImageResource(
       String source, boolean downSampling, boolean syncLoading, MarkdownResourceContext host) {
     mSource = source;
     mHost = host;
-    UIThreadUtils.runOnUiThreadImmediately(() -> createDrawable(downSampling));
+    UIThreadUtils.runOnUiThreadImmediately(() -> fetchImage(downSampling));
     if (syncLoading) {
       try {
         mLoadLatch.await(100, TimeUnit.MILLISECONDS);
@@ -58,74 +57,101 @@ public class MarkdownImageResource {
   public void release() {
     UIThreadUtils.runOnUiThreadImmediately(() -> {
       if (mDrawable != null) {
+        if (mDrawable instanceof Animatable) {
+          ((Animatable) mDrawable).stop();
+        }
+        Drawable.Callback callback = mHost.getDrawableCallback();
+        if (callback instanceof LynxServalViewWrapper) {
+          ((LynxServalViewWrapper) callback).unregisterAnimatedDrawable(mDrawable);
+        }
         mDrawable.setCallback(null);
         mDrawable = null;
       }
-      if (mDraweeHolder != null) {
-        mDraweeHolder.setController(null);
-        mDraweeHolder = null;
+      mImageContent = null;
+      if (mRequestInfo != null) {
+        ILynxImageService service = LynxServiceCenter.inst().getService(ILynxImageService.class);
+        if (service != null) {
+          service.releaseImage(mRequestInfo);
+        }
+        mRequestInfo = null;
       }
     });
   }
 
-  private void createDrawable(boolean downSampling) {
+  private void fetchImage(boolean downSampling) {
     try {
-      LynxContext context = mHost.getLynxContext();
-      if (context == null) {
+      LynxContext lynxContext = mHost.getLynxContext();
+      if (lynxContext == null) {
         return;
       }
-      String source = ImageUrlRedirectUtils.redirectUrl(context, mSource);
+      ILynxImageService service = LynxServiceCenter.inst().getService(ILynxImageService.class);
+      if (service == null) {
+        mHost.onImageLoadError(mSource, null);
+        return;
+      }
+
+      String source = ImageUrlRedirectUtils.redirectUrl(lynxContext, mSource);
       if (TextUtils.isEmpty(source)) {
         mHost.onImageLoadError(mSource, null);
         return;
       }
-      Uri uri = Uri.parse(source);
-      if (uri == null || uri == Uri.EMPTY || uri.getScheme() == null) {
-        mHost.onImageLoadError(mSource, null);
-        return;
-      }
 
-      ImageRequestBuilder requestBuilder = ImageRequestBuilder.newBuilderWithSource(uri);
+      ImageRequestInfoBuilder builder = ImageRequestInfoBuilder.newBuilderWithSource(source);
       if (downSampling) {
-        requestBuilder.setResizeOptions(IMAGE_DOWNSAMPLE_SIZE);
+        builder.setResizeWidth(IMAGE_DOWNSAMPLE_SIZE)
+            .setResizeHeight(IMAGE_DOWNSAMPLE_SIZE)
+            .setEnableDownSampling(true);
+      } else {
+        builder.setEnableDownSampling(false);
       }
-      ImageRequest request = requestBuilder.build();
+      builder.setCallerContext(lynxContext.getFrescoCallerContext());
+      mRequestInfo = builder.build();
 
-      BaseControllerListener<ImageInfo> controllerListener =
-          new BaseControllerListener<ImageInfo>() {
-            @Override
-            public void onFinalImageSet(
-                String id, ImageInfo imageInfo, android.graphics.drawable.Animatable animatable) {
-              if (mDrawable != null && imageInfo != null && imageInfo.getWidth() > 0
-                  && imageInfo.getHeight() > 0) {
-                mDrawable.setBounds(0, 0, imageInfo.getWidth(), imageInfo.getHeight());
+      service.fetchImage(mRequestInfo, new ImageLoadListener() {
+        @Override
+        public void onRequestSubmit(ImageRequestInfo imageRequestInfo) {}
+
+        @Override
+        public void onSuccess(@Nullable ImageContent imageContent, ImageRequestInfo requestInfo,
+            ImageInfo imageInfo) {
+          if (imageContent != null && imageInfo != null && imageInfo.getWidth() > 0
+              && imageInfo.getHeight() > 0) {
+            mImageContent = imageContent;
+            Drawable drawable = imageContent.getDrawable();
+            if (drawable == null) {
+              Bitmap bitmap = imageContent.getBitmap();
+              if (bitmap != null && !bitmap.isRecycled()) {
+                drawable = new BitmapDrawable(null, bitmap);
               }
-              mHost.onImageLoaded(mSource);
             }
-
-            @Override
-            public void onFailure(String id, Throwable throwable) {
-              mHost.onImageLoadError(mSource, throwable);
+            if (drawable != null) {
+              drawable.setBounds(0, 0, imageInfo.getWidth(), imageInfo.getHeight());
+              mDrawable = drawable;
+              Drawable.Callback viewCallback = mHost.getDrawableCallback();
+              if (viewCallback != null) {
+                drawable.setCallback(viewCallback);
+                if (drawable instanceof Animatable
+                    && viewCallback instanceof LynxServalViewWrapper) {
+                  ((LynxServalViewWrapper) viewCallback)
+                      .registerAnimatedDrawable(drawable, mSource);
+                  ((Animatable) drawable).start();
+                }
+              }
             }
-          };
+          }
+          mHost.onImageLoaded(mSource);
+        }
 
-      mDraweeHolder = new DraweeHolder<>(
-          GenericDraweeHierarchyBuilder.newInstance(context.getResources()).build());
-      mDraweeHolder.getHierarchy().setActualImageScaleType(ScalingUtils.ScaleType.FIT_CENTER);
-      DraweeController controller = Fresco.newDraweeControllerBuilder()
-                                        .setAutoPlayAnimations(true)
-                                        .setOldController(mDraweeHolder.getController())
-                                        .setCallerContext(context.getFrescoCallerContext())
-                                        .setImageRequest(request)
-                                        .setControllerListener(controllerListener)
-                                        .build();
-      mDraweeHolder.setController(controller);
-      mDrawable = mDraweeHolder.getTopLevelDrawable();
-      Drawable.Callback callback = mHost.getDrawableCallback();
-      if (mDrawable != null && callback != null) {
-        mDrawable.setCallback(callback);
-        mDrawable.draw(new Canvas());
-      }
+        @Override
+        public void onFailure(int errorCode, Throwable throwable) {
+          mHost.onImageLoadError(mSource, throwable);
+        }
+
+        @Override
+        public void onImageMonitorInfo(JSONObject monitorInfo) {}
+      }, null, lynxContext);
+    } catch (Exception e) {
+      mHost.onImageLoadError(mSource, e);
     } finally {
       mLoadLatch.countDown();
     }


### PR DESCRIPTION
Replace direct Fresco dependency with ILynxImageService in markdown XElement for image loading. This enables GIF animation support with a flicker-free rendering approach that bypasses the full Lynx layout pipeline for animation frame updates.

- Remove compileOnly fresco dependency from build.gradle
- Implement MarkdownImageResource with Drawable.Callback for GIF animation frame scheduling
- Add suppressMarkDirty mechanism to LynxServalViewWrapper to prevent full layout pipeline during animation frame updates
- Cache measure/align params and process animation frames directly in the layout-thread VSync callback

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
