### PR TITLE
[Refactor][Library] Align iOS library marker names

### DIFF
--- a/core/public/jsb/lynx_native_module.h
+++ b/core/public/jsb/lynx_native_module.h
@@ -18,6 +18,14 @@
 #include "core/public/lynx_runtime_proxy.h"
 #include "core/public/pub_value.h"
 
+// The Objective-C library marker macro shares this API name. Keep it out of
+// C++ declarations in Objective-C++ translation units.
+#if defined(__OBJC__) && defined(__cplusplus) && defined(LynxNativeModule)
+#pragma push_macro("LynxNativeModule")
+#undef LynxNativeModule
+#define LYNX_RESTORE_LYNX_NATIVE_MODULE_HEADER 1
+#endif
+
 // TODO(liyanbo.monster): after remove native promise, delete this.
 #if OS_IOS || OS_TVOS || OS_OSX || OS_ANDROID
 #include "core/runtime/js/bindings/modules/lynx_module_timing.h"
@@ -117,5 +125,10 @@ class LYNX_EXPORT_FOR_DEVTOOL LynxNativeModule {
 
 }  // namespace runtime
 }  // namespace lynx
+
+#if defined(LYNX_RESTORE_LYNX_NATIVE_MODULE_HEADER)
+#pragma pop_macro("LynxNativeModule")
+#undef LYNX_RESTORE_LYNX_NATIVE_MODULE_HEADER
+#endif
 
 #endif  // CORE_PUBLIC_JSB_LYNX_NATIVE_MODULE_H_

--- a/core/runtime/js/bindings/modules/ios/lynx_module_darwin.mm
+++ b/core/runtime/js/bindings/modules/ios/lynx_module_darwin.mm
@@ -92,6 +92,12 @@ void LynxModuleDarwin::buildLookupMap(NSDictionary<NSString *, NSString *> *look
 LynxModuleDarwin::LynxModuleDarwin(id<LynxModule> instance)
     : LynxModuleDarwin(instance, [[instance class] name]) {}
 
+#if defined(LynxNativeModule)
+#pragma push_macro("LynxNativeModule")
+#undef LynxNativeModule
+#define LYNX_RESTORE_LYNX_NATIVE_MODULE_DARWIN 1
+#endif
+
 LynxModuleDarwin::LynxModuleDarwin(id<LynxModule> instance, NSString *moduleName)
     : LynxNativeModule(std::make_shared<pub::PubValueFactoryDarwin>()),
       instance_(instance),
@@ -104,6 +110,11 @@ LynxModuleDarwin::LynxModuleDarwin(id<LynxModule> instance, NSString *moduleName
   methodAuthBlocks_ = [[NSMutableArray alloc] init];
   methodSessionBlocks_ = [NSMutableArray array];
 }
+
+#if defined(LYNX_RESTORE_LYNX_NATIVE_MODULE_DARWIN)
+#pragma pop_macro("LynxNativeModule")
+#undef LYNX_RESTORE_LYNX_NATIVE_MODULE_DARWIN
+#endif
 
 void LynxModuleDarwin::Destroy() {}
 

--- a/platform/darwin/common/lynx/public/module/LynxModule.h
+++ b/platform/darwin/common/lynx/public/module/LynxModule.h
@@ -18,8 +18,8 @@ typedef NSDictionary *_Nullable (^LynxMethodSessionBlock)(NSString *method, NSSt
                                                           NSString *invoke_session,
                                                           NSString *name_space);
 
-#if defined(__OBJC__) && !defined(LynxNativeModuleRegister)
-#define LynxNativeModuleRegister(module_name) class LynxNativeModuleRegisterMarker;
+#if defined(__OBJC__) && !defined(LynxNativeModule)
+#define LynxNativeModule(module_name) class LynxNativeModuleMarker;
 #endif
 
 @protocol LynxModule <NSObject>

--- a/platform/darwin/ios/lynx/LynxElement.mm
+++ b/platform/darwin/ios/lynx/LynxElement.mm
@@ -7,6 +7,12 @@
 
 #include <string>
 
+#if defined(LynxElement)
+#pragma push_macro("LynxElement")
+#undef LynxElement
+#define LYNX_RESTORE_LYNX_ELEMENT_EXTENSION 1
+#endif
+
 @interface LynxElement ()
 
 - (instancetype)initWithTemplateRender:(LynxTemplateRender *)templateRender
@@ -20,6 +26,11 @@
                                callback:(void (^_Nonnull)(NSString *_Nullable json))callback;
 
 @end
+
+#if defined(LYNX_RESTORE_LYNX_ELEMENT_EXTENSION)
+#pragma pop_macro("LynxElement")
+#undef LYNX_RESTORE_LYNX_ELEMENT_EXTENSION
+#endif
 
 namespace {
 

--- a/platform/darwin/ios/lynx/LynxTemplateRender.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRender.mm
@@ -87,12 +87,23 @@
 #include "core/shell/runtime/common/module_delegate_impl.h"
 #include "core/value_wrapper/darwin/value_impl_darwin.h"
 
+#if defined(LynxElement)
+#pragma push_macro("LynxElement")
+#undef LynxElement
+#define LYNX_RESTORE_LYNX_ELEMENT_EXTENSION 1
+#endif
+
 @interface LynxElement ()
 
 - (instancetype)initWithTemplateRender:(LynxTemplateRender*)templateRender
                                   sign:(int32_t)sign NS_DESIGNATED_INITIALIZER;
 
 @end
+
+#if defined(LYNX_RESTORE_LYNX_ELEMENT_EXTENSION)
+#pragma pop_macro("LynxElement")
+#undef LYNX_RESTORE_LYNX_ELEMENT_EXTENSION
+#endif
 
 @interface LynxTemplateRender (MemoryUsage)
 

--- a/platform/darwin/ios/lynx/public/LynxElement.h
+++ b/platform/darwin/ios/lynx/public/LynxElement.h
@@ -7,6 +7,14 @@
 
 #import <Foundation/Foundation.h>
 
+// The Objective-C library marker macro shares this public class name. Keep it
+// out before declaring or extending the class API.
+#if defined(LynxElement)
+#pragma push_macro("LynxElement")
+#undef LynxElement
+#define LYNX_RESTORE_LYNX_ELEMENT_HEADER 1
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface LynxElement : NSObject
@@ -25,5 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#if defined(LYNX_RESTORE_LYNX_ELEMENT_HEADER)
+#pragma pop_macro("LynxElement")
+#undef LYNX_RESTORE_LYNX_ELEMENT_HEADER
+#endif
 
 #endif  // PLATFORM_DARWIN_IOS_LYNX_PUBLIC_LYNXELEMENT_H_

--- a/platform/darwin/ios/lynx/public/ui/LynxUI.h
+++ b/platform/darwin/ios/lynx/public/ui/LynxUI.h
@@ -16,8 +16,8 @@
 #import <Lynx/LynxUITarget.h>
 #import <Lynx/UIScrollView+Nested.h>
 
-#if defined(__OBJC__) && !defined(LynxUIRegister)
-#define LynxUIRegister(name) class LynxUIRegisterMarker;
+#if defined(__OBJC__) && !defined(LynxElement)
+#define LynxElement(name) class LynxElementMarker;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/platform/darwin/ios/lynx_service_api/ServiceAPI.h
+++ b/platform/darwin/ios/lynx_service_api/ServiceAPI.h
@@ -73,10 +73,22 @@ typedef struct {
 #define LynxServiceBind(cls, pro) ([LynxServices bindClass:cls toProtocol:@protocol(pro)])
 
 /**
- * Get the default object that implements the specified protocol, e.g.,
- * LYNX_SERVICE(LynxMonitorProtocol) -> id<LynxMonitorProtocol>
+ * Get the default object that implements the specified protocol.
  */
-#define LynxService(pro) ((id<pro>)([LynxServices getInstanceWithProtocol:@protocol(pro)]))
+#define LYNX_SERVICE_GET(pro) ((id<pro>)([LynxServices getInstanceWithProtocol:@protocol(pro)]))
+
+#define LYNX_SERVICE_SELECT(_1, _2, NAME, ...) NAME
+
+/**
+ * LynxService supports service lookup and the two-argument registration marker.
+ *
+ * LynxService(LynxMonitorProtocol) -> id<LynxMonitorProtocol>
+ * @LynxService(LynxMonitorService, LynxServiceMonitorProtocol)
+ */
+#ifndef LynxService
+#define LynxService(...) \
+  LYNX_SERVICE_SELECT(__VA_ARGS__, LynxServiceRegister, LYNX_SERVICE_GET)(__VA_ARGS__)
+#endif
 
 @interface LynxServices : NSObject
 

--- a/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
@@ -175,15 +175,15 @@ module Lynx
               components << ComponentInfo.new(:renderer_host, name.first, class_name)
             end
           end
-          content.scan(/@LynxUIRegister\(\s*@?"([^"]+)"\s*\)\s*@implementation\s+([A-Za-z_][A-Za-z0-9_]*)/) do
+          content.scan(/@LynxElement\(\s*@?"([^"]+)"\s*\)\s*@implementation\s+([A-Za-z_][A-Za-z0-9_]*)/) do
             |name, class_name|
             components << ComponentInfo.new(:ui, name, class_name)
           end
-          content.scan(/@LynxNativeModuleRegister\(\s*@?"([^"]+)"\s*\)\s*@(implementation|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/) do
+          content.scan(/@LynxNativeModule\(\s*@?"([^"]+)"\s*\)\s*@(implementation|interface)\s+([A-Za-z_][A-Za-z0-9_]*)/) do
             |name, _declaration, class_name|
             components << ComponentInfo.new(:native_module, name, class_name)
           end
-          content.scan(/@LynxServiceRegister\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/) do
+          content.scan(/@(?:LynxService|LynxServiceRegister)\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)/) do
             |class_name, protocol_name|
             components << ComponentInfo.new(:service, protocol_name, class_name)
           end

--- a/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
@@ -25,7 +25,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       package_dir = write_library(dir, '@scope/demo-lib', 'DemoLib')
       File.write(File.join(package_dir, 'ios/DemoModule.m'), <<~OBJC)
         #import <Lynx/LynxModule.h>
-        @LynxNativeModuleRegister("NativeLocalStorage")
+        @LynxNativeModule("NativeLocalStorage")
         @interface DemoModule : NSObject <LynxModule>
         @end
         @implementation DemoModule
@@ -34,7 +34,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       OBJC
       File.write(File.join(package_dir, 'ios/DemoUI.m'), <<~OBJC)
         #import <Lynx/LynxUI.h>
-        @LynxUIRegister("marked-ui")
+        @LynxElement("marked-ui")
         @implementation DemoMarkedUI
         @end
 
@@ -49,7 +49,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       OBJC
       File.write(File.join(package_dir, 'ios/DemoService.m'), <<~OBJC)
         #import <LynxServiceAPI/ServiceAPI.h>
-        @LynxServiceRegister(DemoService, LynxDemoServiceProtocol)
+        @LynxService(DemoService, LynxDemoServiceProtocol)
         @implementation DemoService
         @end
 
@@ -96,7 +96,7 @@ class LynxLibraryAutolinkTest < Minitest::Test
       package_dir = write_library(dir, 'demo-lib', 'DemoLib')
       File.write(File.join(package_dir, 'ios/OldModule.m'), <<~OBJC)
         #import <Lynx/LynxModule.h>
-        LynxNativeModuleRegister("OldModule")
+        LynxNativeModule("OldModule")
         @interface OldModule : NSObject <LynxModule>
         @end
       OBJC


### PR DESCRIPTION
Summary:
- Rename iOS library marker macros to LynxNativeModule and LynxElement.
- Add the new two-argument LynxService registration marker while preserving LynxServiceRegister compatibility and the existing LynxService getter usage.
- Update the CocoaPods library scanner and tests for the new marker names.

Tests:
- ruby tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
- git diff --check
- clang syntax checks for LynxNativeModule, LynxElement, and LynxService marker expansion