### PR TITLE
[Feature] Add KSP implementations of the Lynx annotation processors

### DIFF
--- a/platform/android/lynx_processor_ksp/build.gradle
+++ b/platform/android/lynx_processor_ksp/build.gradle
@@ -1,0 +1,18 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+apply plugin: 'java'
+apply from: '../publish.gradle'
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
+dependencies {
+    implementation 'androidx.annotation:annotation:1.0.0'
+    implementation 'com.squareup:javapoet:1.11.1'
+    // Provided by the KSP runtime when the processor is executed; compileOnly avoids
+    // pinning consumers to a specific kotlin-stdlib version.
+    compileOnly 'com.google.devtools.ksp:symbol-processing-api:1.6.21-1.0.6'
+    // Annotation definitions (@LynxProp, @LynxBehavior, ...) shared with the javac processor.
+    implementation project(':LynxProcessor')
+    testImplementation 'junit:junit:4.13.2'
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/KspUtils.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/KspUtils.java
@@ -1,0 +1,177 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.processor.ksp;
+
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.Dependencies;
+import com.google.devtools.ksp.symbol.ClassKind;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFile;
+import com.google.devtools.ksp.symbol.KSType;
+import com.google.devtools.ksp.symbol.KSTypeReference;
+import com.google.devtools.ksp.symbol.Nullability;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeName;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared helpers for the KSP based Lynx processors.
+ *
+ * <p>The javac processors operate on {@code javax.lang.model} mirrors while KSP exposes symbols
+ * through Kotlin's type system (e.g. Java {@code int} is surfaced as {@code kotlin.Int} with
+ * {@link Nullability#NOT_NULL}). The helpers in this class translate KSP symbols back to the
+ * JavaPoet {@link TypeName}s the original code generators were written against, so the generated
+ * sources stay byte-identical with the javac processors.
+ */
+final class KspUtils {
+  private static final Map<String, TypeName> KOTLIN_PRIMITIVES;
+  private static final Map<String, ClassName> KOTLIN_TO_JAVA;
+
+  static {
+    KOTLIN_PRIMITIVES = new HashMap<>();
+    KOTLIN_PRIMITIVES.put("kotlin.Boolean", TypeName.BOOLEAN);
+    KOTLIN_PRIMITIVES.put("kotlin.Byte", TypeName.BYTE);
+    KOTLIN_PRIMITIVES.put("kotlin.Short", TypeName.SHORT);
+    KOTLIN_PRIMITIVES.put("kotlin.Int", TypeName.INT);
+    KOTLIN_PRIMITIVES.put("kotlin.Long", TypeName.LONG);
+    KOTLIN_PRIMITIVES.put("kotlin.Char", TypeName.CHAR);
+    KOTLIN_PRIMITIVES.put("kotlin.Float", TypeName.FLOAT);
+    KOTLIN_PRIMITIVES.put("kotlin.Double", TypeName.DOUBLE);
+
+    KOTLIN_TO_JAVA = new HashMap<>();
+    KOTLIN_TO_JAVA.put("kotlin.Any", ClassName.get("java.lang", "Object"));
+    KOTLIN_TO_JAVA.put("kotlin.String", ClassName.get("java.lang", "String"));
+    KOTLIN_TO_JAVA.put("kotlin.CharSequence", ClassName.get("java.lang", "CharSequence"));
+    KOTLIN_TO_JAVA.put("kotlin.Unit", ClassName.get("java.lang", "Void"));
+  }
+
+  private KspUtils() {}
+
+  /** Maps a resolved KSP type to the JavaPoet type the javac processor would have seen. */
+  static TypeName toTypeName(KSType type) {
+    KSDeclaration declaration = type.getDeclaration();
+    String qualifiedName =
+        declaration.getQualifiedName() != null ? declaration.getQualifiedName().asString() : null;
+    if (qualifiedName == null) {
+      throw new IllegalArgumentException("Could not resolve type " + type);
+    }
+
+    TypeName primitive = KOTLIN_PRIMITIVES.get(qualifiedName);
+    if (primitive != null) {
+      // Java primitives surface as non-null kotlin types; boxed/nullable variants stay boxed.
+      return type.getNullability() == Nullability.NOT_NULL ? primitive : primitive.box();
+    }
+
+    ClassName mapped = KOTLIN_TO_JAVA.get(qualifiedName);
+    if (mapped != null) {
+      return mapped;
+    }
+
+    if (declaration instanceof KSClassDeclaration) {
+      return toClassName((KSClassDeclaration) declaration);
+    }
+    return ClassName.bestGuess(qualifiedName);
+  }
+
+  /** Builds a JavaPoet ClassName, preserving nesting (package.Outer.Inner). */
+  static ClassName toClassName(KSClassDeclaration declaration) {
+    String packageName = declaration.getPackageName().asString();
+    Deque<String> simpleNames = new ArrayDeque<>();
+    KSDeclaration current = declaration;
+    while (current != null) {
+      simpleNames.addFirst(current.getSimpleName().asString());
+      current = current.getParentDeclaration();
+    }
+    String first = simpleNames.removeFirst();
+    return ClassName.get(packageName, first, simpleNames.toArray(new String[0]));
+  }
+
+  /** Returns the direct superclass declaration, skipping interfaces. Null for kotlin.Any roots. */
+  static KSClassDeclaration superclassOf(KSClassDeclaration declaration) {
+    Iterator<KSTypeReference> it = declaration.getSuperTypes().iterator();
+    while (it.hasNext()) {
+      KSType resolved = it.next().resolve();
+      KSDeclaration superDeclaration = resolved.getDeclaration();
+      if (superDeclaration instanceof KSClassDeclaration
+          && ((KSClassDeclaration) superDeclaration).getClassKind() == ClassKind.CLASS) {
+        return (KSClassDeclaration) superDeclaration;
+      }
+    }
+    return null;
+  }
+
+  static String qualifiedNameOf(KSDeclaration declaration) {
+    return declaration.getQualifiedName() != null ? declaration.getQualifiedName().asString()
+                                                  : declaration.getSimpleName().asString();
+  }
+
+  /** Finds an annotation by fully qualified name. */
+  static KSAnnotation findAnnotation(KSAnnotated annotated, String qualifiedName) {
+    String shortName = qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
+    Iterator<KSAnnotation> it = annotated.getAnnotations().iterator();
+    while (it.hasNext()) {
+      KSAnnotation annotation = it.next();
+      if (!shortName.equals(annotation.getShortName().asString())) {
+        continue;
+      }
+      KSDeclaration declaration = annotation.getAnnotationType().resolve().getDeclaration();
+      if (qualifiedName.equals(qualifiedNameOf(declaration))) {
+        return annotation;
+      }
+    }
+    return null;
+  }
+
+  /** Reads an annotation argument; KSP fills unspecified arguments with their defaults. */
+  @SuppressWarnings("unchecked")
+  static <T> T argument(KSAnnotation annotation, String name) {
+    for (com.google.devtools.ksp.symbol.KSValueArgument argument : annotation.getArguments()) {
+      if (argument.getName() != null && name.equals(argument.getName().asString())) {
+        return (T) argument.getValue();
+      }
+    }
+    return null;
+  }
+
+  /** Annotation array arguments arrive as List; normalizes to a String list. */
+  static List<String> stringList(Object value) {
+    List<String> result = new ArrayList<>();
+    if (value instanceof List) {
+      for (Object item : (List<?>) value) {
+        result.add(String.valueOf(item));
+      }
+    } else if (value instanceof String[]) {
+      for (String item : (String[]) value) {
+        result.add(item);
+      }
+    }
+    return result;
+  }
+
+  /** Writes a JavaFile through the KSP CodeGenerator, mirroring Filer#createSourceFile. */
+  static void write(CodeGenerator codeGenerator, KSFile source, String packageName, String fileName,
+      JavaFile javaFile) throws IOException {
+    Dependencies dependencies =
+        source != null ? new Dependencies(false, source) : new Dependencies(false);
+    OutputStream stream = codeGenerator.createNewFile(dependencies, packageName, fileName, "java");
+    try (Writer writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)) {
+      javaFile.writeTo(writer);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxBehaviorSymbolProcessor.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxBehaviorSymbolProcessor.java
@@ -1,0 +1,509 @@
+// Copyright 2020 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.processor.ksp;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+import com.google.devtools.ksp.UtilsKt;
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.Dependencies;
+import com.google.devtools.ksp.processing.KSPLogger;
+import com.google.devtools.ksp.processing.Resolver;
+import com.google.devtools.ksp.processing.SymbolProcessor;
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment;
+import com.google.devtools.ksp.processing.SymbolProcessorProvider;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFile;
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration;
+import com.google.devtools.ksp.symbol.KSNode;
+import com.google.devtools.ksp.symbol.KSType;
+import com.google.devtools.ksp.symbol.KSValueParameter;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * KSP port of {@code com.lynx.processor.LynxBehaviorProcessor}.
+ *
+ * <p>Aggregates classes annotated with {@code @LynxBehavior}, {@code @LynxElement} and
+ * {@code @LynxShadowNode} into a single {@code BehaviorGenerator} registry class, producing the
+ * same Java source as the javac implementation.
+ */
+public class LynxBehaviorSymbolProcessor implements SymbolProcessor {
+  private static final String BEHAVIOR_ANNOTATION = "com.lynx.tasm.behavior.LynxBehavior";
+  private static final String ELEMENT_ANNOTATION = "com.lynx.tasm.behavior.LynxElement";
+  private static final String SHADOW_NODE_ANNOTATION = "com.lynx.tasm.behavior.LynxShadowNode";
+  private static final String GENERATOR_NAME_ANNOTATION =
+      "com.lynx.tasm.behavior.LynxGeneratorName";
+
+  private static final String DEFAULT_RENDERER_HOST_TYPE_NAME =
+      "com.lynx.tasm.behavior.render.IRendererHost";
+  private static final String LYNX_CONTEXT_QUALIFIED = "com.lynx.tasm.behavior.LynxContext";
+
+  private static final ClassName KEEP_TYPE = ClassName.get("androidx.annotation", "Keep");
+
+  private final CodeGenerator mCodeGenerator;
+  private final KSPLogger mLogger;
+  private boolean isCreated = false;
+
+  private final Map<ClassName, ClassInfo> mBehaviorClasses;
+  private final Map<String, ClassInfo> mShadowNodeClasses;
+  /** Originating files of every parsed symbol, used for the aggregating output dependency. */
+  private final List<KSFile> mSourceFiles;
+
+  public LynxBehaviorSymbolProcessor(SymbolProcessorEnvironment environment) {
+    mCodeGenerator = environment.getCodeGenerator();
+    mLogger = environment.getLogger();
+    mBehaviorClasses = new HashMap<>();
+    mShadowNodeClasses = new HashMap<>();
+    mSourceFiles = new ArrayList<>();
+  }
+
+  @Override
+  public List<KSAnnotated> process(Resolver resolver) {
+    // The javac processor only emits the registry on the first round (isCreated guard); the
+    // registry file name is fixed, so later rounds must not regenerate it.
+    if (isCreated) {
+      return Collections.emptyList();
+    }
+    isCreated = true;
+    mBehaviorClasses.clear();
+    String packageName = "";
+
+    Iterator<KSAnnotated> generatorNameSymbols =
+        resolver.getSymbolsWithAnnotation(GENERATOR_NAME_ANNOTATION, false).iterator();
+    while (generatorNameSymbols.hasNext()) {
+      KSAnnotated symbol = generatorNameSymbols.next();
+      try {
+        KSAnnotation annotation = KspUtils.findAnnotation(symbol, GENERATOR_NAME_ANNOTATION);
+        if (packageName.isEmpty() && annotation != null) {
+          String value = KspUtils.argument(annotation, "packageName");
+          packageName = value != null ? value : "";
+        }
+        addSourceFile(symbol);
+      } catch (Exception e) {
+        error(symbol instanceof KSNode ? (KSNode) symbol : null, e.getMessage());
+      }
+    }
+
+    Iterator<KSAnnotated> behaviorSymbols =
+        resolver.getSymbolsWithAnnotation(BEHAVIOR_ANNOTATION, false).iterator();
+    while (behaviorSymbols.hasNext()) {
+      KSAnnotated symbol = behaviorSymbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      try {
+        ClassName className = KspUtils.toClassName(classType);
+        ClassInfo classInfo = parseBehaviorClass(className, classType);
+        if (packageName.isEmpty()) {
+          packageName = className.packageName();
+        }
+        mBehaviorClasses.put(className, classInfo);
+        addSourceFile(classType);
+      } catch (Exception e) {
+        error(classType, e.getMessage());
+      }
+    }
+
+    Iterator<KSAnnotated> elementSymbols =
+        resolver.getSymbolsWithAnnotation(ELEMENT_ANNOTATION, false).iterator();
+    while (elementSymbols.hasNext()) {
+      KSAnnotated symbol = elementSymbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      try {
+        ClassName className = KspUtils.toClassName(classType);
+        ClassInfo classInfo = parseLynxElementClass(className, classType);
+        if (packageName.isEmpty()) {
+          packageName = className.packageName();
+        }
+        mBehaviorClasses.put(className, classInfo);
+        addSourceFile(classType);
+      } catch (Exception e) {
+        error(classType, e.getMessage());
+      }
+    }
+
+    Iterator<KSAnnotated> shadowNodeSymbols =
+        resolver.getSymbolsWithAnnotation(SHADOW_NODE_ANNOTATION, false).iterator();
+    while (shadowNodeSymbols.hasNext()) {
+      KSAnnotated symbol = shadowNodeSymbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      try {
+        ClassName className = KspUtils.toClassName(classType);
+        ClassInfo classInfo = parseShadowNodeClass(className, classType);
+        if (classInfo.shadowNodeTag != null) {
+          mShadowNodeClasses.put(classInfo.shadowNodeTag, classInfo);
+        }
+        addSourceFile(classType);
+      } catch (Exception e) {
+        error(classType, e.getMessage());
+      }
+    }
+
+    if (mBehaviorClasses.size() <= 0) {
+      return Collections.emptyList();
+    }
+
+    try {
+      generateClass(packageName);
+    } catch (Exception e) {
+      error(null, e.getMessage());
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void onError() {}
+
+  private void generateClass(String packageName) throws IOException {
+    String className = "BehaviorGenerator";
+
+    TypeSpec holderClass = TypeSpec.classBuilder(className)
+                               .addAnnotation(KEEP_TYPE)
+                               .addModifiers(PUBLIC)
+                               .addMethod(generateMethodInvokerSpec())
+                               .build();
+
+    JavaFile javaFile = JavaFile.builder(packageName, holderClass)
+                            .addFileComment("Generated by com.lynx.processor.LynxBehaviorProcessor")
+                            .build();
+    writeAggregating(packageName, className, javaFile);
+  }
+
+  /**
+   * Mirrors {@code javaFile.writeTo(mFiler)}; the registry aggregates symbols from many files, so
+   * the output is registered as aggregating with every originating file as input.
+   */
+  private void writeAggregating(String packageName, String fileName, JavaFile javaFile)
+      throws IOException {
+    Dependencies dependencies = new Dependencies(true, mSourceFiles.toArray(new KSFile[0]));
+    OutputStream stream = mCodeGenerator.createNewFile(dependencies, packageName, fileName, "java");
+    try (Writer writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)) {
+      javaFile.writeTo(writer);
+    }
+  }
+
+  private MethodSpec generateMethodInvokerSpec() {
+    ClassName behavior = ClassName.get("com.lynx.tasm.behavior", "Behavior");
+    ClassName list = ClassName.get("java.util", "List");
+    ClassName arrayList = ClassName.get("java.util", "ArrayList");
+    TypeName listOfBehavior = ParameterizedTypeName.get(list, behavior);
+
+    MethodSpec.Builder builder =
+        MethodSpec.methodBuilder("getBehaviors")
+            .addModifiers(PUBLIC)
+            .addModifiers(STATIC)
+            .returns(listOfBehavior)
+            .addStatement("$T result = new $T<>()", listOfBehavior, arrayList);
+    for (ClassName name : mBehaviorClasses.keySet()) {
+      generateClassAndMethod(builder, mBehaviorClasses.get(name));
+    }
+    for (ClassName name : mBehaviorClasses.keySet()) {
+      checkIfShadowNodeOnly(builder, mBehaviorClasses.get(name));
+    }
+
+    if (mShadowNodeClasses.size() > 0) {
+      generateShadowNodeOnly(builder);
+    }
+
+    builder.addStatement("return result");
+    return builder.build();
+  }
+
+  private void checkIfShadowNodeOnly(MethodSpec.Builder builder, ClassInfo classInfo) {
+    for (String tag : classInfo.tagName) {
+      if (mShadowNodeClasses.get(tag) != null) {
+        mShadowNodeClasses.remove(tag);
+        if (mShadowNodeClasses.size() <= 0) {
+          // no need generate shadow node only
+          return;
+        }
+      }
+    }
+  }
+
+  private void generateShadowNodeOnly(MethodSpec.Builder builder) {
+    for (String tag : mShadowNodeClasses.keySet()) {
+      builder.addCode("result.add(new Behavior($S) {\n", tag);
+      ClassName lynxShadowCln = ClassName.get("com.lynx.tasm.behavior.shadow", "ShadowNode");
+      builder.addCode("@Override\n");
+      builder.addCode("public $T createShadowNode() {\n", lynxShadowCln);
+      builder.addCode("return new $T();\n", mShadowNodeClasses.get(tag).mClassName);
+      builder.addCode(" }\n");
+      builder.addCode("});\n");
+    }
+  }
+
+  private boolean checkHasContextAndObjectConstructors(KSClassDeclaration classElement) {
+    boolean hasParamConstructor = false;
+
+    Iterator<KSFunctionDeclaration> constructors = UtilsKt.getConstructors(classElement).iterator();
+    while (constructors.hasNext()) {
+      KSFunctionDeclaration constructor = constructors.next();
+
+      List<KSValueParameter> parameters = constructor.getParameters();
+      if (parameters.size() != 2) {
+        continue;
+      }
+
+      String first =
+          KspUtils.qualifiedNameOf(parameters.get(0).getType().resolve().getDeclaration());
+      String second =
+          KspUtils.qualifiedNameOf(parameters.get(1).getType().resolve().getDeclaration());
+      // java.lang.Object surfaces as kotlin.Any through KSP.
+      if (LYNX_CONTEXT_QUALIFIED.equals(first)
+          && ("java.lang.Object".equals(second) || "kotlin.Any".equals(second))) {
+        hasParamConstructor = true;
+        break;
+      }
+    }
+
+    return hasParamConstructor;
+  }
+
+  private void generateClassAndMethod(MethodSpec.Builder builder, ClassInfo classInfo) {
+    boolean createAsync = classInfo.isCreateAsync;
+    boolean needProcessDirection = classInfo.needProcessDirection;
+    boolean supportFragmentLayerRender = classInfo.supportFragmentLayerRender;
+
+    for (String tag : classInfo.tagName) {
+      ClassName lynxContextCln = ClassName.get("com.lynx.tasm.behavior", "LynxContext");
+      ClassName lynxUICln = ClassName.get("com.lynx.tasm.behavior.ui", "LynxUI");
+      ClassName lynxShadowCln = ClassName.get("com.lynx.tasm.behavior.shadow", "ShadowNode");
+
+      String behaviorArgs = "$S, false, " + (createAsync ? "true" : "false") + ", "
+          + (needProcessDirection ? "true" : "false");
+      if (supportFragmentLayerRender) {
+        behaviorArgs += ", " + (supportFragmentLayerRender ? "true" : "false");
+      }
+
+      if (checkHasContextAndObjectConstructors(classInfo.mElement)) {
+        builder.addCode("result.add(new Behavior(" + behaviorArgs + ") {\n", tag);
+        builder.addCode("@Override\n");
+        builder.addCode("public $T createUIWithParams($T context, Object params) {\n", lynxUICln,
+            lynxContextCln);
+        builder.addCode("return new $T(context, params);\n", classInfo.mClassName);
+        builder.addCode(" }\n");
+      } else {
+        builder.addCode("result.add(new Behavior(" + behaviorArgs + ") {\n", tag);
+        builder.addCode("@Override\n");
+        builder.addCode("public $T createUI($T context) {\n", lynxUICln, lynxContextCln);
+        builder.addCode("return new $T(context);\n", classInfo.mClassName);
+        builder.addCode(" }\n");
+      }
+
+      if (supportFragmentLayerRender && classInfo.fragmentLayerRendererHost != null) {
+        ClassName iRendererHostCln =
+            ClassName.get("com.lynx.tasm.behavior.render", "IRendererHost");
+        ClassName rendererHostCln = classInfo.fragmentLayerRendererHost;
+        builder.addCode("@Override\n");
+        builder.addCode("public $T createPlatformRendererHost($T context) {\n", iRendererHostCln,
+            lynxContextCln);
+        builder.addCode("return new $T(context);\n", rendererHostCln);
+        builder.addCode(" }\n");
+      }
+
+      if (mShadowNodeClasses.get(tag) != null) {
+        builder.addCode("@Override\n");
+        builder.addCode("public $T createShadowNode() {\n", lynxShadowCln);
+        builder.addCode("return new $T();\n", mShadowNodeClasses.get(tag).mClassName);
+        builder.addCode(" }\n");
+        builder.addCode("});\n");
+      } else {
+        builder.addCode("});\n");
+      }
+    }
+  }
+
+  private ClassInfo parseBehaviorClass(ClassName className, KSClassDeclaration typeElement) {
+    ClassInfo classInfo = new ClassInfo(className, typeElement);
+    classInfo.addBehaviorTag(typeElement);
+    classInfo.addBehaviorIsCreateAsync(typeElement);
+    classInfo.addBehaviorNeedProcessDirection(typeElement);
+    classInfo.addBehaviorSupportFragmentLayerRender(typeElement);
+    classInfo.addBehaviorFragmentLayerRendererHost(typeElement);
+    return classInfo;
+  }
+
+  private ClassInfo parseLynxElementClass(ClassName className, KSClassDeclaration typeElement) {
+    ClassInfo classInfo = new ClassInfo(className, typeElement);
+    classInfo.addLynxElementTag(typeElement);
+    classInfo.addLynxElementIsCreateAsync(typeElement);
+    classInfo.addLynxElementNeedProcessDirection(typeElement);
+    classInfo.addLynxElementSupportFragmentLayerRender(typeElement);
+    classInfo.addLynxElementFragmentLayerRendererHost(typeElement);
+    return classInfo;
+  }
+
+  private ClassInfo parseShadowNodeClass(ClassName className, KSClassDeclaration typeElement) {
+    ClassInfo classInfo = new ClassInfo(className, typeElement);
+    classInfo.addShadowNodeTag(typeElement);
+    return classInfo;
+  }
+
+  private void addSourceFile(KSAnnotated symbol) {
+    if (!(symbol instanceof KSDeclaration)) {
+      return;
+    }
+    KSFile file = ((KSDeclaration) symbol).getContainingFile();
+    if (file != null && !mSourceFiles.contains(file)) {
+      mSourceFiles.add(file);
+    }
+  }
+
+  private void error(KSNode node, String message) {
+    mLogger.error(message != null ? message : "unknown error", node);
+  }
+
+  private static class ClassInfo {
+    public final ClassName mClassName;
+    public final KSClassDeclaration mElement;
+    public final List<String> tagName;
+    public boolean isCreateAsync;
+    public String shadowNodeTag;
+    public boolean needProcessDirection;
+    public boolean supportFragmentLayerRender;
+    public ClassName fragmentLayerRendererHost;
+
+    public ClassInfo(ClassName mClassName, KSClassDeclaration mElement) {
+      this.mClassName = mClassName;
+      this.mElement = mElement;
+      this.tagName = new ArrayList<>();
+      this.isCreateAsync = false;
+      this.needProcessDirection = false;
+      this.supportFragmentLayerRender = false;
+      this.fragmentLayerRendererHost = null;
+    }
+
+    public void addBehaviorTag(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, BEHAVIOR_ANNOTATION);
+      tagName.addAll(KspUtils.stringList(KspUtils.argument(annotation, "tagName")));
+    }
+
+    public void addLynxElementTag(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, ELEMENT_ANNOTATION);
+      String name = KspUtils.argument(annotation, "name");
+      tagName.add(name);
+    }
+
+    public void addBehaviorIsCreateAsync(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, BEHAVIOR_ANNOTATION);
+      isCreateAsync = booleanArgument(annotation, "isCreateAsync");
+    }
+
+    public void addLynxElementIsCreateAsync(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, ELEMENT_ANNOTATION);
+      isCreateAsync = booleanArgument(annotation, "isCreateAsync");
+    }
+
+    public void addBehaviorNeedProcessDirection(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, BEHAVIOR_ANNOTATION);
+      needProcessDirection = booleanArgument(annotation, "needProcessDirection");
+    }
+
+    public void addLynxElementNeedProcessDirection(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, ELEMENT_ANNOTATION);
+      needProcessDirection = booleanArgument(annotation, "needProcessDirection");
+    }
+
+    public void addBehaviorSupportFragmentLayerRender(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, BEHAVIOR_ANNOTATION);
+      supportFragmentLayerRender = booleanArgument(annotation, "supportFragmentLayerRender");
+    }
+
+    public void addLynxElementSupportFragmentLayerRender(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, ELEMENT_ANNOTATION);
+      supportFragmentLayerRender = booleanArgument(annotation, "supportFragmentLayerRender");
+    }
+
+    public void addBehaviorFragmentLayerRendererHost(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, BEHAVIOR_ANNOTATION);
+      fragmentLayerRendererHost = resolveRendererHost(annotation);
+    }
+
+    public void addLynxElementFragmentLayerRendererHost(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, ELEMENT_ANNOTATION);
+      fragmentLayerRendererHost = resolveRendererHost(annotation);
+    }
+
+    public void addShadowNodeTag(KSClassDeclaration element) {
+      KSAnnotation annotation = KspUtils.findAnnotation(element, SHADOW_NODE_ANNOTATION);
+      shadowNodeTag = KspUtils.argument(annotation, "tagName");
+    }
+
+    private static boolean booleanArgument(KSAnnotation annotation, String name) {
+      Boolean value = KspUtils.argument(annotation, name);
+      return value != null && value;
+    }
+
+    /**
+     * Reads the {@code fragmentLayerRendererHost} Class argument. Class-typed annotation values
+     * arrive as {@link KSType}; the javac {@code void.class} default surfaces through KSP as
+     * {@code kotlin.Unit} (mapped to {@code java.lang.Void} on the Java side), and both sentinels
+     * mean "not set", as does the default {@code IRendererHost} itself.
+     */
+    private static ClassName resolveRendererHost(KSAnnotation annotation) {
+      Object value = KspUtils.argument(annotation, "fragmentLayerRendererHost");
+      KSDeclaration declaration = null;
+      if (value instanceof KSType) {
+        declaration = ((KSType) value).getDeclaration();
+      } else if (value instanceof KSClassDeclaration) {
+        declaration = (KSDeclaration) value;
+      }
+      if (!(declaration instanceof KSClassDeclaration)) {
+        return null;
+      }
+      String typeName = KspUtils.qualifiedNameOf(declaration);
+      if (isFragmentLayerRendererHostSet(typeName)) {
+        return KspUtils.toClassName((KSClassDeclaration) declaration);
+      }
+      return null;
+    }
+  }
+
+  private static boolean isFragmentLayerRendererHostSet(String typeName) {
+    return !"void".equals(typeName) && !"kotlin.Unit".equals(typeName)
+        && !"java.lang.Void".equals(typeName) && !"kotlin.Nothing".equals(typeName)
+        && !DEFAULT_RENDERER_HOST_TYPE_NAME.equals(typeName);
+  }
+
+  /** Entry point registered in META-INF/services. */
+  public static class Provider implements SymbolProcessorProvider {
+    @Override
+    public SymbolProcessor create(SymbolProcessorEnvironment environment) {
+      return new LynxBehaviorSymbolProcessor(environment);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxJSPropertySymbolProcessor.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxJSPropertySymbolProcessor.java
@@ -1,0 +1,534 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.processor.ksp;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.Dependencies;
+import com.google.devtools.ksp.processing.Resolver;
+import com.google.devtools.ksp.processing.SymbolProcessor;
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment;
+import com.google.devtools.ksp.processing.SymbolProcessorProvider;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFile;
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration;
+import com.google.devtools.ksp.symbol.KSType;
+import com.google.devtools.ksp.symbol.KSTypeArgument;
+import com.google.devtools.ksp.symbol.KSTypeReference;
+import com.google.devtools.ksp.symbol.Nullability;
+import com.google.devtools.ksp.symbol.Variance;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.lang.model.element.Modifier;
+
+/**
+ * KSP port of {@code com.lynx.jsbridge.jsi.LynxJSPropertyProcessor}.
+ *
+ * <p>Collects fields annotated with {@code @LynxJSProperty} inside {@code ILynxJSIObject}
+ * implementations and generates the {@code <Class>$$Descriptor} classes, producing the same Java
+ * sources as the javac implementation.
+ */
+public class LynxJSPropertySymbolProcessor implements SymbolProcessor {
+  private static final String TAG = "LynxJSIObjectProcessor";
+  private static final String DESCRIPTOR_NAME_SUFFIX = "$$Descriptor";
+  private static final String LYNX_JS_PROPERTY_ANNOTATION = "com.lynx.jsbridge.jsi.LynxJSProperty";
+  private static final String SERIALIZED_NAME_ANNOTATION =
+      "com.google.gson.annotations.SerializedName";
+  private static final ClassName I_LYNX_JSI_OBJECT =
+      ClassName.get("com.lynx.jsbridge.jsi", "ILynxJSIObject");
+  private static final ClassName LYNX_JSI_OBJECT_DESCRIPTOR =
+      ClassName.get("com.lynx.jsbridge.jsi", "AbsLynxJSIObjectDescriptor");
+  private static final ClassName LYNX_JS_PROPERTY_DESCRIPTOR =
+      ClassName.get("com.lynx.jsbridge.jsi", "LynxJSPropertyDescriptor");
+  private static final ClassName KEEP = ClassName.get("androidx.annotation", "Keep");
+
+  /** javac sees primitive TypeKinds; KSP surfaces them as non-null kotlin types. */
+  private static final Map<String, String> PRIMITIVE_DESCRIPTORS;
+  /** Java primitive arrays surface as the dedicated kotlin array types. */
+  private static final Map<String, String> PRIMITIVE_ARRAY_DESCRIPTORS;
+  /** Kotlin collection names whose JVM binary name differs from the declaration name. */
+  private static final Map<String, String> BINARY_NAME_OVERRIDES;
+  private static final Set<String> PRIMITIVE_OR_WRAPPER_NAMES;
+  private static final Set<String> STRING_NAMES;
+  private static final Set<String> LIST_NAMES;
+  private static final Set<String> I_LYNX_JSI_OBJECT_NAMES;
+
+  static {
+    PRIMITIVE_DESCRIPTORS = new HashMap<>();
+    PRIMITIVE_DESCRIPTORS.put("kotlin.Boolean", "Z");
+    PRIMITIVE_DESCRIPTORS.put("kotlin.Int", "I");
+    PRIMITIVE_DESCRIPTORS.put("kotlin.Long", "J");
+    PRIMITIVE_DESCRIPTORS.put("kotlin.Float", "F");
+    PRIMITIVE_DESCRIPTORS.put("kotlin.Double", "D");
+
+    PRIMITIVE_ARRAY_DESCRIPTORS = new HashMap<>();
+    PRIMITIVE_ARRAY_DESCRIPTORS.put("kotlin.BooleanArray", "[Z");
+    PRIMITIVE_ARRAY_DESCRIPTORS.put("kotlin.IntArray", "[I");
+    PRIMITIVE_ARRAY_DESCRIPTORS.put("kotlin.LongArray", "[J");
+    PRIMITIVE_ARRAY_DESCRIPTORS.put("kotlin.FloatArray", "[F");
+    PRIMITIVE_ARRAY_DESCRIPTORS.put("kotlin.DoubleArray", "[D");
+
+    BINARY_NAME_OVERRIDES = new HashMap<>();
+    BINARY_NAME_OVERRIDES.put("kotlin.collections.List", "java.util.List");
+    BINARY_NAME_OVERRIDES.put("kotlin.collections.MutableList", "java.util.List");
+
+    PRIMITIVE_OR_WRAPPER_NAMES = new HashSet<>();
+    PRIMITIVE_OR_WRAPPER_NAMES.add("kotlin.Boolean");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("kotlin.Int");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("kotlin.Long");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("kotlin.Float");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("kotlin.Double");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("java.lang.Boolean");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("java.lang.Integer");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("java.lang.Long");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("java.lang.Float");
+    PRIMITIVE_OR_WRAPPER_NAMES.add("java.lang.Double");
+
+    STRING_NAMES = new HashSet<>();
+    STRING_NAMES.add("kotlin.String");
+    STRING_NAMES.add("java.lang.String");
+
+    LIST_NAMES = new HashSet<>();
+    LIST_NAMES.add("java.util.List");
+    LIST_NAMES.add("kotlin.collections.List");
+    LIST_NAMES.add("kotlin.collections.MutableList");
+
+    I_LYNX_JSI_OBJECT_NAMES = new HashSet<>();
+    I_LYNX_JSI_OBJECT_NAMES.add(I_LYNX_JSI_OBJECT.reflectionName());
+  }
+
+  private final CodeGenerator mCodeGenerator;
+
+  private static class JSIObjectDescriptor {
+    final String simpleClassName;
+    final String reflectionClassName;
+    /**
+     * Fields with annotation @LynxJSProperty
+     */
+    final Map<String, JSPropertyDescriptor> mFields = new HashMap<>();
+    /**
+     * Source files the field walk touched; the descriptor also collects superclass fields living
+     * in other files, so all of them are reported as origins for incremental processing.
+     */
+    final Set<KSFile> mSourceFiles = new LinkedHashSet<>();
+
+    JSIObjectDescriptor(ClassName className) {
+      reflectionClassName = className.reflectionName();
+      int lastDotIndex = reflectionClassName.lastIndexOf('.');
+      simpleClassName =
+          lastDotIndex < 0 ? reflectionClassName : reflectionClassName.substring(lastDotIndex + 1);
+    }
+  }
+
+  private static class JSPropertyDescriptor {
+    final String fieldName;
+    final String jniFieldDescriptor;
+    JSPropertyDescriptor(String name, String descriptor) {
+      fieldName = name;
+      jniFieldDescriptor = descriptor;
+    }
+  }
+
+  public LynxJSPropertySymbolProcessor(SymbolProcessorEnvironment environment) {
+    mCodeGenerator = environment.getCodeGenerator();
+  }
+
+  @Override
+  public List<KSAnnotated> process(Resolver resolver) {
+    List<KSAnnotated> jsPropertyElements = new ArrayList<>();
+    Iterator<KSAnnotated> symbols =
+        resolver.getSymbolsWithAnnotation(LYNX_JS_PROPERTY_ANNOTATION, false).iterator();
+    while (symbols.hasNext()) {
+      jsPropertyElements.add(symbols.next());
+    }
+    if (jsPropertyElements.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    final Map<ClassName, JSIObjectDescriptor> jsiObjectDescriptorMap =
+        collectJSIObjectClassesInfo(jsPropertyElements);
+
+    generateJSIObjectDescriptorClasses(jsiObjectDescriptorMap);
+
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void onError() {}
+
+  /**
+   * collect classesInfo with element annotated with LynxJSProperty
+   */
+  private Map<ClassName, JSIObjectDescriptor> collectJSIObjectClassesInfo(
+      List<KSAnnotated> elements) {
+    System.out.println(TAG + ", start to collect class info, element size = " + elements.size());
+    Map<ClassName, JSIObjectDescriptor> descriptorMap = new HashMap<>();
+    for (KSAnnotated element : elements) {
+      KSDeclaration declaration = (KSDeclaration) element;
+      KSClassDeclaration classElement = (KSClassDeclaration) declaration.getParentDeclaration();
+      ClassName className = KspUtils.toClassName(classElement);
+      System.out.println(TAG + ", find an element, name: " + declaration.getSimpleName().asString()
+          + "in class: " + className.simpleName());
+      checkJSPropertyValidate(declaration, className);
+
+      // collect class info
+      if (!descriptorMap.containsKey(className)) {
+        JSIObjectDescriptor descriptor = new JSIObjectDescriptor(className);
+        // collect elements in enclosing class
+        collectFieldsFromJSIObject(classElement, descriptor);
+        descriptorMap.put(className, descriptor);
+      }
+    }
+    return descriptorMap;
+  }
+
+  /**
+   * check if the JSProperty has valid type, currently only String is supported
+   */
+  private void checkJSPropertyValidate(KSDeclaration element, ClassName className) {
+    if (!(element instanceof KSPropertyDeclaration)) {
+      throwException("@LynxJSProperty must be a field", element.toString(),
+          element.getSimpleName().asString(), className.simpleName());
+    }
+    checkJSPropertyValidate(
+        ((KSPropertyDeclaration) element).getType().resolve(), element, className);
+  }
+
+  // only support primitive types, string, ILynxJSIObject, array
+  private void checkJSPropertyValidate(
+      KSType fieldType, KSDeclaration element, ClassName className) {
+    if (isPrimitiveOrWrapper(fieldType)) {
+      return;
+    }
+
+    String qualifiedName = KspUtils.qualifiedNameOf(fieldType.getDeclaration());
+    if (STRING_NAMES.contains(qualifiedName)
+        || isAssignableTo(fieldType.getDeclaration(), I_LYNX_JSI_OBJECT_NAMES)) {
+      return;
+    }
+
+    // javac sees ArrayType; KSP surfaces primitive arrays and kotlin.Array<T> instead
+    if (PRIMITIVE_ARRAY_DESCRIPTORS.containsKey(qualifiedName)) {
+      return;
+    }
+    if ("kotlin.Array".equals(qualifiedName)) {
+      KSTypeReference componentType =
+          fieldType.getArguments().isEmpty() ? null : fieldType.getArguments().get(0).getType();
+      if (componentType != null) {
+        checkJSPropertyValidate(componentType.resolve(), element, className);
+        return;
+      }
+    }
+
+    if (isAssignableTo(fieldType.getDeclaration(), LIST_NAMES)) {
+      List<KSTypeArgument> typeArguments = fieldType.getArguments();
+      if (typeArguments.isEmpty()) {
+        return;
+      }
+      KSTypeArgument typeArgument = typeArguments.get(0);
+      if (typeArgument.getVariance() == Variance.COVARIANT) {
+        // `? extends X` wildcards arrive as covariant projections
+        KSTypeReference upperBound = typeArgument.getType();
+        if (upperBound != null
+            && isAssignableTo(upperBound.resolve().getDeclaration(), I_LYNX_JSI_OBJECT_NAMES)) {
+          return;
+        }
+      } else if (typeArgument.getVariance() == Variance.INVARIANT) {
+        KSTypeReference argumentType = typeArgument.getType();
+        if (argumentType != null) {
+          checkJSPropertyValidate(argumentType.resolve(), element, className);
+          return;
+        }
+      }
+    }
+
+    throwException(
+        "InValidate @LynxJSProperty type, supported type: int, Integer, long, Long, float, Float, "
+            + "double, Double, boolean, Boolean, String, array, List, ILynxJSIObject",
+        fieldType.toString(), element.getSimpleName().asString(), className.simpleName());
+  }
+
+  // support int, long, float, double, bool, Integer, Long, Float, Double, Boolean
+  private boolean isPrimitiveOrWrapper(KSType fieldType) {
+    return PRIMITIVE_OR_WRAPPER_NAMES.contains(
+        KspUtils.qualifiedNameOf(fieldType.getDeclaration()));
+  }
+
+  /**
+   * Erasure-level assignability: walks the supertype chain looking for one of the target
+   * qualified names, matching the javac processor's {@code Types#isAssignable} on erasures.
+   */
+  private static boolean isAssignableTo(KSDeclaration declaration, Set<String> targetNames) {
+    if (!(declaration instanceof KSClassDeclaration)) {
+      return false;
+    }
+    if (targetNames.contains(KspUtils.qualifiedNameOf(declaration))) {
+      return true;
+    }
+    Iterator<KSTypeReference> superTypes =
+        ((KSClassDeclaration) declaration).getSuperTypes().iterator();
+    while (superTypes.hasNext()) {
+      if (isAssignableTo(superTypes.next().resolve().getDeclaration(), targetNames)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void collectFieldsFromJSIObject(
+      KSClassDeclaration jsiObject, JSIObjectDescriptor descriptor) {
+    // collect current class field
+    System.out.println(TAG + ", collect fields for class: " + descriptor.simpleClassName);
+    if (!isAssignableTo(jsiObject, I_LYNX_JSI_OBJECT_NAMES)) {
+      throwException("Enclosing class must be a ILynxJSIObject",
+          jsiObject.getClassKind().toString(), jsiObject.getSimpleName().asString(),
+          descriptor.simpleClassName);
+    }
+    // Recursively get the element of the parent class
+    KSClassDeclaration curElement = jsiObject;
+    while (curElement != null && isAssignableTo(curElement, I_LYNX_JSI_OBJECT_NAMES)) {
+      if (curElement.getContainingFile() != null) {
+        descriptor.mSourceFiles.add(curElement.getContainingFile());
+      }
+      Iterator<KSDeclaration> enclosedElements = curElement.getDeclarations().iterator();
+      while (enclosedElements.hasNext()) {
+        KSDeclaration enclosedElement = enclosedElements.next();
+        // collect all enclosed field with @LynxJSProperty
+        if (!(enclosedElement instanceof KSPropertyDeclaration)
+            || KspUtils.findAnnotation(enclosedElement, LYNX_JS_PROPERTY_ANNOTATION) == null) {
+          continue;
+        }
+
+        String fieldName = enclosedElement.getSimpleName().asString();
+        String jniFieldDescriptor =
+            getJNIFieldDescriptor(((KSPropertyDeclaration) enclosedElement).getType().resolve(),
+                fieldName, descriptor.simpleClassName);
+
+        String serializedName = getSerializedName(enclosedElement);
+        String fieldNameForScript = serializedName != null ? serializedName : fieldName;
+        descriptor.mFields.put(
+            fieldNameForScript, new JSPropertyDescriptor(fieldName, jniFieldDescriptor));
+        System.out.println(
+            TAG + ", collect a field, name: " + fieldName + ", serialized name: " + serializedName);
+      }
+      // get parent class element
+      curElement = KspUtils.superclassOf(curElement);
+    }
+  }
+
+  private String getSerializedName(KSDeclaration element) {
+    KSAnnotation serializableAnno = KspUtils.findAnnotation(element, SERIALIZED_NAME_ANNOTATION);
+    if (serializableAnno != null) {
+      Object value = KspUtils.argument(serializableAnno, "value");
+      if (value != null) {
+        return (String) value;
+      }
+    }
+    return null;
+  }
+
+  private String getJNIFieldDescriptor(KSType type, String fieldName, String className) {
+    String qualifiedName = KspUtils.qualifiedNameOf(type.getDeclaration());
+
+    // Java primitives arrive as non-null kotlin types; nullable ones stay boxed
+    if (type.getNullability() == Nullability.NOT_NULL) {
+      String primitive = PRIMITIVE_DESCRIPTORS.get(qualifiedName);
+      if (primitive != null) {
+        return primitive;
+      }
+    }
+
+    String primitiveArray = PRIMITIVE_ARRAY_DESCRIPTORS.get(qualifiedName);
+    if (primitiveArray != null) {
+      return primitiveArray;
+    }
+
+    if ("kotlin.Array".equals(qualifiedName)) {
+      KSTypeReference componentType =
+          type.getArguments().isEmpty() ? null : type.getArguments().get(0).getType();
+      if (componentType != null) {
+        String componentSig = getJNIFieldDescriptor(componentType.resolve(), fieldName, className);
+        return "[" + componentSig;
+      }
+      throwException(
+          "getJNIFieldDescriptor failed, current type: ", type.toString(), fieldName, className);
+      return null;
+    }
+
+    // javac uses Elements#getBinaryName; kotlin collection interfaces map back to java.util
+    String overriddenBinaryName = BINARY_NAME_OVERRIDES.get(qualifiedName);
+    if (overriddenBinaryName != null) {
+      return "L" + overriddenBinaryName.replace('.', '/') + ";";
+    }
+
+    TypeName typeName = KspUtils.toTypeName(type);
+    if (typeName instanceof ClassName) {
+      return "L" + ((ClassName) typeName).reflectionName().replace('.', '/') + ";";
+    }
+
+    throwException(
+        "getJNIFieldDescriptor failed, current type: ", type.toString(), fieldName, className);
+    return null;
+  }
+
+  private void throwException(String msg, String typeName, String elementName, String className) {
+    throw new IllegalArgumentException(TAG + ", error: " + msg + ", type: " + typeName
+        + ", element name: " + elementName + ", in class: " + className);
+  }
+
+  private boolean generateJSIObjectDescriptorClasses(
+      Map<ClassName, JSIObjectDescriptor> descriptorMap) {
+    System.out.println(
+        TAG + ", start to generate classes' descriptors, size: " + descriptorMap.size());
+    for (Map.Entry<ClassName, JSIObjectDescriptor> entry : descriptorMap.entrySet()) {
+      ClassName className = entry.getKey();
+      JSIObjectDescriptor descriptor = entry.getValue();
+      System.out.println(
+          TAG + ", generate LynxJSIObjectDescriptor for class: " + descriptor.simpleClassName);
+
+      // generate class name: OriginLynxJSIObject$$Descriptor
+      TypeSpec.Builder classBuilder =
+          TypeSpec.classBuilder(descriptor.simpleClassName + DESCRIPTOR_NAME_SUFFIX)
+              .addModifiers(PUBLIC);
+
+      // generate method: String getClassName()
+      generateGetClassNameMethod(descriptor, classBuilder);
+
+      // generate method: getFieldInfoArray()
+      generateGetFieldInfoMethod(descriptor, classBuilder);
+
+      // generate annotations: @Keep and @AutoService
+      generateAnnotations(classBuilder);
+
+      // add superclass for LynxJSIObjectDescriptor
+      classBuilder.superclass(LYNX_JSI_OBJECT_DESCRIPTOR);
+
+      // write to file; the javac processor stamps its own class name into the comment
+      JavaFile javaFile =
+          JavaFile.builder(className.packageName(), classBuilder.build())
+              .addFileComment("Generated by com.lynx.jsbridge.jsi.LynxJSPropertyProcessor")
+              .build();
+      try {
+        write(descriptor, className.packageName(),
+            descriptor.simpleClassName + DESCRIPTOR_NAME_SUFFIX, javaFile);
+      } catch (IOException e) {
+        System.out.println(TAG + ", fail to write javaFile: " + e.getMessage());
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Same as {@link KspUtils#write} but reporting every source file the field walk touched, since
+   * descriptors also include superclass fields living in other files.
+   */
+  private void write(JSIObjectDescriptor descriptor, String packageName, String fileName,
+      JavaFile javaFile) throws IOException {
+    KSFile[] sourceFiles = descriptor.mSourceFiles.toArray(new KSFile[0]);
+    OutputStream stream = mCodeGenerator.createNewFile(
+        new Dependencies(false, sourceFiles), packageName, fileName, "java");
+    try (Writer writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)) {
+      javaFile.writeTo(writer);
+    }
+  }
+
+  /**
+   * build Method as:
+   * @Override
+   * public String getClassName() {
+   *     return "com.xxx.xxx.YourClassName$YourClassName";
+   * }
+   */
+  private void generateGetClassNameMethod(
+      JSIObjectDescriptor descriptor, TypeSpec.Builder classBuilder) {
+    MethodSpec getClassNameMethod = MethodSpec.methodBuilder("getClassName")
+                                        .addAnnotation(Override.class)
+                                        .addModifiers(Modifier.PUBLIC)
+                                        .returns(String.class)
+                                        .addStatement("return $S", descriptor.reflectionClassName)
+                                        .build();
+    classBuilder.addMethod(getClassNameMethod);
+  }
+
+  /**
+   * build Method for getFieldInfoArray
+   * private LynxJSIObjectDescriptorInfo[] mFieldInfos = null;
+   * @Override
+   * protect ConcurrentHashMap<String, LynxJSPropertyDescriptor> createFieldInfos() {
+   *     ConcurrentHashMap<String, LynxJSPropertyDescriptor> fieldInfos = new HashMap();
+   *     fieldInfos.add("mStr", new LynxJSPropertyDescriptor("mStr", "Ljava/lang/String;"));
+   *     fieldInfos.add("xxx",  new LynxJSPropertyDescriptor("xxx", "xxx"));
+   *     return fieldInfos;
+   *   }
+   */
+  private void generateGetFieldInfoMethod(
+      JSIObjectDescriptor descriptor, TypeSpec.Builder classBuilder) {
+    Class mapClass = ConcurrentHashMap.class;
+    MethodSpec.Builder createFieldInfosMethodBuilder =
+        MethodSpec.methodBuilder("createFieldInfos")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PROTECTED)
+            .returns(ParameterizedTypeName.get(
+                ClassName.get(mapClass), ClassName.get(String.class), LYNX_JS_PROPERTY_DESCRIPTOR))
+            .addStatement("$T<String, $T> fieldInfos = new $T()", mapClass,
+                LYNX_JS_PROPERTY_DESCRIPTOR, mapClass);
+
+    for (Map.Entry<String, JSPropertyDescriptor> entry : descriptor.mFields.entrySet()) {
+      JSPropertyDescriptor jsPropertyDescriptor = entry.getValue();
+      String fieldName = jsPropertyDescriptor.fieldName;
+      String fieldType = jsPropertyDescriptor.jniFieldDescriptor;
+      createFieldInfosMethodBuilder.addStatement("fieldInfos.put($S, new $T($S, $S))",
+          entry.getKey(), LYNX_JS_PROPERTY_DESCRIPTOR, fieldName, fieldType);
+      System.out.println(TAG + ", generate LynxJSPropertyDescriptor for field: " + fieldName);
+    }
+
+    createFieldInfosMethodBuilder.addStatement("return fieldInfos");
+
+    classBuilder.addMethod(createFieldInfosMethodBuilder.build());
+  }
+
+  /**
+   * build Annotations as:
+   * @Keep
+   */
+  private void generateAnnotations(TypeSpec.Builder classBuilder) {
+    classBuilder.addAnnotation(AnnotationSpec.builder(KEEP).build());
+  }
+
+  /** Entry point registered in META-INF/services. */
+  public static class Provider implements SymbolProcessorProvider {
+    @Override
+    public SymbolProcessor create(SymbolProcessorEnvironment environment) {
+      return new LynxJSPropertySymbolProcessor(environment);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxLibrarySymbolProcessor.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxLibrarySymbolProcessor.java
@@ -1,0 +1,263 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.processor.ksp;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.Dependencies;
+import com.google.devtools.ksp.processing.KSPLogger;
+import com.google.devtools.ksp.processing.Resolver;
+import com.google.devtools.ksp.processing.SymbolProcessor;
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment;
+import com.google.devtools.ksp.processing.SymbolProcessorProvider;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFile;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * KSP port of {@code com.lynx.processor.LynxLibraryProcessor}.
+ *
+ * <p>Generates a single {@code LynxLibraryProviderImpl} registry entry point for libraries that
+ * opt in through the {@code lynx.library.packageName} option, producing the same Java source as
+ * the javac implementation. Unlike the props processor this is an aggregating processor: one
+ * output file collects every {@code @LynxNativeModule}/{@code @LynxService} class plus the
+ * behavior generator reference, so the file is written with aggregating {@link Dependencies}.
+ */
+public class LynxLibrarySymbolProcessor implements SymbolProcessor {
+  public static final String OPTION_LIBRARY_PACKAGE_NAME = "lynx.library.packageName";
+
+  private static final String BEHAVIOR_ANNOTATION = "com.lynx.tasm.behavior.LynxBehavior";
+  private static final String ELEMENT_ANNOTATION = "com.lynx.tasm.behavior.LynxElement";
+  private static final String NATIVE_MODULE_ANNOTATION = "com.lynx.jsbridge.LynxNativeModule";
+  private static final String SERVICE_ANNOTATION = "com.lynx.tasm.service.LynxService";
+  private static final String GENERATOR_NAME_ANNOTATION =
+      "com.lynx.tasm.behavior.LynxGeneratorName";
+
+  private static final ClassName KEEP_TYPE = ClassName.get("androidx.annotation", "Keep");
+
+  private final CodeGenerator mCodeGenerator;
+  private final KSPLogger mLogger;
+  private final Map<String, String> mOptions;
+  // Containing files of every annotated symbol feeding the aggregated provider output.
+  private final Set<KSFile> mSourceFiles = new LinkedHashSet<>();
+  // The provider must be generated at most once per compilation; process() runs every round.
+  private boolean mCreated;
+
+  public LynxLibrarySymbolProcessor(SymbolProcessorEnvironment environment) {
+    mCodeGenerator = environment.getCodeGenerator();
+    mLogger = environment.getLogger();
+    mOptions = environment.getOptions();
+  }
+
+  @Override
+  public List<KSAnnotated> process(Resolver resolver) {
+    if (mCreated) {
+      return Collections.emptyList();
+    }
+
+    String providerPackageName = getProviderPackageName();
+    if (providerPackageName.length() == 0) {
+      return Collections.emptyList();
+    }
+    mCreated = true;
+
+    mSourceFiles.clear();
+    String behaviorGeneratorPackageName = getBehaviorGeneratorPackageName(resolver);
+    List<ModuleInfo> modules = getNativeModules(resolver);
+    List<ClassName> services = getServices(resolver);
+    boolean hasBehaviors = behaviorGeneratorPackageName.length() > 0;
+
+    try {
+      generateProvider(
+          providerPackageName, behaviorGeneratorPackageName, hasBehaviors, modules, services);
+    } catch (IOException e) {
+      error(e.getMessage());
+    }
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void onError() {}
+
+  private String getProviderPackageName() {
+    String packageName = mOptions.get(OPTION_LIBRARY_PACKAGE_NAME);
+    if (packageName != null && packageName.trim().length() > 0) {
+      return packageName.trim();
+    }
+    // Provider generation is opt-in through the Autolink Gradle plugin. Regular Lynx
+    // modules may use the same annotations for behavior generation and should not emit
+    // a library provider.
+    return "";
+  }
+
+  private String getBehaviorGeneratorPackageName(Resolver resolver) {
+    Iterator<KSAnnotated> generatorNames =
+        resolver.getSymbolsWithAnnotation(GENERATOR_NAME_ANNOTATION, false).iterator();
+    while (generatorNames.hasNext()) {
+      KSAnnotated symbol = generatorNames.next();
+      collectSourceFile(symbol);
+      KSAnnotation annotation = KspUtils.findAnnotation(symbol, GENERATOR_NAME_ANNOTATION);
+      if (annotation == null) {
+        continue;
+      }
+      String packageName = KspUtils.argument(annotation, "packageName");
+      if (packageName != null && packageName.length() > 0) {
+        return packageName;
+      }
+    }
+    Iterator<KSAnnotated> behaviors =
+        resolver.getSymbolsWithAnnotation(BEHAVIOR_ANNOTATION, false).iterator();
+    while (behaviors.hasNext()) {
+      KSAnnotated symbol = behaviors.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      collectSourceFile(symbol);
+      return KspUtils.toClassName((KSClassDeclaration) symbol).packageName();
+    }
+    Iterator<KSAnnotated> elements =
+        resolver.getSymbolsWithAnnotation(ELEMENT_ANNOTATION, false).iterator();
+    while (elements.hasNext()) {
+      KSAnnotated symbol = elements.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      collectSourceFile(symbol);
+      return KspUtils.toClassName((KSClassDeclaration) symbol).packageName();
+    }
+    return "";
+  }
+
+  private List<ModuleInfo> getNativeModules(Resolver resolver) {
+    List<ModuleInfo> modules = new ArrayList<>();
+    Iterator<KSAnnotated> symbols =
+        resolver.getSymbolsWithAnnotation(NATIVE_MODULE_ANNOTATION, false).iterator();
+    while (symbols.hasNext()) {
+      KSAnnotated symbol = symbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      collectSourceFile(classType);
+      KSAnnotation annotation = KspUtils.findAnnotation(classType, NATIVE_MODULE_ANNOTATION);
+      if (annotation == null) {
+        continue;
+      }
+      String name = KspUtils.argument(annotation, "name");
+      modules.add(new ModuleInfo(name, KspUtils.toClassName(classType)));
+    }
+    return modules;
+  }
+
+  private List<ClassName> getServices(Resolver resolver) {
+    List<ClassName> services = new ArrayList<>();
+    Iterator<KSAnnotated> symbols =
+        resolver.getSymbolsWithAnnotation(SERVICE_ANNOTATION, false).iterator();
+    while (symbols.hasNext()) {
+      KSAnnotated symbol = symbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      collectSourceFile(classType);
+      services.add(KspUtils.toClassName(classType));
+    }
+    return services;
+  }
+
+  private void generateProvider(String providerPackageName, String behaviorGeneratorPackageName,
+      boolean hasBehaviors, List<ModuleInfo> modules, List<ClassName> services) throws IOException {
+    ClassName provider = ClassName.get("com.lynx.tasm.library", "LynxLibraryProvider");
+    ClassName registry = ClassName.get("com.lynx.tasm.library", "LynxLibraryRegistry");
+
+    MethodSpec.Builder register = MethodSpec.methodBuilder("register")
+                                      .addAnnotation(Override.class)
+                                      .addModifiers(PUBLIC)
+                                      .addParameter(registry, "registry");
+    if (hasBehaviors) {
+      register.addStatement("registry.addBehaviors($T.getBehaviors())",
+          ClassName.get(behaviorGeneratorPackageName, "BehaviorGenerator"));
+    }
+    for (ModuleInfo module : modules) {
+      register.addStatement("registry.registerModule($S, $T.class)", module.name, module.className);
+    }
+    for (ClassName service : services) {
+      register.addStatement("registry.registerService($T.class)", service);
+    }
+
+    TypeSpec providerClass = TypeSpec.classBuilder("LynxLibraryProviderImpl")
+                                 .addAnnotation(KEEP_TYPE)
+                                 .addModifiers(PUBLIC)
+                                 .addSuperinterface(provider)
+                                 .addMethod(register.build())
+                                 .build();
+
+    JavaFile javaFile = JavaFile.builder(providerPackageName, providerClass)
+                            .addFileComment("Generated by com.lynx.processor.LynxLibraryProcessor")
+                            .build();
+
+    // Aggregating output: any new or changed annotated class must regenerate the provider, so
+    // this bypasses KspUtils.write (which records isolating dependencies).
+    Dependencies dependencies = new Dependencies(true, mSourceFiles.toArray(new KSFile[0]));
+    OutputStream stream = mCodeGenerator.createNewFile(
+        dependencies, providerPackageName, "LynxLibraryProviderImpl", "java");
+    try (Writer writer = new OutputStreamWriter(stream, StandardCharsets.UTF_8)) {
+      javaFile.writeTo(writer);
+    }
+  }
+
+  private void collectSourceFile(KSAnnotated symbol) {
+    if (!(symbol instanceof KSDeclaration)) {
+      return;
+    }
+    KSFile file = ((KSDeclaration) symbol).getContainingFile();
+    if (file != null) {
+      mSourceFiles.add(file);
+    }
+  }
+
+  private void error(String message) {
+    mLogger.error(message != null ? message : "unknown error", null);
+  }
+
+  private static class ModuleInfo {
+    final String name;
+    final ClassName className;
+
+    ModuleInfo(String name, ClassName className) {
+      this.name = name;
+      this.className = className;
+    }
+  }
+
+  /** Entry point registered in META-INF/services. */
+  public static class Provider implements SymbolProcessorProvider {
+    @Override
+    public SymbolProcessor create(SymbolProcessorEnvironment environment) {
+      return new LynxLibrarySymbolProcessor(environment);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxPropsSymbolProcessor.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxPropsSymbolProcessor.java
@@ -1,0 +1,614 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.processor.ksp;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+import com.google.devtools.ksp.UtilsKt;
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.KSPLogger;
+import com.google.devtools.ksp.processing.Resolver;
+import com.google.devtools.ksp.processing.SymbolProcessor;
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment;
+import com.google.devtools.ksp.processing.SymbolProcessorProvider;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSAnnotation;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration;
+import com.google.devtools.ksp.symbol.KSNode;
+import com.google.devtools.ksp.symbol.KSValueParameter;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * KSP port of {@code com.lynx.processor.LynxPropsProcessor}.
+ *
+ * <p>Generates {@code <Class>$$PropsSetter} holders for classes annotated with
+ * {@code @LynxPropsHolder}, producing the same Java sources as the javac implementation.
+ */
+public class LynxPropsSymbolProcessor implements SymbolProcessor {
+  private static final String PROPS_HOLDER_ANNOTATION = "com.lynx.tasm.behavior.LynxPropsHolder";
+  private static final String PROP_ANNOTATION = "com.lynx.tasm.behavior.LynxProp";
+  private static final String PROP_GROUP_ANNOTATION = "com.lynx.tasm.behavior.LynxPropGroup";
+
+  private static final String LYNX_UI_QUALIFIED = "com.lynx.tasm.behavior.ui.LynxBaseUI";
+  private static final String SHADOW_NODE_QUALIFIED = "com.lynx.tasm.behavior.shadow.ShadowNode";
+
+  private static final Map<TypeName, String> DEFAULT_TYPES;
+  private static final Set<TypeName> BOXED_PRIMITIVES;
+
+  private static final TypeName PROPS_TYPE =
+      ClassName.get("com.lynx.tasm.behavior", "StylesDiffMap");
+  private static final TypeName STRING_TYPE = TypeName.get(String.class);
+  private static final TypeName READABLE_MAP_TYPE =
+      ClassName.get("com.lynx.react.bridge", "ReadableMap");
+  private static final TypeName READABLE_ARRAY_TYPE =
+      ClassName.get("com.lynx.react.bridge", "ReadableArray");
+  private static final TypeName DYNAMIC_TYPE = ClassName.get("com.lynx.react.bridge", "Dynamic");
+
+  private static final ClassName LYNX_UI_TYPE =
+      ClassName.get("com.lynx.tasm.behavior.ui", "LynxBaseUI");
+  private static final ClassName SHADOW_NODE_IMPL_TYPE =
+      ClassName.get("com.lynx.tasm.behavior.shadow", "ShadowNode");
+
+  private static final ClassName LYNX_UI_SETTER_TYPE =
+      ClassName.get("com.lynx.tasm.behavior.utils", "LynxUISetter");
+  private static final ClassName SHADOW_NODE_SETTER_TYPE =
+      ClassName.get("com.lynx.tasm.behavior.utils", "ShadowNodeSetter");
+
+  static {
+    DEFAULT_TYPES = new HashMap<>();
+
+    // Primitives
+    DEFAULT_TYPES.put(TypeName.BOOLEAN, "boolean");
+    DEFAULT_TYPES.put(TypeName.DOUBLE, "number");
+    DEFAULT_TYPES.put(TypeName.FLOAT, "number");
+    DEFAULT_TYPES.put(TypeName.INT, "number");
+    DEFAULT_TYPES.put(TypeName.LONG, "number");
+
+    // Boxed primitives
+    DEFAULT_TYPES.put(TypeName.BOOLEAN.box(), "boolean");
+    DEFAULT_TYPES.put(TypeName.INT.box(), "number");
+    DEFAULT_TYPES.put(TypeName.LONG.box(), "number");
+
+    // Class types
+    DEFAULT_TYPES.put(STRING_TYPE, "String");
+    DEFAULT_TYPES.put(READABLE_ARRAY_TYPE, "Array");
+    DEFAULT_TYPES.put(READABLE_MAP_TYPE, "Map");
+    DEFAULT_TYPES.put(DYNAMIC_TYPE, "Dynamic");
+
+    BOXED_PRIMITIVES = new HashSet<>();
+    BOXED_PRIMITIVES.add(TypeName.BOOLEAN.box());
+    BOXED_PRIMITIVES.add(TypeName.FLOAT.box());
+    BOXED_PRIMITIVES.add(TypeName.INT.box());
+    BOXED_PRIMITIVES.add(TypeName.LONG.box());
+  }
+
+  private final CodeGenerator mCodeGenerator;
+  private final KSPLogger mLogger;
+  private final Map<ClassName, ClassInfo> mClasses = new HashMap<>();
+
+  public LynxPropsSymbolProcessor(SymbolProcessorEnvironment environment) {
+    mCodeGenerator = environment.getCodeGenerator();
+    mLogger = environment.getLogger();
+  }
+
+  @Override
+  public List<KSAnnotated> process(Resolver resolver) {
+    // Clear properties from previous rounds
+    mClasses.clear();
+
+    Iterator<KSAnnotated> symbols =
+        resolver.getSymbolsWithAnnotation(PROPS_HOLDER_ANNOTATION, false).iterator();
+    while (symbols.hasNext()) {
+      KSAnnotated symbol = symbols.next();
+      if (!(symbol instanceof KSClassDeclaration)) {
+        continue;
+      }
+      KSClassDeclaration classType = (KSClassDeclaration) symbol;
+      try {
+        ClassName className = KspUtils.toClassName(classType);
+        mClasses.put(className, parseClass(className, classType));
+      } catch (Exception e) {
+        error(classType, e.getMessage());
+      }
+    }
+
+    for (ClassInfo classInfo : mClasses.values()) {
+      try {
+        if (!shouldIgnoreClass(classInfo)) {
+          // Sort by name
+          Collections.sort(classInfo.mProperties, new Comparator<PropertyInfo>() {
+            @Override
+            public int compare(PropertyInfo a, PropertyInfo b) {
+              return a.mProperty.name().compareTo(b.mProperty.name());
+            }
+          });
+          generateCode(classInfo, classInfo.mProperties);
+        } else {
+          warning(classInfo.mDeclaration, "Class was skipped. Classes need to be non-private.");
+        }
+      } catch (IOException e) {
+        error(null, e.getMessage());
+      } catch (ReactPropertyException e) {
+        error(e.node, e.getMessage());
+      } catch (Exception e) {
+        error(classInfo.mDeclaration, e.getMessage());
+      }
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void onError() {}
+
+  private ClassInfo parseClass(ClassName className, KSClassDeclaration classType) {
+    SettableType settableType = findSettableType(classType);
+
+    ClassInfo classInfo = new ClassInfo(className, classType, settableType);
+    findProperties(classInfo, classType);
+
+    return classInfo;
+  }
+
+  /** Walks the superclass chain to decide whether the holder targets a LynxUI or a ShadowNode. */
+  private static SettableType findSettableType(KSClassDeclaration classType) {
+    KSClassDeclaration current = classType;
+    while (current != null) {
+      String qualifiedName = KspUtils.qualifiedNameOf(current);
+      if (LYNX_UI_QUALIFIED.equals(qualifiedName)) {
+        return SettableType.LYNX_UI;
+      }
+      if (SHADOW_NODE_QUALIFIED.equals(qualifiedName)) {
+        return SettableType.SHADOW_NODE;
+      }
+      if ("kotlin.Any".equals(qualifiedName) || "java.lang.Object".equals(qualifiedName)) {
+        throw new IllegalArgumentException("Could not find target type " + qualifiedName);
+      }
+      current = KspUtils.superclassOf(current);
+    }
+    throw new IllegalArgumentException("Could not find target type for " + classType);
+  }
+
+  private void findProperties(ClassInfo classInfo, KSClassDeclaration classType) {
+    Iterator<KSDeclaration> declarations = classType.getDeclarations().iterator();
+    while (declarations.hasNext()) {
+      KSDeclaration declaration = declarations.next();
+      if (!(declaration instanceof KSFunctionDeclaration)) {
+        continue;
+      }
+      KSFunctionDeclaration method = (KSFunctionDeclaration) declaration;
+      KSAnnotation prop = KspUtils.findAnnotation(method, PROP_ANNOTATION);
+      KSAnnotation propGroup = KspUtils.findAnnotation(method, PROP_GROUP_ANNOTATION);
+
+      try {
+        if (prop != null || propGroup != null) {
+          checkElement(method);
+        }
+
+        if (prop != null) {
+          classInfo.addProperty(PropertyInfo.build(classInfo, method, new RegularProperty(prop)));
+        } else if (propGroup != null) {
+          List<String> names = KspUtils.stringList(KspUtils.argument(propGroup, "names"));
+          for (int i = 0, size = names.size(); i < size; i++) {
+            classInfo.addProperty(
+                PropertyInfo.build(classInfo, method, new GroupProperty(propGroup, names, i)));
+          }
+        }
+      } catch (ReactPropertyException e) {
+        error(e.node, e.getMessage());
+      }
+    }
+  }
+
+  private void generateCode(ClassInfo classInfo, List<PropertyInfo> properties)
+      throws IOException, ReactPropertyException {
+    TypeName superType = getSuperType(classInfo);
+    ClassName className = classInfo.mClassName;
+
+    ClassName pClassName = null;
+    if (!classInfo.mIsLynxUIBase && !classInfo.mIsShadowNodeBase) {
+      String packageName = classInfo.mParentClassName.packageName();
+      String simpleName = classInfo.mParentClassName.simpleName() + "$$PropsSetter";
+      pClassName = ClassName.get(packageName, simpleName);
+    }
+
+    String holderClassName =
+        getClassName(classInfo.mDeclaration, className.packageName()) + "$$PropsSetter";
+    TypeSpec.Builder builder = TypeSpec.classBuilder(holderClassName)
+                                   .addModifiers(PUBLIC)
+                                   .addMethod(generateSetPropertySpec(classInfo, properties));
+    if (null != pClassName) {
+      builder.superclass(pClassName);
+    } else {
+      builder.addSuperinterface(superType);
+    }
+
+    TypeSpec holderClass = builder.build();
+
+    JavaFile javaFile = JavaFile.builder(className.packageName(), holderClass)
+                            .addFileComment("Generated by com.lynx.processor.LynxPropsProcessor")
+                            .build();
+
+    KspUtils.write(mCodeGenerator, classInfo.mDeclaration.getContainingFile(),
+        className.packageName(), holderClassName, javaFile);
+  }
+
+  private static String getClassName(KSClassDeclaration type, String packageName) {
+    int packageLen = packageName.length() + 1;
+    return KspUtils.qualifiedNameOf(type).substring(packageLen).replace('.', '$');
+  }
+
+  private static TypeName getSuperType(ClassInfo classInfo) {
+    switch (classInfo.getType()) {
+      case LYNX_UI:
+        return ParameterizedTypeName.get(LYNX_UI_SETTER_TYPE, classInfo.mClassName);
+      case SHADOW_NODE:
+        return ParameterizedTypeName.get(SHADOW_NODE_SETTER_TYPE, classInfo.mClassName);
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  private static MethodSpec generateSetPropertySpec(
+      ClassInfo classInfo, List<PropertyInfo> properties) {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("setProperty")
+                                     .addModifiers(PUBLIC)
+                                     .addAnnotation(Override.class)
+                                     .returns(TypeName.VOID);
+    ClassName className;
+    if (classInfo.getType() == SettableType.LYNX_UI) {
+      className = LYNX_UI_TYPE;
+    } else {
+      className = SHADOW_NODE_IMPL_TYPE;
+    }
+    builder.addParameter(className, "manager");
+
+    return builder.addParameter(STRING_TYPE, "name")
+        .addParameter(PROPS_TYPE, "props")
+        .addCode(generateSetProperty(classInfo, properties))
+        .build();
+  }
+
+  private static CodeBlock generateSetProperty(ClassInfo info, List<PropertyInfo> properties) {
+    if (properties.isEmpty()) {
+      return CodeBlock.builder().addStatement("super.setProperty(manager, name, props)").build();
+    }
+
+    CodeBlock.Builder builder = CodeBlock.builder();
+
+    builder.addStatement(
+        "$T $N = ($T) $N", info.mClassName, "manager2", info.mClassName, "manager");
+
+    builder.add("switch (name) {\n").indent();
+    for (int i = 0, size = properties.size(); i < size; i++) {
+      PropertyInfo propertyInfo = properties.get(i);
+      builder.add("case \"$L\":\n", propertyInfo.mProperty.name()).indent();
+      builder.add("manager2.$L(", propertyInfo.methodName);
+      if (propertyInfo.mProperty instanceof GroupProperty) {
+        builder.add("$L, ", ((GroupProperty) propertyInfo.mProperty).mGroupIndex);
+      }
+      if (BOXED_PRIMITIVES.contains(propertyInfo.propertyType)) {
+        builder.add("props.isNull(name) ? null : ");
+      }
+      getPropertyExtractor(propertyInfo, builder);
+      builder.addStatement(")");
+      builder.addStatement("return").unindent();
+    }
+    builder.unindent().add("}\n");
+    if (!info.mIsLynxUIBase && !info.mIsShadowNodeBase) {
+      builder.addStatement("super.setProperty(manager, name, props)");
+    }
+
+    return builder.build();
+  }
+
+  private static CodeBlock.Builder getPropertyExtractor(
+      PropertyInfo info, CodeBlock.Builder builder) {
+    TypeName propertyType = info.propertyType;
+    if (propertyType.equals(STRING_TYPE)) {
+      return builder.add("props.getString(name)");
+    } else if (propertyType.equals(READABLE_ARRAY_TYPE)) {
+      return builder.add("props.getArray(name)");
+    } else if (propertyType.equals(READABLE_MAP_TYPE)) {
+      return builder.add("props.getMap(name)");
+    } else if (propertyType.equals(DYNAMIC_TYPE)) {
+      return builder.add("props.getDynamic(name)");
+    }
+
+    if (BOXED_PRIMITIVES.contains(propertyType)) {
+      propertyType = propertyType.unbox();
+    }
+
+    if (propertyType.equals(TypeName.BOOLEAN)) {
+      return builder.add("props.getBoolean(name, $L)", info.mProperty.defaultBoolean());
+    }
+    if (propertyType.equals(TypeName.DOUBLE)) {
+      double defaultDouble = info.mProperty.defaultDouble();
+      if (Double.isNaN(defaultDouble)) {
+        return builder.add("props.getDouble(name, $T.NaN)", Double.class);
+      } else {
+        return builder.add("props.getDouble(name, $Lf)", defaultDouble);
+      }
+    }
+    if (propertyType.equals(TypeName.FLOAT)) {
+      float defaultFloat = info.mProperty.defaultFloat();
+      if (Float.isNaN(defaultFloat)) {
+        return builder.add("props.getFloat(name, $T.NaN)", Float.class);
+      } else {
+        return builder.add("props.getFloat(name, $Lf)", defaultFloat);
+      }
+    }
+    if (propertyType.equals(TypeName.INT)) {
+      return builder.add("props.getInt(name, $L)", info.mProperty.defaultInt());
+    }
+    if (propertyType.equals(TypeName.LONG)) {
+      return builder.add("props.getLong(name, 0L)");
+    }
+
+    throw new IllegalArgumentException();
+  }
+
+  private static void checkElement(KSFunctionDeclaration method) throws ReactPropertyException {
+    if (UtilsKt.isPublic(method)) {
+      return;
+    }
+
+    throw new ReactPropertyException(
+        "@LynxProp and @ReachPropGroup annotation must be on a public method", method);
+  }
+
+  private static boolean shouldIgnoreClass(ClassInfo classInfo) {
+    return UtilsKt.isPrivate(classInfo.mDeclaration);
+  }
+
+  private void error(KSNode node, String message) {
+    mLogger.error(message != null ? message : "unknown error", node);
+  }
+
+  private void warning(KSNode node, String message) {
+    mLogger.warn(message, node);
+  }
+
+  private interface Property {
+    String name();
+    String customType();
+    double defaultDouble();
+    float defaultFloat();
+    int defaultInt();
+    boolean defaultBoolean();
+  }
+
+  private static class RegularProperty implements Property {
+    private final KSAnnotation mProp;
+
+    RegularProperty(KSAnnotation prop) {
+      mProp = prop;
+    }
+
+    @Override
+    public String name() {
+      return KspUtils.argument(mProp, "name");
+    }
+
+    @Override
+    public String customType() {
+      return KspUtils.argument(mProp, "customType");
+    }
+
+    @Override
+    public double defaultDouble() {
+      Number value = KspUtils.argument(mProp, "defaultDouble");
+      return value != null ? value.doubleValue() : 0.0;
+    }
+
+    @Override
+    public float defaultFloat() {
+      Number value = KspUtils.argument(mProp, "defaultFloat");
+      return value != null ? value.floatValue() : 0.0f;
+    }
+
+    @Override
+    public int defaultInt() {
+      Number value = KspUtils.argument(mProp, "defaultInt");
+      return value != null ? value.intValue() : 0;
+    }
+
+    @Override
+    public boolean defaultBoolean() {
+      Boolean value = KspUtils.argument(mProp, "defaultBoolean");
+      return value != null && value;
+    }
+  }
+
+  private static class GroupProperty implements Property {
+    private final KSAnnotation mProp;
+    private final List<String> mNames;
+    final int mGroupIndex;
+
+    GroupProperty(KSAnnotation prop, List<String> names, int groupIndex) {
+      mProp = prop;
+      mNames = names;
+      mGroupIndex = groupIndex;
+    }
+
+    @Override
+    public String name() {
+      return mNames.get(mGroupIndex);
+    }
+
+    @Override
+    public String customType() {
+      return KspUtils.argument(mProp, "customType");
+    }
+
+    @Override
+    public double defaultDouble() {
+      Number value = KspUtils.argument(mProp, "defaultDouble");
+      return value != null ? value.doubleValue() : 0.0;
+    }
+
+    @Override
+    public float defaultFloat() {
+      Number value = KspUtils.argument(mProp, "defaultFloat");
+      return value != null ? value.floatValue() : 0.0f;
+    }
+
+    @Override
+    public int defaultInt() {
+      Number value = KspUtils.argument(mProp, "defaultInt");
+      return value != null ? value.intValue() : 0;
+    }
+
+    @Override
+    public boolean defaultBoolean() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private enum SettableType { LYNX_UI, SHADOW_NODE }
+
+  private static class ClassInfo {
+    final ClassName mParentClassName;
+    final ClassName mClassName;
+    final KSClassDeclaration mDeclaration;
+    final List<PropertyInfo> mProperties;
+    final SettableType mSettableType;
+    final boolean mIsLynxUIBase;
+    final boolean mIsShadowNodeBase;
+
+    ClassInfo(ClassName className, KSClassDeclaration declaration, SettableType settableType) {
+      KSClassDeclaration superclass = KspUtils.superclassOf(declaration);
+      if (superclass != null) {
+        ClassName superclassName = KspUtils.toClassName(superclass);
+        String qualifiedName = KspUtils.qualifiedNameOf(superclass);
+        mParentClassName = "kotlin.Any".equals(qualifiedName)
+            ? ClassName.get("java.lang", "Object")
+            : superclassName;
+      } else {
+        mParentClassName = ClassName.get("java.lang", "Object");
+      }
+      mClassName = className;
+      mDeclaration = declaration;
+      mProperties = new ArrayList<>();
+      mSettableType = settableType;
+
+      String ownQualifiedName = KspUtils.qualifiedNameOf(declaration);
+      mIsLynxUIBase = LYNX_UI_QUALIFIED.equals(ownQualifiedName);
+      mIsShadowNodeBase = SHADOW_NODE_QUALIFIED.equals(ownQualifiedName);
+    }
+
+    SettableType getType() {
+      return mSettableType;
+    }
+
+    void addProperty(PropertyInfo propertyInfo) throws ReactPropertyException {
+      String name = propertyInfo.mProperty.name();
+      if (checkPropertyExists(name)) {
+        System.out.print("Module " + mClassName + " has already registered a property named \""
+            + name + "\". If you want to override a property, don't add"
+            + "the @LynxProp annotation to the property in the subclass");
+        return;
+      }
+
+      mProperties.add(propertyInfo);
+    }
+
+    private boolean checkPropertyExists(String name) {
+      for (PropertyInfo propertyInfo : mProperties) {
+        if (propertyInfo.mProperty.name().equals(name)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+
+  private static class PropertyInfo {
+    final String methodName;
+    final TypeName propertyType;
+    final KSNode node;
+    final Property mProperty;
+
+    private PropertyInfo(String methodName, TypeName propertyType, KSNode node, Property property) {
+      this.methodName = methodName;
+      this.propertyType = propertyType;
+      this.node = node;
+      mProperty = property;
+    }
+
+    static PropertyInfo build(ClassInfo classInfo, KSFunctionDeclaration method, Property property)
+        throws ReactPropertyException {
+      String methodName = method.getSimpleName().asString();
+
+      List<KSValueParameter> parameters = method.getParameters();
+
+      if (parameters.size() != getArgCount(property)) {
+        throw new ReactPropertyException("Wrong number of args", method);
+      }
+
+      int index = 0;
+      if (property instanceof GroupProperty) {
+        TypeName indexType = KspUtils.toTypeName(parameters.get(index++).getType().resolve());
+        if (!indexType.equals(TypeName.INT)) {
+          throw new ReactPropertyException(
+              "Argument " + index + " must be an int for @LynxPropGroup", method);
+        }
+      }
+
+      TypeName propertyType = KspUtils.toTypeName(parameters.get(index++).getType().resolve());
+      if (!DEFAULT_TYPES.containsKey(propertyType)) {
+        throw new ReactPropertyException(
+            "Argument " + index + " must be of a supported type", method);
+      }
+
+      return new PropertyInfo(methodName, propertyType, method, property);
+    }
+
+    private static int getArgCount(Property property) {
+      int baseCount = 1;
+      return property instanceof GroupProperty ? baseCount + 1 : baseCount;
+    }
+  }
+
+  private static class ReactPropertyException extends Exception {
+    final KSNode node;
+
+    ReactPropertyException(String message, KSNode node) {
+      super(message);
+      this.node = node;
+    }
+  }
+
+  /** Entry point registered in META-INF/services. */
+  public static class Provider implements SymbolProcessorProvider {
+    @Override
+    public SymbolProcessor create(SymbolProcessorEnvironment environment) {
+      return new LynxPropsSymbolProcessor(environment);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxUIMethodsSymbolProcessor.java
+++ b/platform/android/lynx_processor_ksp/src/main/java/com/lynx/processor/ksp/LynxUIMethodsSymbolProcessor.java
@@ -1,0 +1,272 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.processor.ksp;
+
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+import com.google.devtools.ksp.processing.CodeGenerator;
+import com.google.devtools.ksp.processing.KSPLogger;
+import com.google.devtools.ksp.processing.Resolver;
+import com.google.devtools.ksp.processing.SymbolProcessor;
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment;
+import com.google.devtools.ksp.processing.SymbolProcessorProvider;
+import com.google.devtools.ksp.symbol.KSAnnotated;
+import com.google.devtools.ksp.symbol.KSClassDeclaration;
+import com.google.devtools.ksp.symbol.KSDeclaration;
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration;
+import com.google.devtools.ksp.symbol.KSNode;
+import com.google.devtools.ksp.symbol.KSValueParameter;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * KSP port of {@code com.lynx.processor.LynxUIMethodsProcessor}.
+ *
+ * <p>Generates {@code <Class>$$MethodInvoker} holders for classes annotated with
+ * {@code @LynxUIMethodsHolder}, producing the same Java sources as the javac implementation.
+ */
+public class LynxUIMethodsSymbolProcessor implements SymbolProcessor {
+  private static final String UI_METHODS_HOLDER_ANNOTATION =
+      "com.lynx.tasm.behavior.LynxUIMethodsHolder";
+  private static final String UI_METHOD_ANNOTATION = "com.lynx.tasm.behavior.LynxUIMethod";
+
+  private static final TypeName STRING_TYPE = TypeName.get(String.class);
+  private static final TypeName READABLE_MAP_TYPE =
+      ClassName.get("com.lynx.react.bridge", "ReadableMap");
+  private static final TypeName CALLBACK_TYPE = ClassName.get("com.lynx.react.bridge", "Callback");
+  private static final ClassName LYNX_UI_METHOD_INVOKER_TYPE =
+      ClassName.get("com.lynx.tasm.behavior.utils", "LynxUIMethodInvoker");
+  private static final ClassName LYNX_UI_METHOD_CONSTANTS =
+      ClassName.get("com.lynx.tasm.behavior", "LynxUIMethodConstants");
+  // The javac processor references androidx.annotation.Keep through Keep.class; using the
+  // ClassName keeps the generated import identical without a compile-time androidx dependency.
+  private static final ClassName KEEP_TYPE = ClassName.get("androidx.annotation", "Keep");
+
+  private final CodeGenerator mCodeGenerator;
+  private final KSPLogger mLogger;
+  private final Map<ClassName, ClassInfo> mClasses = new HashMap<>();
+
+  public LynxUIMethodsSymbolProcessor(SymbolProcessorEnvironment environment) {
+    mCodeGenerator = environment.getCodeGenerator();
+    mLogger = environment.getLogger();
+  }
+
+  @Override
+  public List<KSAnnotated> process(Resolver resolver) {
+    // Clear classes from previous rounds
+    mClasses.clear();
+
+    List<KSClassDeclaration> holders = new ArrayList<>();
+    Iterator<KSAnnotated> symbols =
+        resolver.getSymbolsWithAnnotation(UI_METHODS_HOLDER_ANNOTATION, false).iterator();
+    while (symbols.hasNext()) {
+      KSAnnotated symbol = symbols.next();
+      if (symbol instanceof KSClassDeclaration) {
+        holders.add((KSClassDeclaration) symbol);
+      }
+    }
+
+    System.out.print("LynxUIMethodProcessor: process start size = " + holders.size() + "\n");
+    for (KSClassDeclaration classType : holders) {
+      try {
+        System.out.print("LynxUIMethodProcessor: process classType = "
+            + KspUtils.qualifiedNameOf(classType) + "\n");
+        ClassName className = KspUtils.toClassName(classType);
+        ClassInfo classInfo = parseClass(className, classType);
+        if (classInfo.mMethods.size() > 0) {
+          mClasses.put(className, classInfo);
+        } else {
+          System.out.print("no methods");
+        }
+      } catch (Exception e) {
+        error(classType, e.getMessage());
+      }
+    }
+
+    for (ClassInfo classInfo : mClasses.values()) {
+      try {
+        generateCode(classInfo);
+      } catch (IOException e) {
+        error(null, e.getMessage());
+      } catch (Exception e) {
+        error(classInfo.mDeclaration, e.getMessage());
+      }
+    }
+
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void finish() {}
+
+  @Override
+  public void onError() {}
+
+  private ClassInfo parseClass(ClassName className, KSClassDeclaration classType) {
+    ClassInfo classInfo = new ClassInfo(className, classType);
+
+    // findLynxUIMethods: like the javac processor, walk the whole superclass chain so
+    // inherited @LynxUIMethod methods end up in the subclass invoker as well.
+    KSClassDeclaration current = classType;
+    while (current != null) {
+      Iterator<KSDeclaration> declarations = current.getDeclarations().iterator();
+      while (declarations.hasNext()) {
+        KSDeclaration declaration = declarations.next();
+        if (!(declaration instanceof KSFunctionDeclaration)) {
+          continue;
+        }
+        if (KspUtils.findAnnotation(declaration, UI_METHOD_ANNOTATION) != null) {
+          classInfo.addMethod((KSFunctionDeclaration) declaration);
+        }
+      }
+
+      current = KspUtils.superclassOf(current);
+    }
+
+    return classInfo;
+  }
+
+  private void generateCode(ClassInfo classInfo) throws IOException {
+    TypeName superType =
+        ParameterizedTypeName.get(LYNX_UI_METHOD_INVOKER_TYPE, classInfo.mClassName);
+    ClassName className = classInfo.mClassName;
+    String holderClassName =
+        getClassName(classInfo.mDeclaration, className.packageName()) + "$$MethodInvoker";
+    TypeSpec holderClass = TypeSpec.classBuilder(holderClassName)
+                               .addAnnotation(KEEP_TYPE)
+                               .addSuperinterface(superType)
+                               .addModifiers(PUBLIC)
+                               .addMethod(generateMethodInvokerSpec(classInfo))
+                               .build();
+
+    JavaFile javaFile =
+        JavaFile
+            .builder(className.packageName(), holderClass)
+            // Hardcoded to the javac processor FQCN so the output stays byte-identical.
+            .addFileComment("Generated by com.lynx.processor.LynxUIMethodsProcessor")
+            .addStaticImport(LYNX_UI_METHOD_CONSTANTS, "METHOD_NOT_FOUND")
+            .build();
+
+    KspUtils.write(mCodeGenerator, classInfo.mDeclaration.getContainingFile(),
+        className.packageName(), holderClassName, javaFile);
+  }
+
+  private static MethodSpec generateMethodInvokerSpec(ClassInfo classInfo) {
+    MethodSpec.Builder builder = MethodSpec.methodBuilder("invoke")
+                                     .addModifiers(PUBLIC)
+                                     .addAnnotation(Override.class)
+                                     .returns(TypeName.VOID);
+
+    builder.addParameter(classInfo.mClassName, "ui")
+        .addParameter(STRING_TYPE, "methodName")
+        .addParameter(READABLE_MAP_TYPE, "params")
+        .addParameter(CALLBACK_TYPE, "callback");
+
+    builder.addCode(generateMethodInvokerCodeBlock(classInfo));
+
+    return builder.build();
+  }
+
+  private static CodeBlock generateMethodInvokerCodeBlock(ClassInfo classInfo) {
+    CodeBlock.Builder builder = CodeBlock.builder();
+    builder.add("switch (methodName) {\n").indent();
+
+    List<KSFunctionDeclaration> methods = classInfo.mMethods;
+    for (int i = 0, size = methods.size(); i < size; i++) {
+      KSFunctionDeclaration method = methods.get(i);
+      String methodName = method.getSimpleName().asString();
+      builder.add("case \"$L\":\n", methodName).indent();
+      builder.add("ui.$L(", methodName);
+
+      List<KSValueParameter> parameters = method.getParameters();
+      if (parameters.size() > 2) {
+        throw new IllegalArgumentException("params size of method annotated with LynxUIMethod "
+            + "should not be greater than 2, class: " + classInfo.mClassName);
+      }
+
+      // add params
+      List<String> params = new ArrayList<>();
+      for (KSValueParameter param : parameters) {
+        TypeName targetType = KspUtils.toTypeName(param.getType().resolve());
+        if (targetType.equals(READABLE_MAP_TYPE)) {
+          params.add("params");
+        } else if (targetType.equals(CALLBACK_TYPE)) {
+          params.add("callback");
+        }
+      }
+      builder.add(String.join(",", params));
+      builder.addStatement(")");
+      builder.addStatement("break").unindent();
+    }
+    builder.add("default:\n").indent();
+    builder.addStatement("callback.invoke(METHOD_NOT_FOUND)");
+    builder.addStatement("break").unindent();
+    builder.unindent().add("}\n");
+
+    return builder.build();
+  }
+
+  private static String getClassName(KSClassDeclaration type, String packageName) {
+    int packageLen = packageName.length() + 1;
+    return KspUtils.qualifiedNameOf(type).substring(packageLen).replace('.', '$');
+  }
+
+  private void error(KSNode node, String message) {
+    mLogger.error(message != null ? message : "unknown error", node);
+  }
+
+  private static class ClassInfo {
+    final ClassName mClassName;
+    final KSClassDeclaration mDeclaration;
+    final List<KSFunctionDeclaration> mMethods;
+
+    ClassInfo(ClassName className, KSClassDeclaration declaration) {
+      mClassName = className;
+      mDeclaration = declaration;
+      mMethods = new ArrayList<>();
+    }
+
+    void addMethod(KSFunctionDeclaration method) {
+      String name = method.getSimpleName().asString();
+      if (checkMethodExists(name)) {
+        System.out.print("Module " + mClassName + " has already registered a method named \"" + name
+            + "\". If you want to override a method, don't add"
+            + "the @LynxUIMethod annotation to the property in the subclass");
+        return;
+      }
+
+      mMethods.add(method);
+    }
+
+    private boolean checkMethodExists(String name) {
+      for (KSFunctionDeclaration method : mMethods) {
+        if (method.getSimpleName().asString().equals(name)) {
+          return true;
+        }
+      }
+
+      return false;
+    }
+  }
+
+  /** Entry point registered in META-INF/services. */
+  public static class Provider implements SymbolProcessorProvider {
+    @Override
+    public SymbolProcessor create(SymbolProcessorEnvironment environment) {
+      return new LynxUIMethodsSymbolProcessor(environment);
+    }
+  }
+}

--- a/platform/android/lynx_processor_ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/platform/android/lynx_processor_ksp/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,5 @@
+com.lynx.processor.ksp.LynxPropsSymbolProcessor$Provider
+com.lynx.processor.ksp.LynxUIMethodsSymbolProcessor$Provider
+com.lynx.processor.ksp.LynxLibrarySymbolProcessor$Provider
+com.lynx.processor.ksp.LynxBehaviorSymbolProcessor$Provider
+com.lynx.processor.ksp.LynxJSPropertySymbolProcessor$Provider

--- a/platform/android/settings.gradle
+++ b/platform/android/settings.gradle
@@ -14,6 +14,8 @@ include ':LynxJSSDK'
 project(":LynxJSSDK").projectDir = new File(rootProject.projectDir, './lynx_js_sdk')
 include ':LynxProcessor'
 project(":LynxProcessor").projectDir = new File(rootProject.projectDir, './lynx_processor')
+include ':LynxProcessorKsp'
+project(":LynxProcessorKsp").projectDir = new File(rootProject.projectDir, './lynx_processor_ksp')
 include ':LynxLibraryPlugin'
 project(":LynxLibraryPlugin").projectDir = new File(rootProject.projectDir, './lynx_library_plugin')
 include ':TestingBase'


### PR DESCRIPTION
## Summary

This PR adds a new `LynxProcessorKsp` module providing [KSP](https://github.com/google/ksp) implementations of all five Lynx annotation processors (`LynxPropsProcessor`, `LynxUIMethodsProcessor`, `LynxBehaviorProcessor`, `LynxLibraryProcessor`, `LynxJSPropertyProcessor`), so Kotlin consumers no longer need to keep kapt enabled just for Lynx.

Closes #7236 (also related to #2186).

## Motivation

kapt is in maintenance mode and KSP is the officially recommended replacement (up to 2x faster annotation processing). Today `lynx-processor` is javac-only, which forces every Kotlin app integrating custom Lynx UIs to keep the kapt plugin in their build.

## Usage

```groovy
// before
plugins { id 'org.jetbrains.kotlin.kapt' }
dependencies { kapt 'org.lynxsdk.lynx:lynx-processor:x.y.z' }

// after
plugins { id 'com.google.devtools.ksp' }
dependencies { ksp 'org.lynxsdk.lynx:lynx-processor-ksp:x.y.z' }
```

No source changes are required — the same annotations produce the same generated code.

## Design

- **New module, zero changes to the existing one** — `platform/android/lynx_processor_ksp`, registered in `settings.gradle`. The javac `lynx_processor` and its `annotationProcessor`/`kapt` paths are untouched; consumers opt in by replacing `kapt(...)` with `ksp(...)`.
- **Plain Java, same style as the existing module** — no Kotlin toolchain added to the repo build. The module compiles against `symbol-processing-api:1.6.21-1.0.6` (`compileOnly`), matching the repo's pinned Kotlin version; KSP keeps the processor API binary-compatible, so consumers on newer Kotlin/KSP runtimes can load it as-is.
- **Byte-identical output** — the generators reuse the same JavaPoet code; a shared `KspUtils` helper translates KSP symbols back to the `javax.lang.model` view the generators were written against (e.g. Java `int` arrives as `kotlin.Int` + `NOT_NULL`, `Integer` as platform-nullable; `void.class` sentinels arrive as `kotlin.Unit`; primitive arrays as `kotlin.IntArray`).

## TEST

- Golden test: identical Java fixtures compiled through both javac (`annotationProcessor`) and KSP, then diffing the generated trees — **byte-identical for all five processors**, covering nested classes, `@LynxPropGroup`, NaN defaults, inheritance chains, the aggregated `BehaviorGenerator`/`LynxLibraryProviderImpl` registries (incl. the `lynx.library.packageName` option mapped to a `ksp` arg), and JSI descriptors with array/list/wildcard fields. The consumer side of the golden build ran on the repo's pinned toolchain (Gradle 6.7.1, KSP gradle plugin 1.6.21-1.0.6). Happy to contribute the fixture harness as a test module if you'd like it in-repo.
- In-repo: `./gradlew :LynxProcessorKsp:build :LynxProcessor:test` passes (new module builds with the repo toolchain; existing javac processor tests are unaffected).

## Notes for maintainers

- Publishing: the module applies the shared `publish.gradle`; you'd need to add a `lynx-processor-ksp` artifact to the release pipeline.
- One stricter behavior: raw `List` fields annotated `@LynxJSProperty` are rejected by KSP (surfaced as star projection) while javac accepted them — arguably a latent bug either way; can align if desired.

