### PR TITLE
[BugFix][Android] Fix Explorer schema navigation context

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/ExplorerModule.java
@@ -19,12 +19,12 @@ public class ExplorerModule extends LynxModule {
 
   @LynxMethod
   public void openScan() {
-    LynxModuleAdapter.getInstance().openScan();
+    LynxModuleAdapter.getInstance().openScan(mContext);
   }
 
   @LynxMethod
   public void openSchema(String url) {
-    LynxModuleAdapter.getInstance().openSchema(url);
+    LynxModuleAdapter.getInstance().openSchema(mContext, url);
   }
 
   @LynxMethod
@@ -50,7 +50,7 @@ public class ExplorerModule extends LynxModule {
   @Deprecated
   @LynxMethod
   public void openDevtoolSwitchPage() {
-    LynxModuleAdapter.getInstance().openSchema(DEVTOOL_SWITCH_ASSETS);
+    LynxModuleAdapter.getInstance().openSchema(mContext, DEVTOOL_SWITCH_ASSETS);
   }
 
   @LynxMethod

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/modules/LynxModuleAdapter.java
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.explorer.modules;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -20,6 +21,8 @@ import com.lynx.explorer.shell.TemplateDispatcher;
 import com.lynx.react.bridge.JavaOnlyMap;
 import com.lynx.react.bridge.WritableMap;
 import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.utils.ContextUtils;
+import java.lang.ref.WeakReference;
 
 public class LynxModuleAdapter {
   private Context mContext;
@@ -36,6 +39,33 @@ public class LynxModuleAdapter {
   private static final int OPEN_SCAN = 1;
   private static final LynxModuleAdapter sInstance = new LynxModuleAdapter();
 
+  private static class ActivityRequest {
+    @Nullable private final WeakReference<Activity> mActivityRef;
+
+    ActivityRequest(Context context) {
+      Activity activity = context != null ? ContextUtils.getActivity(context) : null;
+      mActivityRef = activity != null ? new WeakReference<>(activity) : null;
+    }
+
+    @Nullable
+    Activity getActivity() {
+      Activity activity = mActivityRef != null ? mActivityRef.get() : null;
+      if (activity == null || activity.isFinishing() || activity.isDestroyed()) {
+        return null;
+      }
+      return activity;
+    }
+  }
+
+  private static class OpenSchemaRequest extends ActivityRequest {
+    private final String mUrl;
+
+    OpenSchemaRequest(Context context, String url) {
+      super(context);
+      mUrl = url;
+    }
+  }
+
   public static LynxModuleAdapter getInstance() {
     return sInstance;
   }
@@ -47,10 +77,11 @@ public class LynxModuleAdapter {
       public void handleMessage(Message msg) {
         switch (msg.what) {
           case OPEN_SCAN:
-            startQRScanActivity();
+            startQRScanActivity(((ActivityRequest) msg.obj).getActivity());
             break;
           case OPEN_SCHEMA:
-            startFromUrl((String) msg.obj);
+            OpenSchemaRequest request = (OpenSchemaRequest) msg.obj;
+            startFromUrl(request.getActivity(), request.mUrl);
             break;
           default:
         }
@@ -62,12 +93,23 @@ public class LynxModuleAdapter {
   }
 
   public void openScan() {
-    mHandler.sendEmptyMessage(OPEN_SCAN);
+    openScan(mContext);
+  }
+
+  public void openScan(Context context) {
+    Message msg = Message.obtain();
+    msg.obj = new ActivityRequest(context);
+    msg.what = OPEN_SCAN;
+    mHandler.sendMessage(msg);
   }
 
   public void openSchema(String url) {
+    openSchema(mContext, url);
+  }
+
+  public void openSchema(Context context, String url) {
     Message msg = Message.obtain();
-    msg.obj = url;
+    msg.obj = new OpenSchemaRequest(context, url);
     msg.what = OPEN_SCHEMA;
     mHandler.sendMessage(msg);
   }
@@ -96,19 +138,28 @@ public class LynxModuleAdapter {
     return map;
   }
 
-  private void startQRScanActivity() {
-    Intent intent = new Intent(mContext, QRScanActivity.class);
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    mContext.startActivity(intent);
+  private void startQRScanActivity(@Nullable Activity activity) {
+    Context startContext = getStartContext(activity);
+    Intent intent = new Intent(startContext, QRScanActivity.class);
+    if (!(startContext instanceof Activity)) {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+    startContext.startActivity(intent);
   }
 
-  private void startFromUrl(String url) {
-    TemplateDispatcher.dispatchUrl(mContext, url);
+  private void startFromUrl(@Nullable Activity activity, String url) {
+    Context startContext = getStartContext(activity);
+    int flags = startContext instanceof Activity ? 0 : Intent.FLAG_ACTIVITY_NEW_TASK;
+    TemplateDispatcher.dispatchUrl(startContext, url, flags);
   }
 
   private void startFromUrlSingleTop(String url) {
     TemplateDispatcher.dispatchUrl(
         mContext, url, Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+  }
+
+  private Context getStartContext(@Nullable Activity activity) {
+    return activity != null ? activity : mContext;
   }
 
   public void saveThemePreferences(String theme, String value) {


### PR DESCRIPTION
## Summary

Lynx Explorer's Android `ExplorerModule` routed `openSchema` through the singleton application context. That forced `TemplateDispatcher` to launch `LynxViewShellActivity` with `FLAG_ACTIVITY_NEW_TASK`, which could bring the existing task forward instead of pushing a new visible page when a Lynx page opened another local bundle.

This change passes the current module context into `LynxModuleAdapter`, resolves the backing `Activity` when available, and launches Activity-backed navigation with normal task-stack flags. Non-Activity callers still fall back to the application context with `FLAG_ACTIVITY_NEW_TASK`.

## Verification

- `python3 tools_shared/git_lynx.py check --checkers commit-message`
- `./gradlew :LynxExplorer:assembleNoAsanDebug --no-daemon --stacktrace`
- Fixed state on API 33 arm64 emulator:
  - Installed APK and launched Lynx Explorer.
  - Verified Home -> Showcase -> Animation.
  - Confirmed activity stack reached three `LynxViewShellActivity` entries.
  - Confirmed logcat loaded `showcase/menu/main.lynx.bundle` and `showcase/menu/animation.lynx.bundle`.
  - Checked logcat for `FATAL EXCEPTION`, app crash, and ANR markers.
- Unfixed state, temporary `HEAD^` version of the two files:
  - Rebuilt and installed successfully.
  - Tapping Showcase dispatched `ExplorerModule.openSchema(...)` and Android logged a `FLAG_ACTIVITY_NEW_TASK` start.
  - Activity stack stayed at one `LynxViewShellActivity`.
  - No Showcase bundle load occurred and the screenshot remained on the Home screen.
