### PR TITLE
[Lynxtron] Enable public Skity build linkage

### DIFF
--- a/clay/gfx/BUILD.gn
+++ b/clay/gfx/BUILD.gn
@@ -60,6 +60,7 @@ source_set("gfx") {
       "paint_image_skity.cc",
       "paint_image_skity.h",
       "paint_recorder_skity.cc",
+      "svg/svg_dom.cc",
       "text_blob_skity.cc",
       "text_blob_skity.h",
     ]

--- a/clay/gfx/skity/BUILD.gn
+++ b/clay/gfx/skity/BUILD.gn
@@ -25,6 +25,10 @@ source_set("skity") {
 
   public_deps = [ "../../fml:fml" ]
 
+  if (enable_skity) {
+    public_deps += [ "//third_party/skity:skity" ]
+  }
+
   public_configs = [ "../../:config" ]
 
   if (!enable_skity) {

--- a/clay/gfx/svg/svg_dom.cc
+++ b/clay/gfx/svg/svg_dom.cc
@@ -1,0 +1,22 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "clay/gfx/svg/svg_dom.h"
+
+namespace clay {
+namespace {
+class FallbackSVGDom : public SVGDom {
+ public:
+  std::shared_ptr<skity::Image> Render(
+      int width, int height, fml::RefPtr<GPUUnrefQueue> unref_queue) override {
+    return nullptr;
+  }
+};
+}  // namespace
+
+std::shared_ptr<SVGDom> SVGDom::Create(std::shared_ptr<skity::Data> data,
+                                       ImageCallback callback) {
+  return std::make_shared<FallbackSVGDom>();
+}
+}  // namespace clay

--- a/clay/ui/resource/image_fetcher.cc
+++ b/clay/ui/resource/image_fetcher.cc
@@ -25,6 +25,28 @@ namespace clay {
 
 namespace {
 
+class SkityStaticPlatformImage : public PlatformImage {
+ public:
+  explicit SkityStaticPlatformImage(std::shared_ptr<skity::Pixmap> pixmap)
+      : pixmap_(std::move(pixmap)) {}
+
+  int GetWidth() override { return pixmap_ ? pixmap_->Width() : 0; }
+  int GetHeight() override { return pixmap_ ? pixmap_->Height() : 0; }
+  int64_t GetDuration() override { return 0; }
+  std::shared_ptr<skity::Pixmap> ToBitmap() override { return pixmap_; }
+  void DrawFrame(std::function<void()> on_frame_changed) override {}
+  bool IsAnimated() override { return false; }
+  void SetAutoPlay(bool auto_play) override {}
+  void SetLoopCount(int loop_count) override {}
+  void StartAnimation() override {}
+  void StopAnimation() override {}
+  void PauseAnimation() override {}
+  void ResumeAnimation() override {}
+
+ private:
+  std::shared_ptr<skity::Pixmap> pixmap_;
+};
+
 uint64_t NextUniqueID() {
   static std::atomic<uint64_t> next_id(1);
   uint64_t id;
@@ -56,7 +78,64 @@ std::shared_ptr<ResourceLoader> GetOrCreateResourceLoader(
 #endif
 }
 
+std::shared_ptr<PlatformImage> DecodeStaticImage(const uint8_t* data,
+                                                 size_t size) {
+  if (!data || size == 0) {
+    return nullptr;
+  }
+
+  auto image_data = skity::Data::MakeWithCopy(data, size);
+  auto codec = skity::Codec::MakeFromData(image_data);
+  if (!codec) {
+    return nullptr;
+  }
+
+  codec->SetData(image_data);
+  auto pixmap = codec->Decode();
+  if (!pixmap) {
+    return nullptr;
+  }
+
+  return std::make_shared<SkityStaticPlatformImage>(std::move(pixmap));
+}
+
+class DefaultImageFetcher : public ImageFetcher {
+ public:
+  using ImageFetcher::ImageFetcher;
+
+ private:
+  void FetchImage(
+      const std::string& trimmed_url,
+      const std::function<void(std::shared_ptr<PlatformImage>)>& callback,
+      bool need_redirect) override {
+    auto loader =
+        GetOrCreateResourceLoader(resource_loader_intercept_, trimmed_url,
+                                  task_runners_.GetUITaskRunner(),
+                                  service_manager_);
+    if (!loader) {
+      callback(nullptr);
+      return;
+    }
+
+    loader->Load(
+        trimmed_url,
+        [callback](const uint8_t* data, size_t size) {
+          callback(DecodeStaticImage(data, size));
+        },
+        ResourceType::kImage, need_redirect);
+  }
+};
+
 }  // namespace
+
+fml::RefPtr<ImageFetcher> ImageFetcher::Create(
+    std::shared_ptr<ResourceLoaderIntercept> intercept,
+    clay::TaskRunners task_runners, fml::RefPtr<GPUUnrefQueue> unref_queue,
+    std::shared_ptr<ServiceManager> service_manager) {
+  return fml::MakeRefCounted<DefaultImageFetcher>(
+      std::move(intercept), std::move(task_runners), std::move(unref_queue),
+      std::move(service_manager));
+}
 
 ImageFetcher::ImageFetcher(std::shared_ptr<ResourceLoaderIntercept> intercept,
                            clay::TaskRunners task_runners,

--- a/dependencies/DEPS.lynxtron
+++ b/dependencies/DEPS.lynxtron
@@ -154,7 +154,7 @@ deps = {
             "PATH": os.pathsep.join([PNPM_PATH, os.path.dirname(NODE_PATH), os.environ["PATH"]])
         },
         "commands": [
-            "pnpm install --frozen-lockfile"
+            "pnpm install --no-frozen-lockfile --strict-peer-dependencies=false"
         ],
         "require": [
             "prepare_pnpm_shim"


### PR DESCRIPTION
## Summary

This PR carries the Lynx-side pieces needed by Lynxtron public Skity build:

- allow the Lynxtron dependency sync path to install public npm dependencies without relying on the frozen internal lockfile behavior
- link the Skity target when `enable_skity` is enabled
- add a Skity-backed default static image decode path for Lynxtron public builds
- add a fallback SVG DOM implementation for the Skity path

## Impact

The change is intended for the Lynxtron public Skity build path. It touches Clay image/resource code and `dependencies/DEPS.lynxtron`, so it is not purely declarative. Non-Skity builds should remain unchanged for the Skity-specific source/dependency additions, but the image fetcher factory/default decode path should be reviewed carefully by Clay owners.

## Validation

Validated from the Lynxtron integration branch:

- public standalone `lynxtron/lynxtron` dependency sync
- public GN with `enable_skity = true`
- `ninja -C out/Debug lynxtron_app`
- `out/Debug/lynxtron.app/Contents/MacOS/lynxtron --version` -> `v1.0.0`
- internal Lynxtron default build remains without `enable_skity` and smoke outputs `v1.0.0`
