### PR TITLE
[Infra] Update public actions in Github CI to adapt node 24

### DIFF
--- a/.github/actions/android-explorer-build/action.yml
+++ b/.github/actions/android-explorer-build/action.yml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     - name: Python Setup
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install Common Dependencies

--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -47,7 +47,7 @@ runs:
 
     - name: Setup cache action
       if: ${{ inputs.cache-backend == 'github' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.habitat_cache
         key: hab-${{ runner.os }}-${{ steps.hab.outputs.HABITAT_TARGETS }}-${{ steps.hab.outputs.HABITAT_DEPS_FILE_DIGEST }}

--- a/.github/actions/ios-common-deps/action.yml
+++ b/.github/actions/ios-common-deps/action.yml
@@ -34,7 +34,7 @@ runs:
           ${{ runner.os }}-ruby-${{ steps.get_ruby_version.outputs.VERSION }}
     - name: setup cache action
       if: ${{ inputs.cache-backend == 'github' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ inputs.path }}/${{ steps.get_ruby_version.outputs.VERSION }}
         key: ${{ runner.os }}-ruby-${{ steps.get_ruby_version.outputs.VERSION }}-${{ hashFiles('lynx/Gemfile.lock') }}

--- a/.github/actions/setup-android-env/action.yml
+++ b/.github/actions/setup-android-env/action.yml
@@ -6,7 +6,7 @@ runs:
   using: composite
   steps:
     - name: Setup Java SDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: 11
         distribution: 'zulu'

--- a/.github/actions/windows-common-deps/action.yml
+++ b/.github/actions/windows-common-deps/action.yml
@@ -74,7 +74,7 @@ runs:
 
     - name: Setup cache action
       if: ${{ inputs.cache-backend == 'github' }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.hab-cache-dir.outputs.HABITAT_CACHE_DIR }}
         key: hab-${{ runner.os }}-${{ steps.hab.outputs.HABITAT_TARGETS }}-${{ steps.hab.outputs.HABITAT_DEPS_FILE_DIGEST }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
@@ -66,7 +66,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Install Common Dependencies
@@ -82,11 +82,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -102,11 +102,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -122,7 +122,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Install Common Dependencies
@@ -162,7 +162,7 @@ jobs:
     runs-on: lynx-ubuntu-22.04-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Set up Ruby
@@ -197,11 +197,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -219,7 +219,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Install Common Dependencies
@@ -242,7 +242,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Install Common Dependencies
@@ -262,11 +262,11 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -284,11 +284,11 @@ jobs:
     runs-on: lynx-ubuntu-22.04-physical-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -308,7 +308,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Setup gradle cache
@@ -336,11 +336,11 @@ jobs:
           git config --global http.sslBackend "schannel"
         working-directory: ./
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -357,11 +357,11 @@ jobs:
     runs-on: lynx-ubuntu-22.04-large
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -397,11 +397,11 @@ jobs:
     runs-on: lynx-ubuntu-22.04-physical-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
@@ -414,7 +414,7 @@ jobs:
           pnpm install appium-espresso-driver@4.0.0 -w
           popd
       - name: Setup Java SDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -578,7 +578,7 @@ jobs:
     runs-on: lynx-ubuntu-22.04-large
     steps:
       - name: Download Integeration Demo Source Code
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           repository: lynx-family/integrating-lynx-demo-projects
           ref: b106f7f21d5221acfed645f4afa9d829a1cc0cc2
@@ -596,11 +596,11 @@ jobs:
           name: android-sdk-release
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Setup Java SDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'
@@ -636,7 +636,7 @@ jobs:
         shell: bash
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Build Explorer App
@@ -650,7 +650,7 @@ jobs:
         arch: [arm64, x86_64]
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Build Explorer App
@@ -673,7 +673,7 @@ jobs:
       POD_VERSION: '0.0.1-alpha.1'
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2
           ref: ${{ github.event.pull_request.head.sha }}
@@ -697,7 +697,7 @@ jobs:
           git config --global user.email "lynx.authors@users.noreply.github.com"
           python3 tools/ios_tools/cocoapods_publish_helper.py --publish_local $LOCAL_POD_NAME --component all
       - name: Download the Demo Project
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: demo
           repository: lynx-family/integrating-lynx-demo-projects
@@ -724,7 +724,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Install Common Dependencies
@@ -895,7 +895,7 @@ jobs:
     runs-on: lynx-darwin-14-medium
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Build Clay Example
@@ -914,7 +914,7 @@ jobs:
         arch: [arm64, x64]
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Build macOS Explorer

--- a/.github/workflows/cocoapods_token_keepalive.yml
+++ b/.github/workflows/cocoapods_token_keepalive.yml
@@ -11,7 +11,7 @@ jobs:
       COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Setup Ruby Cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/css-defines-publish.yml
+++ b/.github/workflows/css-defines-publish.yml
@@ -13,19 +13,19 @@ jobs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install SSH Key
-        uses: kielabokkie/ssh-key-and-known-hosts-action@v1
+        uses: kielabokkie/ssh-key-and-known-hosts-action@v1.4.1
         with:
           ssh-private-key: ${{ secrets.PRIVATE_SSH_KEY }}
           ssh-host: github.com
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/lynx-core-publish.yml
+++ b/.github/workflows/lynx-core-publish.yml
@@ -11,18 +11,18 @@ jobs:
       id-token: write
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
         with:
           cache-backend: github
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/lynx-types-publish.yml
+++ b/.github/workflows/lynx-types-publish.yml
@@ -17,18 +17,18 @@ jobs:
       id-token: write
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
         with:
           cache-backend: github
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -157,7 +157,7 @@ jobs:
     if: ${{ !contains(needs.get-version.outputs.version, '-nightly.') }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
@@ -185,7 +185,7 @@ jobs:
         arch: [arm64, x86_64]
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
@@ -218,7 +218,7 @@ jobs:
         shell: bash
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
@@ -240,7 +240,7 @@ jobs:
     timeout-minutes: 240
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
@@ -248,7 +248,7 @@ jobs:
       - name: Free up disk space
         uses: ./lynx/.github/actions/free-android-disk
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Setup Android environment
@@ -296,13 +296,13 @@ jobs:
       REPO_LYNX_ARTIFACTS_S3_PATH_PREFIX: ${{ vars.REPO_LYNX_ARTIFACTS_S3_PATH_PREFIX || 'ios-sdk' }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-version.outputs.checkout_ref }}
           fetch-depth: 0
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Set up Ruby + specify Bundler version
@@ -347,7 +347,7 @@ jobs:
       contents: read
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.get-version.outputs.checkout_ref }}
           fetch-depth: 0
@@ -397,7 +397,7 @@ jobs:
           echo "gem_file=$gem_file" >> "$GITHUB_OUTPUT"
           ruby -rrubygems/package -e 'spec = Gem::Package.new(ARGV.fetch(0)).spec; puts "#{spec.name} #{spec.version}"; puts spec.summary' "$gem_file"
       - name: Upload gem artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cocoapods-lynx-library-${{ steps.gem_version.outputs.version }}
           path: lynx/tools/ios_tools/cocoapods-lynx-library/${{ steps.build_gem.outputs.gem_file }}
@@ -448,7 +448,7 @@ jobs:
           cargo install git-cliff --locked
           git-cliff --version
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           fetch-depth: 0
@@ -499,7 +499,7 @@ jobs:
         arch: [arm64, x64]
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
@@ -534,13 +534,13 @@ jobs:
           git config --global http.sslBackend "schannel"
         working-directory: ./
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ needs.get-version.outputs.checkout_ref }}
           fetch-depth: 0
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies

--- a/.github/workflows/sdk-release-test.yml
+++ b/.github/workflows/sdk-release-test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ github.event.inputs.commitId || github.ref }}
@@ -29,7 +29,7 @@ jobs:
       - name: Free up disk space
         uses: ./lynx/.github/actions/free-android-disk
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Setup Android environment
@@ -55,13 +55,13 @@ jobs:
       POD_VERSION: '0.0.1-alpha.1'
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           ref: ${{ github.event.inputs.commitId || github.ref }}
           fetch-depth: 0
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Set up Ruby + specify Bundler version

--- a/.github/workflows/tasm-publish.yml
+++ b/.github/workflows/tasm-publish.yml
@@ -15,7 +15,7 @@ jobs:
       version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           fetch-depth: 2 # latest 2 commits
@@ -50,14 +50,14 @@ jobs:
     needs: check-version-change
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Install Common Dependencies
@@ -74,7 +74,7 @@ jobs:
           npm run build:release:linux
           popd
       - name: Upload Linux Tasm Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tasm_linux
           path: lynx/oliver/lynx-tasm/build/linux/Release/lepus.node
@@ -85,14 +85,14 @@ jobs:
     needs: check-version-change
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
       - name: Install Common Dependencies
@@ -109,7 +109,7 @@ jobs:
           npm run build:release:darwin
           popd
       - name: Upload Darwin Tasm Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: tasm_darwin
           path: lynx/oliver/lynx-tasm/build/darwin/Release/lepus.node
@@ -123,14 +123,14 @@ jobs:
     environment: npm
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -148,12 +148,12 @@ jobs:
           npm run build:wasm
           popd
       - name: Download Linux Tasm Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: tasm_linux
           path: lynx/oliver/lynx-tasm/build/linux/Release
       - name: Download Darwin Tasm Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: tasm_darwin
           path: lynx/oliver/lynx-tasm/build/darwin/Release

--- a/.github/workflows/type-config-publish.yml
+++ b/.github/workflows/type-config-publish.yml
@@ -17,18 +17,18 @@ jobs:
       id-token: write
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
       - name: Python Setup
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - name: Install Common Dependencies
         uses: ./lynx/.github/actions/common-deps
         with:
           cache-backend: github
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/type-element-api-publish.yml
+++ b/.github/workflows/type-element-api-publish.yml
@@ -15,11 +15,11 @@ jobs:
       version_changed: ${{ steps.check.outputs.version_changed }}
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           fetch-depth: 1 # latest 1 commit
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -55,11 +55,11 @@ jobs:
       id-token: write
     steps:
       - name: Download Source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6
         with:
           path: lynx
           fetch-depth: 1 # latest 1 commit
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Upgrade the public and third-party actions used in GitHub Workflows to comply with GitHub's Node.js version requirements.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
