### PR TITLE
[Refactor][Explorer][Android] Use Lynx LLog in ExplorerApplication

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
@@ -18,11 +18,14 @@ import com.lynx.service.http.LynxHttpService;
 import com.lynx.service.image.LynxImageService;
 import com.lynx.service.log.LynxLogService;
 import com.lynx.tasm.LynxEnv;
+import com.lynx.tasm.base.LLog;
 import com.lynx.tasm.service.ILynxHttpService;
 import com.lynx.tasm.service.ILynxImageService;
 import com.lynx.tasm.service.LynxServiceCenter;
 
 public class ExplorerApplication extends Application {
+  private static final String TAG = "ExplorerApplication";
+
   @Override
   public void onCreate() {
     super.onCreate();
@@ -74,11 +77,11 @@ public class ExplorerApplication extends Application {
       hybridKitClass.getMethod("setHybridConfig", hybridConfigClass, Application.class)
           .invoke(hybridKit, hybridConfig, this);
       hybridKitClass.getMethod("initLynxKit").invoke(hybridKit);
-      android.util.Log.i("ExplorerApplication", "Sparkling HybridKit initialized");
+      LLog.i(TAG, "Sparkling HybridKit initialized");
     } catch (ClassNotFoundException e) {
-      android.util.Log.w("ExplorerApplication", "Sparkling SDK not on classpath, skipping init", e);
+      LLog.w(TAG, "Sparkling SDK not on classpath, skipping init: " + e);
     } catch (Exception e) {
-      android.util.Log.e("ExplorerApplication", "Sparkling init failed", e);
+      LLog.e(TAG, "Sparkling init failed: " + e);
     }
   }
 


### PR DESCRIPTION
## Summary

Replace `android.util.Log` in `ExplorerApplication`'s Sparkling init with Lynx's `LLog` so Sparkling init logging follows the existing Android logging path used across Lynx.

## Details

- Add a `TAG` constant and import `com.lynx.tasm.base.LLog`.
- Swap the three `android.util.Log` calls (`i`/`w`/`e`) in `initSparkling()` for the equivalent `LLog` calls. Since `LLog` exposes `(tag, msg)` signatures only, the throwable is appended to the message.

No behavior change other than routing these logs through Lynx's logging utility.