### PR TITLE
[BugFix][Android] Fix Sparkling Lynx dependency ownership

### DIFF
--- a/explorer/android/build.gradle
+++ b/explorer/android/build.gradle
@@ -81,7 +81,9 @@ ext.getFlavorNamesAndBuildTypes = { Project project ->
             runTasks = gradle.parent.startParameter.taskNames.toString().toLowerCase()
         }
     }
-    if (runTasks.contains("generateAllGnCmakeTargets".toLowerCase()) || runTasks.contains("clean")) {
+    if (runTasks.contains("generateAllGnCmakeTargets".toLowerCase()) ||
+            runTasks.contains("verifySparklingAndroid".toLowerCase()) ||
+            runTasks.contains("clean")) {
         return [flavorNames, buildTypes]
     }
     // To reduce the generation of cmake scripts, the following types that will
@@ -130,42 +132,101 @@ task generateAllGnCmakeTargets {
     // force Gradle to evaluate the child build.gradle files before the parent
     evaluationDependsOnChildren()
 
+    def previousGnConfigTask = null
     rootProject.allprojects { Project project ->
         if(project.tasks.findByName('configGnCompileParas')) {
             println project.name + " has configGnCompileParas task."
-            dependsOn project.configGnCompileParas
+            def gnConfigTask = project.configGnCompileParas
+            if (previousGnConfigTask != null) {
+                gnConfigTask.mustRunAfter previousGnConfigTask
+            }
+            previousGnConfigTask = gnConfigTask
+            dependsOn gnConfigTask
         }
     }
-    exec {
-        workingDir "../../"
-        rootProject.ext.configurePythonExec(delegate, "tools_shared/android_tools/generate_cmake_scripts_from_gn.py")
-        println commandLine
+    doLast {
+        exec {
+            workingDir "../../"
+            rootProject.ext.configurePythonExec(delegate, "tools_shared/android_tools/generate_cmake_scripts_from_gn.py")
+            println commandLine
+        }
     }
+}
+
+rootProject.allprojects { Project nativeProject ->
+    nativeProject.tasks.matching {
+        it.name.startsWith('generateJsonModel') || it.name.startsWith('externalNativeBuild')
+    }.all { task ->
+        task.dependsOn generateAllGnCmakeTargets
+    }
+    nativeProject.tasks.whenTaskAdded { task ->
+        if (task.name.startsWith('generateJsonModel') || task.name.startsWith('externalNativeBuild')) {
+            task.dependsOn generateAllGnCmakeTargets
+        }
+    }
+}
+
+task generateAutoGenStyleConstants {
+    description "Generate Android Java CSS style constants."
+    def cssGeneratorDir = rootProject.file("../../tools/css_generator")
+    def autoGenStyleConstantsFile = rootProject.file(
+            "../../platform/android/lynx_android/src/main/java/com/lynx/tasm/behavior/AutoGenStyleConstants.java")
+
+    inputs.files(fileTree(dir: "${cssGeneratorDir}/css_defines", include: "*.json"))
+    inputs.file("${cssGeneratorDir}/property_index.json")
+    inputs.files(
+            "${cssGeneratorDir}/css_parser_generator.py",
+            "${cssGeneratorDir}/enum_css_generator.py",
+            "${cssGeneratorDir}/utils.py")
+    outputs.file(autoGenStyleConstantsFile)
+
+    doLast {
+        exec {
+            workingDir cssGeneratorDir
+            rootProject.ext.configurePythonExec(delegate, "-c", [
+                    "import css_parser_generator, enum_css_generator",
+                    "json_obj = css_parser_generator.check_and_get_defines()",
+                    "enum_css_generator.genJavaEnum(" +
+                            "'enum_handler.cc', css_parser_generator.sortJson(json_obj)['enum'])"
+            ].join("; "))
+            println commandLine
+        }
+    }
+}
+
+project(':LynxAndroid').tasks.matching {
+    it.name.startsWith('compile') && it.name.endsWith('JavaWithJavac')
+}.all { Task javaCompileTask ->
+    javaCompileTask.dependsOn generateAutoGenStyleConstants
 }
 
 task buildHomePage {
     description "Build home page card."
-    exec {
-        workingDir "../homepage"
-        rootProject.ext.configurePythonExec(delegate, "build.py")
-        println commandLine
-    }
-    copy {
-        from "../homepage/dist/"
-        into "lynx_explorer/src/main/assets"
-        include 'main.lynx.bundle'
-        rename { String fileName ->
-            'homepage.lynx.bundle'
+    doLast {
+        exec {
+            workingDir "../homepage"
+            rootProject.ext.configurePythonExec(delegate, "build.py")
+            println commandLine
+        }
+        copy {
+            from "../homepage/dist/"
+            into "lynx_explorer/src/main/assets"
+            include 'main.lynx.bundle'
+            rename { String fileName ->
+                'homepage.lynx.bundle'
+            }
         }
     }
 }
 
 task buildShowcase {
     description "Build showcase card."
-    exec {
-        workingDir "../showcase"
-        rootProject.ext.configurePythonExec(delegate, "./build_and_copy.py")
-        println commandLine
+    doLast {
+        exec {
+            workingDir "../showcase"
+            rootProject.ext.configurePythonExec(delegate, "./build_and_copy.py")
+            println commandLine
+        }
     }
 }
 
@@ -174,12 +235,25 @@ buildShowcase.onlyIf { build_showcase == 'true' }
 if (buildIntegrationDemo) {
     task buildIntegrationDemo {
         description "Build Integeration Test Demo Card."
-        exec {
-            workingDir "../../testing/integration_test/demo_pages"
-            rootProject.ext.configurePythonExec(delegate, "./build_and_copy.py")
-            println commandLine
+        doLast {
+            exec {
+                workingDir "../../testing/integration_test/demo_pages"
+                rootProject.ext.configurePythonExec(delegate, "./build_and_copy.py")
+                println commandLine
+            }
         }
     }
+}
+
+def generatedExplorerAssetTasks = [buildHomePage, buildShowcase]
+if (tasks.findByName('buildIntegrationDemo') != null) {
+    generatedExplorerAssetTasks << tasks.findByName('buildIntegrationDemo')
+}
+
+project(':LynxExplorer').tasks.matching {
+    it.name.startsWith('merge') && it.name.endsWith('Assets')
+}.all { Task mergeAssetsTask ->
+    mergeAssetsTask.dependsOn generatedExplorerAssetTasks
 }
 
 task clean(type: Delete) {

--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -6,6 +6,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
+apply from: rootProject.file('sparkling-lynx-ownership.gradle')
+apply from: rootProject.file('sparkling-runtime-allowlist.gradle')
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
 
@@ -73,8 +76,19 @@ android {
         checkReleaseBuilds false
     }
 
-    flavorDimensions "lynx"
+    flavorDimensions "sparklingMode", "lynx"
     productFlavors {
+        withSparkling {
+            dimension "sparklingMode"
+            buildConfigField "boolean", "ENABLE_SPARKLING", "true"
+            matchingFallbacks = ["withSparkling"]
+        }
+        withoutSparkling {
+            dimension "sparklingMode"
+            buildConfigField "boolean", "ENABLE_SPARKLING", "false"
+            matchingFallbacks = ["withoutSparkling"]
+            getIsDefault().set(true)
+        }
         asan {
             dimension "lynx"
             matchingFallbacks = ["asan"]
@@ -96,7 +110,9 @@ android {
         noasan {
             jni.srcDirs = ["../../core/build/gen"]
         }
-
+        withSparkling {
+            java.srcDir "../../../node_modules/.pnpm/sparkling-navigation@2.1.0-rc.12/node_modules/sparkling-navigation/android/src/main/java"
+        }
     }
 
     externalNativeBuild {
@@ -112,10 +128,12 @@ tasks.whenTaskAdded { task ->
 }
 
 dependencies {
-    // Sparkling SDK — exclude Lynx Maven artifacts that Sparkling depends on transitively;
-    // this project already includes them as local source modules (:lynx_service_log,
-    // :LynxAndroid, etc.), so without this exclusion R8 sees duplicate class definitions.
-    implementation('com.tiktok.sparkling:sparkling:2.1.0-rc.12') {
+    def sparklingAndroidVersion = project.findProperty('sparklingAndroidVersion') ?: '2.1.0-rc.12'
+
+    // Sparkling is explicit opt-in. The broad Lynx group exclusion is verified by
+    // verifySparklingLynxGraph so released Lynx implementation artifacts cannot
+    // silently enter the enabled runtime graph.
+    withSparklingImplementation("com.tiktok.sparkling:sparkling:${sparklingAndroidVersion}") {
         exclude group: 'org.lynxsdk.lynx'
     }
 
@@ -158,4 +176,369 @@ dependencies {
 
     kapt project(':LynxProcessor')
     compileOnly project(':LynxProcessor')
+
+    androidTestImplementation project(':TestingBase')
+}
+
+tasks.register('assembleNoasanRelease') {
+    group = 'build'
+    description = 'Compatibility task for the legacy noasan release APK.'
+    dependsOn 'assembleWithoutSparklingNoasanRelease'
+
+    doLast {
+        def sourceApk =
+                file("${buildDir}/outputs/apk/withoutSparklingNoasan/release/LynxExplorer-withoutSparkling-noasan-release.apk")
+        if (!sourceApk.exists()) {
+            throw new GradleException("Expected release APK was not generated: ${sourceApk}")
+        }
+
+        copy {
+            from sourceApk
+            into file("${buildDir}/outputs/apk/noasan/release")
+            rename { 'LynxExplorer-noasan-release.apk' }
+        }
+    }
+}
+
+tasks.register('verifySparklingLynxGraph') {
+    group = 'verification'
+    description = 'Verifies Sparkling-enabled Android classpaths use local Lynx source projects.'
+
+    doLast {
+        def allowlist = project.ext.sparklingRuntimeAllowlist
+        def sourceOwnedArtifacts = project.ext.sparklingLynxOwnedArtifacts
+        def runtimeClasspaths = configurations.findAll {
+            it.name.endsWith('RuntimeClasspath') && it.canBeResolved &&
+                    !it.name.toLowerCase().contains('androidtest')
+        }
+        def enabledClasspaths = runtimeClasspaths.findAll {
+            it.name.toLowerCase().contains('withsparkling')
+        }
+        def disabledClasspaths = runtimeClasspaths.findAll {
+            it.name.toLowerCase().contains('withoutsparkling')
+        }
+
+        if (enabledClasspaths.isEmpty()) {
+            throw new GradleException('No Sparkling-enabled runtime classpaths were found.')
+        }
+        if (disabledClasspaths.isEmpty()) {
+            throw new GradleException('No Sparkling-disabled runtime classpaths were found.')
+        }
+
+        def failures = []
+        enabledClasspaths.each { configuration ->
+            def moduleDependencies =
+                    configuration.resolvedConfiguration.lenientConfiguration.allModuleDependencies
+            def projectIds = configuration.incoming.resolutionResult.allComponents.collect {
+                it.id.displayName
+            }
+
+            sourceOwnedArtifacts.each { artifact, projectPath ->
+                if (!projectIds.any { it == "project ${projectPath}" }) {
+                    failures << "${configuration.name}: expected local ${projectPath} for ${artifact}"
+                }
+            }
+
+            moduleDependencies.each { dependency ->
+                if (dependency.moduleGroup == 'org.lynxsdk.lynx') {
+                    def coordinate = "${dependency.moduleGroup}:${dependency.moduleName}"
+                    def expectedVersion = allowlist[coordinate]
+                    if (sourceOwnedArtifacts.containsKey(coordinate)) {
+                        failures << "${configuration.name}: released source-owned artifact ${coordinate}:${dependency.moduleVersion} is present; expected ${sourceOwnedArtifacts[coordinate]}"
+                    } else if (expectedVersion == null) {
+                        failures << "${configuration.name}: unclassified Lynx artifact ${coordinate}:${dependency.moduleVersion}"
+                    } else if (expectedVersion != dependency.moduleVersion) {
+                        failures << "${configuration.name}: ${coordinate} resolved to ${dependency.moduleVersion}, expected ${expectedVersion}"
+                    }
+                }
+            }
+        }
+
+        disabledClasspaths.each { configuration ->
+            def moduleDependencies =
+                    configuration.resolvedConfiguration.lenientConfiguration.allModuleDependencies
+            moduleDependencies.each { dependency ->
+                if (dependency.moduleGroup == 'com.tiktok.sparkling') {
+                    failures << "${configuration.name}: disabled classpath contains ${dependency.moduleGroup}:${dependency.moduleName}:${dependency.moduleVersion}"
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("Sparkling Lynx graph verification failed:\n - " + failures.join('\n - '))
+        }
+
+        println "Sparkling Lynx graph verification passed for ${enabledClasspaths.size()} enabled and ${disabledClasspaths.size()} disabled runtime classpaths."
+    }
+}
+
+def sparklingVerificationVariants = [
+        [
+                name: 'withSparklingNoasanDebug',
+                buildConfigPath: 'withSparklingNoasan/debug/com/lynx/explorer/BuildConfig.java',
+                enabled: true
+        ],
+        [
+                name: 'withSparklingNoasanRelease',
+                buildConfigPath: 'withSparklingNoasan/release/com/lynx/explorer/BuildConfig.java',
+                enabled: true
+        ],
+        [
+                name: 'withoutSparklingNoasanDebug',
+                buildConfigPath: 'withoutSparklingNoasan/debug/com/lynx/explorer/BuildConfig.java',
+                enabled: false
+        ],
+]
+
+tasks.register('verifySparklingAndroidIntegration') {
+    group = 'verification'
+    description = 'Verifies Sparkling manifest and BuildConfig gating for Android Explorer.'
+    dependsOn 'verifySparklingLynxGraph'
+    sparklingVerificationVariants.each { variant ->
+        def taskSuffix = variant.name.capitalize()
+        dependsOn "process${taskSuffix}Manifest"
+        dependsOn "generate${taskSuffix}BuildConfig"
+    }
+
+    doLast {
+        def sparklingActivity = 'com.tiktok.sparkling.SparklingActivity'
+        def failures = []
+        def mainManifest = file('src/main/AndroidManifest.xml')
+        if (!mainManifest.exists()) {
+            failures << "Missing base manifest: ${mainManifest}"
+        } else if (mainManifest.text.contains(sparklingActivity)) {
+            failures << "Base manifest must not declare ${sparklingActivity}"
+        }
+
+        sparklingVerificationVariants.each { variant ->
+            def mergedManifest = [
+                    file("${buildDir}/intermediates/merged_manifests/${variant.name}/AndroidManifest.xml"),
+                    file("${buildDir}/intermediates/merged_manifest/${variant.name}/out/AndroidManifest.xml")
+            ].find { it.exists() }
+            if (mergedManifest == null) {
+                failures << "${variant.name}: merged manifest was not generated"
+            } else {
+                def hasSparklingActivity = mergedManifest.text.contains(sparklingActivity)
+                if (variant.enabled && !hasSparklingActivity) {
+                    failures << "${variant.name}: merged manifest is missing ${sparklingActivity}"
+                }
+                if (!variant.enabled && hasSparklingActivity) {
+                    failures << "${variant.name}: merged manifest unexpectedly contains ${sparklingActivity}"
+                }
+            }
+
+            def buildConfig = file("${buildDir}/generated/source/buildConfig/${variant.buildConfigPath}")
+            if (!buildConfig.exists()) {
+                failures << "${variant.name}: BuildConfig was not generated at ${buildConfig}"
+            } else {
+                def expectedField =
+                        "public static final boolean ENABLE_SPARKLING = ${variant.enabled};"
+                if (!buildConfig.text.contains(expectedField)) {
+                    failures << "${variant.name}: BuildConfig does not contain ${expectedField}"
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("Sparkling Android integration verification failed:\n - " + failures.join('\n - '))
+        }
+
+        println "Sparkling Android integration verification passed for ${sparklingVerificationVariants.size()} variants."
+    }
+}
+
+def sparklingArtifactVerificationVariants = [
+        [
+                name: 'withSparklingNoasanDebug',
+                assembleTask: 'assembleWithSparklingNoasanDebug',
+                apkPath: 'outputs/apk/withSparklingNoasan/debug/LynxExplorer-withSparkling-noasan-debug.apk',
+                enabled: true
+        ],
+        [
+                name: 'withSparklingNoasanRelease',
+                assembleTask: 'assembleWithSparklingNoasanRelease',
+                apkPath: 'outputs/apk/withSparklingNoasan/release/LynxExplorer-withSparkling-noasan-release.apk',
+                enabled: true
+        ],
+        [
+                name: 'legacyNoasanRelease',
+                assembleTask: 'assembleNoasanRelease',
+                apkPath: 'outputs/apk/noasan/release/LynxExplorer-noasan-release.apk',
+                enabled: false
+        ],
+        [
+                name: 'withoutSparklingNoasanDebug',
+                assembleTask: 'assembleWithoutSparklingNoasanDebug',
+                apkPath: 'outputs/apk/withoutSparklingNoasan/debug/LynxExplorer-withoutSparkling-noasan-debug.apk',
+                enabled: false
+        ],
+]
+
+tasks.register('verifySparklingAndroidPackageArtifacts') {
+    group = 'verification'
+    description = 'Verifies assembled Android Explorer APK contents for Sparkling gating.'
+    dependsOn 'verifySparklingAndroidIntegration'
+    sparklingArtifactVerificationVariants.each { variant ->
+        dependsOn variant.assembleTask
+    }
+
+    doLast {
+        def failures = []
+        def requiredArm64Libs = [
+                'lib/arm64-v8a/liblynx.so',
+                'lib/arm64-v8a/liblynxtrace.so',
+                'lib/arm64-v8a/liblynxbase.so',
+                'lib/arm64-v8a/liblynxdevtool.so',
+                'lib/arm64-v8a/liblynx_service_api.so',
+        ]
+        def readEntryNames = { File apk ->
+            def zip = new java.util.zip.ZipFile(apk)
+            try {
+                return zip.entries().toList().collect { it.name }
+            } finally {
+                zip.close()
+            }
+        }
+        def dexContains = { File apk, String needle ->
+            def zip = new java.util.zip.ZipFile(apk)
+            try {
+                return zip.entries().toList().findAll {
+                    it.name ==~ /classes[0-9]*\.dex/
+                }.any { entry ->
+                    zip.getInputStream(entry).withCloseable { input ->
+                        return new String(input.bytes, 'ISO-8859-1').contains(needle)
+                    }
+                }
+            } finally {
+                zip.close()
+            }
+        }
+
+        sparklingArtifactVerificationVariants.each { variant ->
+            def apk = file("${buildDir}/${variant.apkPath}")
+            if (!apk.exists()) {
+                failures << "${variant.name}: APK was not generated at ${apk}"
+                return
+            }
+
+            def entryNames = readEntryNames(apk)
+            requiredArm64Libs.each { lib ->
+                if (!entryNames.contains(lib)) {
+                    failures << "${variant.name}: APK is missing ${lib}"
+                }
+            }
+
+            def hasSparklingKotlinModule = entryNames.any {
+                it == 'META-INF/sparkling_release.kotlin_module' ||
+                        it == 'META-INF/sparkling-method_release.kotlin_module'
+            }
+            def hasSparklingTypeDescriptor =
+                    dexContains(apk, 'Lcom/tiktok/sparkling/SparklingActivity;')
+            def hasSparklingPipe = dexContains(apk, 'spkPipe')
+            def hasSparklingRouterOpen =
+                    dexContains(apk, 'Lcom/tiktok/sparkling/method/router/open/RouterOpenMethod;') &&
+                            dexContains(apk, 'router.open')
+
+            if (variant.enabled) {
+                if (!hasSparklingKotlinModule) {
+                    failures << "${variant.name}: enabled APK is missing Sparkling Kotlin module metadata"
+                }
+                if (!hasSparklingTypeDescriptor) {
+                    failures << "${variant.name}: enabled APK is missing SparklingActivity bytecode descriptor"
+                }
+                if (!hasSparklingPipe) {
+                    failures << "${variant.name}: enabled APK is missing spkPipe bytecode marker"
+                }
+                if (!hasSparklingRouterOpen) {
+                    failures << "${variant.name}: enabled APK is missing sparkling-navigation router.open bytecode"
+                }
+            } else {
+                if (hasSparklingKotlinModule) {
+                    failures << "${variant.name}: disabled APK unexpectedly contains Sparkling Kotlin module metadata"
+                }
+                if (dexContains(apk, 'Lcom/tiktok/sparkling/')) {
+                    failures << "${variant.name}: disabled APK unexpectedly contains Sparkling bytecode descriptors"
+                }
+                if (dexContains(apk, 'Lcom/tiktok/sparkling/method/router/')) {
+                    failures << "${variant.name}: disabled APK unexpectedly contains Sparkling router bytecode descriptors"
+                }
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("Sparkling Android package artifact verification failed:\n - " + failures.join('\n - '))
+        }
+
+        println "Sparkling Android package artifact verification passed for ${sparklingArtifactVerificationVariants.size()} APKs."
+    }
+}
+
+def sparklingRuntimeSmokeTestVariants = [
+        [
+                name: 'withSparklingNoasanDebug',
+                assembleTask: 'assembleWithSparklingNoasanDebugAndroidTest',
+                apkPath: 'outputs/apk/androidTest/withSparklingNoasan/debug/LynxExplorer-withSparkling-noasan-debug-androidTest.apk',
+                testDescriptor: 'Lcom/lynx/explorer/SparklingRuntimeSmokeTest;'
+        ],
+        [
+                name: 'withoutSparklingNoasanDebug',
+                assembleTask: 'assembleWithoutSparklingNoasanDebugAndroidTest',
+                apkPath: 'outputs/apk/androidTest/withoutSparklingNoasan/debug/LynxExplorer-withoutSparkling-noasan-debug-androidTest.apk',
+                testDescriptor: 'Lcom/lynx/explorer/SparklingRuntimeSmokeTest;'
+        ],
+]
+
+tasks.register('verifySparklingAndroidRuntimeSmokeTestArtifacts') {
+    group = 'verification'
+    description = 'Verifies Android Sparkling runtime smoke instrumentation APKs are compiled and packaged.'
+    dependsOn 'verifySparklingAndroidPackageArtifacts'
+    sparklingRuntimeSmokeTestVariants.each { variant ->
+        dependsOn variant.assembleTask
+    }
+
+    doLast {
+        def failures = []
+        def dexContains = { File apk, String needle ->
+            def zip = new java.util.zip.ZipFile(apk)
+            try {
+                def found = false
+                zip.entries().toList().findAll {
+                    it.name ==~ /classes[0-9]*\.dex/
+                }.each { entry ->
+                    if (!found) {
+                        def input = zip.getInputStream(entry)
+                        try {
+                            found = new String(input.bytes, 'ISO-8859-1').contains(needle)
+                        } finally {
+                            input.close()
+                        }
+                    }
+                }
+                return found
+            } finally {
+                zip.close()
+            }
+        }
+
+        sparklingRuntimeSmokeTestVariants.each { variant ->
+            def apk = file("${buildDir}/${variant.apkPath}")
+            if (!apk.exists()) {
+                failures << "${variant.name}: Android test APK was not generated at ${apk}"
+            } else if (!dexContains(apk, variant.testDescriptor)) {
+                failures << "${variant.name}: Android test APK is missing ${variant.testDescriptor}"
+            }
+        }
+
+        if (!failures.isEmpty()) {
+            throw new GradleException("Sparkling Android runtime smoke test artifact verification failed:\n - " + failures.join('\n - '))
+        }
+
+        println "Sparkling Android runtime smoke test artifact verification passed for ${sparklingRuntimeSmokeTestVariants.size()} Android test APKs."
+    }
+}
+
+tasks.register('verifySparklingAndroidRefactor') {
+    group = 'verification'
+    description = 'Runs Android Sparkling dependency, manifest, BuildConfig, APK, and runtime smoke test artifact checks.'
+    dependsOn 'verifySparklingAndroidRuntimeSmokeTestArtifacts'
 }

--- a/explorer/android/lynx_explorer/proguard-rules.pro
+++ b/explorer/android/lynx_explorer/proguard-rules.pro
@@ -33,6 +33,14 @@
 -keep class androidx.lifecycle.** { *; }
 -keep class androidx.savedstate.** { *; }
 
+# Sparkling navigation router methods are registered through Sparkling's IDL
+# reflection path and must keep their class names and annotations in minified
+# enabled builds.
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+-keep class com.lynx.explorer.sparkling.SparklingNavigationRegistrar { *; }
+-keep class com.tiktok.sparkling.method.router.** { *; }
+-keep class com.tiktok.sparkling.method.registry.core.annotation.** { *; }
+
 # Sparkling SDK's bundled lint-check JARs reference com.android.tools.lint.client.api.Vendor
 # which is only available in AGP 7+. This project uses AGP 4.1.0; suppress the class warning
 # at the R8 level (the lint task itself is suppressed via lintOptions.checkReleaseBuilds=false).

--- a/explorer/android/lynx_explorer/src/androidTest/AndroidManifest.xml
+++ b/explorer/android/lynx_explorer/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.lynx.explorer.test">
+
+    <application>
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$BootstrapActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
+        <activity
+            android:name="androidx.test.core.app.InstrumentationActivityInvoker$EmptyFloatingActivity"
+            android:exported="true"
+            tools:node="merge"
+            tools:replace="android:exported" />
+    </application>
+</manifest>

--- a/explorer/android/lynx_explorer/src/androidTest/java/com/lynx/explorer/SparklingRuntimeSmokeTest.java
+++ b/explorer/android/lynx_explorer/src/androidTest/java/com/lynx/explorer/SparklingRuntimeSmokeTest.java
@@ -1,0 +1,223 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.explorer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.app.Activity;
+import android.app.Instrumentation;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.view.View;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.lynx.react.bridge.Callback;
+import com.lynx.react.bridge.JavaOnlyMap;
+import com.lynx.react.bridge.ReadableMap;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class SparklingRuntimeSmokeTest {
+  private final AtomicReference<Object> sparklingViewRef = new AtomicReference<>();
+
+  @After
+  public void tearDown() {
+    final Object sparklingView = sparklingViewRef.getAndSet(null);
+    if (sparklingView != null) {
+      InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+        try {
+          sparklingView.getClass().getMethod("release").invoke(sparklingView);
+        } catch (Exception exception) {
+          throw new AssertionError("Failed to release SparklingView", exception);
+        }
+      });
+    }
+  }
+
+  @Test
+  public void enabledVariantCreatesSparklingBridgeAndContainerGlobalProps() throws Throwable {
+    if (!BuildConfig.ENABLE_SPARKLING) {
+      return;
+    }
+
+    Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    ClassLoader classLoader = targetContext.getClassLoader();
+    Class<?> sparklingClass = classLoader.loadClass("com.tiktok.sparkling.Sparkling");
+    Class<?> sparklingContextClass = classLoader.loadClass("com.tiktok.sparkling.SparklingContext");
+    assertNotNull(classLoader.loadClass("com.tiktok.sparkling.SparklingActivity"));
+    assertNotNull(classLoader.loadClass("com.tiktok.sparkling.hybridkit.HybridKit"));
+
+    Object sparklingContext = sparklingContextClass.getConstructor().newInstance();
+    sparklingContextClass.getMethod("setScheme", String.class)
+        .invoke(sparklingContext,
+            "hybrid://lynxview_page?bundle=homepage.lynx.bundle&hide_loading=1&hide_nav_bar=1");
+
+    Method buildMethod = sparklingClass.getMethod("build", Context.class, sparklingContextClass);
+    Object sparkling = buildMethod.invoke(null, targetContext, sparklingContext);
+    sparklingClass.getMethod("processSparklingContext", sparklingContextClass)
+        .invoke(sparkling, sparklingContext);
+
+    String containerId =
+        (String) sparklingContextClass.getMethod("getContainerId").invoke(sparklingContext);
+    assertNotNull(containerId);
+    assertFalse(containerId.trim().isEmpty());
+
+    Object schemeParam =
+        sparklingContextClass.getMethod("getHybridSchemeParam").invoke(sparklingContext);
+    assertNotNull(schemeParam);
+    assertEquals(
+        "homepage.lynx.bundle", schemeParam.getClass().getMethod("getBundle").invoke(schemeParam));
+
+    AtomicReference<Throwable> failureRef = new AtomicReference<>();
+    InstrumentationRegistry.getInstrumentation().runOnMainSync(() -> {
+      try {
+        Object sparklingView =
+            sparklingClass.getMethod("createView", boolean.class).invoke(sparkling, false);
+        assertNotNull(sparklingView);
+        assertSame(sparklingContext,
+            sparklingView.getClass().getMethod("getSparklingContext").invoke(sparklingView));
+        assertSame(sparklingContext,
+            sparklingView.getClass().getMethod("obtainHybridContext").invoke(sparklingView));
+        assertTrue(
+            sparklingView.getClass().getMethod("actualView").invoke(sparklingView) instanceof View);
+        sparklingViewRef.set(sparklingView);
+      } catch (Throwable throwable) {
+        failureRef.set(throwable);
+      }
+    });
+
+    if (failureRef.get() != null) {
+      throw failureRef.get();
+    }
+
+    assertNotNull(sparklingContextClass.getMethod("getBridge").invoke(sparklingContext));
+    Map<String, Object> globalProps = getSparklingGlobalProps(classLoader, containerId);
+    assertEquals(containerId, globalProps.get("containerID"));
+    assertEquals(Boolean.TRUE, globalProps.get("sparklingAvailable"));
+    assertEquals(Boolean.TRUE, globalProps.get("sparklingNavigation"));
+    assertNotNull(globalProps.get("queryItems"));
+    assertRouterOpenRegistered(classLoader);
+    assertRouterOpenBridgeCallSucceeds(
+        classLoader, sparklingContext, sparklingContextClass, containerId);
+  }
+
+  @Test
+  public void disabledVariantDoesNotExposeSparklingRuntime() throws Exception {
+    if (BuildConfig.ENABLE_SPARKLING) {
+      return;
+    }
+
+    Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    try {
+      targetContext.getClassLoader().loadClass("com.tiktok.sparkling.SparklingActivity");
+      fail("SparklingActivity should not be loadable in a disabled Explorer build.");
+    } catch (ClassNotFoundException expected) {
+      // Expected: disabled builds must not package Sparkling runtime classes.
+    }
+
+    PackageInfo packageInfo = targetContext.getPackageManager().getPackageInfo(
+        targetContext.getPackageName(), PackageManager.GET_ACTIVITIES);
+    if (packageInfo.activities != null) {
+      for (ActivityInfo activityInfo : packageInfo.activities) {
+        assertNotEquals("com.tiktok.sparkling.SparklingActivity", activityInfo.name);
+      }
+    }
+  }
+
+  @Test
+  public void disabledVariantLaunchesExplorerActivityWithoutSparkling() {
+    if (BuildConfig.ENABLE_SPARKLING) {
+      return;
+    }
+
+    Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    Intent intent = new Intent(targetContext, LynxViewShellActivity.class);
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    intent.putExtra("lynx_initial_url", "file://lynx?local://homepage.lynx.bundle");
+
+    Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+    Activity activity = instrumentation.startActivitySync(intent);
+    try {
+      instrumentation.waitForIdleSync();
+      assertFalse(activity.isFinishing());
+    } finally {
+      activity.finish();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> getSparklingGlobalProps(
+      ClassLoader classLoader, String containerId) throws Exception {
+    Class<?> globalPropsUtilsClass =
+        classLoader.loadClass("com.tiktok.sparkling.hybridkit.utils.GlobalPropsUtils");
+    Field companionField = globalPropsUtilsClass.getField("Companion");
+    Object companion = companionField.get(null);
+    Object globalPropsUtils = companion.getClass().getMethod("getInstance").invoke(companion);
+    return (Map<String, Object>) globalPropsUtilsClass.getMethod("getGlobalProps", String.class)
+        .invoke(globalPropsUtils, containerId);
+  }
+
+  private static void assertRouterOpenRegistered(ClassLoader classLoader) throws Exception {
+    Class<?> registrarClass =
+        classLoader.loadClass("com.lynx.explorer.sparkling.SparklingNavigationRegistrar");
+    Object registered = registrarClass.getMethod("isRouterOpenRegistered").invoke(null);
+    assertEquals(Boolean.TRUE, registered);
+  }
+
+  private static void assertRouterOpenBridgeCallSucceeds(ClassLoader classLoader,
+      Object sparklingContext, Class<?> sparklingContextClass, String containerId)
+      throws Exception {
+    Object bridge = sparklingContextClass.getMethod("getBridge").invoke(sparklingContext);
+    assertNotNull(bridge);
+    Object bridgeContext = bridge.getClass().getMethod("getBridgeContext").invoke(bridge);
+    assertNotNull(bridgeContext);
+
+    JavaOnlyMap data = new JavaOnlyMap();
+    data.putString("scheme",
+        "hybrid://lynxview_page?bundle=homepage.lynx.bundle&hide_loading=1&hide_nav_bar=1");
+    JavaOnlyMap params = new JavaOnlyMap();
+    params.putString("containerID", containerId);
+    params.putString("protocolVersion", "1.0.0");
+    params.putMap("data", data);
+
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicReference<Object[]> callbackArgsRef = new AtomicReference<>();
+    Callback callback = args -> {
+      callbackArgsRef.set(args);
+      latch.countDown();
+    };
+
+    Class<?> delegateClass = classLoader.loadClass(
+        "com.tiktok.sparkling.method.protocol.impl.lynx.RealLynxBridgeDelegate");
+    Object delegate = delegateClass.getConstructor(Object.class).newInstance(bridgeContext);
+    delegateClass.getMethod("call", String.class, ReadableMap.class, Callback.class, String.class)
+        .invoke(delegate, "router.open", params, callback, "Lynx");
+
+    assertTrue("router.open callback did not run", latch.await(10, TimeUnit.SECONDS));
+    Object[] callbackArgs = callbackArgsRef.get();
+    assertNotNull(callbackArgs);
+    assertTrue(callbackArgs.length > 0);
+    assertTrue(callbackArgs[0] instanceof Map);
+    Object code = ((Map<?, ?>) callbackArgs[0]).get("code");
+    assertTrue(code instanceof Number);
+    assertEquals(1, ((Number) code).intValue());
+  }
+}

--- a/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
+++ b/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.lynx.explorer">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA"/>
@@ -48,13 +47,6 @@
         android:theme="@style/LynxShellTheme">
       </activity>
 
-      <activity
-        android:name="com.tiktok.sparkling.SparklingActivity"
-        android:exported="false"
-        android:windowSoftInputMode="adjustNothing"
-        android:theme="@style/LynxShellTheme"
-        tools:replace="android:theme">
-      </activity>
     </application>
 
 </manifest>

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/ExplorerApplication.java
@@ -29,17 +29,18 @@ public class ExplorerApplication extends Application {
     super.onCreate();
     initLynxService();
     initLynxEnv();
-    initSparkling();
+    if (BuildConfig.ENABLE_SPARKLING) {
+      initSparkling();
+    }
     installLynxJSModule(); // register native module.
     initFresco();
     initLynxRecorder();
   }
 
   private void initSparkling() {
-    // Use reflection so this compiles when only the public Sparkling AAR is available.
+    // Use reflection so disabled builds compile without Sparkling on the classpath.
     // The classes below live under .hybridkit.* (not the top-level package) and HybridKit
     // is a Kotlin object whose methods must be invoked on its INSTANCE field, not statically.
-    // If any lookup fails we log and skip Sparkling integration gracefully.
     try {
       Class<?> hybridKitClass = Class.forName("com.tiktok.sparkling.hybridkit.HybridKit");
       Object hybridKit = hybridKitClass.getField("INSTANCE").get(null);
@@ -75,11 +76,21 @@ public class ExplorerApplication extends Application {
       hybridKitClass.getMethod("setHybridConfig", hybridConfigClass, Application.class)
           .invoke(hybridKit, hybridConfig, this);
       hybridKitClass.getMethod("initLynxKit").invoke(hybridKit);
+      Class<?> sparklingNavigationRegistrar =
+          Class.forName("com.lynx.explorer.sparkling.SparklingNavigationRegistrar");
+      sparklingNavigationRegistrar.getMethod("install", Application.class).invoke(null, this);
       android.util.Log.i("ExplorerApplication", "Sparkling HybridKit initialized");
     } catch (ClassNotFoundException e) {
-      android.util.Log.w("ExplorerApplication", "Sparkling SDK not on classpath, skipping init", e);
+      if (BuildConfig.DEBUG) {
+        throw new IllegalStateException("Sparkling is enabled but SDK classes are missing", e);
+      }
+      android.util.Log.e(
+          "ExplorerApplication", "Sparkling SDK classes missing in enabled build", e);
     } catch (Exception e) {
-      android.util.Log.e("ExplorerApplication", "Sparkling init failed", e);
+      if (BuildConfig.DEBUG) {
+        throw new IllegalStateException("Sparkling init failed", e);
+      }
+      android.util.Log.e("ExplorerApplication", "Sparkling init failed in enabled build", e);
     }
   }
 

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -376,6 +376,13 @@ public class LynxViewShellActivity extends AppCompatActivity {
       globalProps.put(propsKey, value);
     });
 
+    // Plain Explorer-created LynxView instances do not register Sparkling's
+    // spkPipe module yet, even in withSparkling builds. Keep JS navigation on
+    // the legacy ExplorerModule path until a view is explicitly wired to Sparkling.
+    globalProps.put("sparklingAvailable", false);
+    globalProps.put("sparklingNavigation", false);
+    globalProps.remove("containerID");
+
     return TemplateData.fromMap(globalProps);
   }
 

--- a/explorer/android/lynx_explorer/src/withSparkling/AndroidManifest.xml
+++ b/explorer/android/lynx_explorer/src/withSparkling/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name="com.tiktok.sparkling.SparklingActivity"
+            android:exported="false"
+            android:theme="@style/LynxShellTheme"
+            android:windowSoftInputMode="adjustNothing"
+            tools:replace="android:theme">
+        </activity>
+    </application>
+</manifest>

--- a/explorer/android/lynx_explorer/src/withSparkling/java/com/lynx/explorer/sparkling/SparklingNavigationRegistrar.kt
+++ b/explorer/android/lynx_explorer/src/withSparkling/java/com/lynx/explorer/sparkling/SparklingNavigationRegistrar.kt
@@ -1,0 +1,81 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+package com.lynx.explorer.sparkling
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import com.tiktok.sparkling.Sparkling
+import com.tiktok.sparkling.SparklingContext
+import com.tiktok.sparkling.hybridkit.utils.GlobalPropsUtils
+import com.tiktok.sparkling.method.registry.core.BridgePlatformType
+import com.tiktok.sparkling.method.registry.core.IBridgeContext
+import com.tiktok.sparkling.method.registry.core.SparklingBridgeManager
+import com.tiktok.sparkling.method.registry.core.model.context.ContextProviderFactory
+import com.tiktok.sparkling.method.router.close.RouterCloseMethod
+import com.tiktok.sparkling.method.router.open.RouterOpenMethod
+import com.tiktok.sparkling.method.router.utils.AbsRouteOpenHandler
+import com.tiktok.sparkling.method.router.utils.IHostRouterDepend
+import com.tiktok.sparkling.method.router.utils.RouterProvider
+
+object SparklingNavigationRegistrar {
+  @JvmStatic
+  fun install(application: Application) {
+    SparklingBridgeManager.registerIDLMethod(RouterOpenMethod::class.java, BridgePlatformType.LYNX)
+    SparklingBridgeManager.registerIDLMethod(RouterCloseMethod::class.java, BridgePlatformType.LYNX)
+    RouterProvider.hostRouterDepend = ExplorerRouterDepend(application)
+    GlobalPropsUtils.Companion.instance.setStableProps(
+        mapOf(
+            "sparklingAvailable" to true,
+            "sparklingNavigation" to true,
+        ))
+  }
+
+  @JvmStatic
+  fun isRouterOpenRegistered(): Boolean {
+    return SparklingBridgeManager.findIDLMethodClass(
+        BridgePlatformType.LYNX, "router.open") != null
+  }
+
+  private class ExplorerRouterDepend(private val application: Application) : IHostRouterDepend {
+    override fun openScheme(
+        bridgeContext: IBridgeContext?,
+        scheme: String,
+        extraParams: Map<String, Any>,
+        platformType: BridgePlatformType,
+        context: Context?): Boolean {
+      if (scheme.isBlank()) {
+        return false
+      }
+      val sparklingContext = SparklingContext()
+      sparklingContext.scheme = scheme
+      val launchContext = context ?: bridgeContext?.context ?: application
+      return Sparkling.build(launchContext.applicationContext, sparklingContext).navigate()
+    }
+
+    override fun closeView(
+        bridgeContext: IBridgeContext?,
+        type: BridgePlatformType,
+        containerID: String?,
+        animated: Boolean?): Boolean {
+      val activity = bridgeContext?.ownerActivity ?: return false
+      activity.runOnUiThread {
+        if (!activity.isFinishing) {
+          activity.finish()
+        }
+      }
+      return true
+    }
+
+    override fun provideRouteOpenHandlerList(
+        contextProviderFactory: ContextProviderFactory?): List<AbsRouteOpenHandler> {
+      return emptyList()
+    }
+
+    override fun provideRouteOpenExceptionHandler(
+        contextProviderFactory: ContextProviderFactory?): AbsRouteOpenHandler? {
+      return null
+    }
+  }
+}

--- a/explorer/android/sparkling-lynx-ownership.gradle
+++ b/explorer/android/sparkling-lynx-ownership.gradle
@@ -1,0 +1,27 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+ext.sparklingLynxOwnedArtifacts = [
+        'org.lynxsdk.lynx:lynx'                 : ':LynxAndroid',
+        'org.lynxsdk.lynx:lynx-base'            : ':LynxBase',
+        'org.lynxsdk.lynx:lynx-trace'           : ':LynxTrace',
+        'org.lynxsdk.lynx:lynx-jssdk'           : ':LynxJSSDK',
+        'org.lynxsdk.lynx:service-api'          : ':ServiceAPI',
+        'org.lynxsdk.lynx:lynx-service-log'     : ':lynx_service_log',
+        'org.lynxsdk.lynx:lynx-service-image'   : ':lynx_service_image',
+        'org.lynxsdk.lynx:lynx-service-http'    : ':lynx_service_http',
+        'org.lynxsdk.lynx:lynx-service-devtool' : ':lynx_service_devtool',
+        'org.lynxsdk.lynx:lynx-devtool'         : ':LynxDevtool',
+        'org.lynxsdk.lynx:base-devtool'         : ':BaseDevtool',
+        'org.lynxsdk.lynx:xelement'             : ':LynxXElement',
+        'org.lynxsdk.lynx:xelement-input'       : ':LynxXElement:Input',
+        'org.lynxsdk.lynx:xelement-overlay'     : ':LynxXElement:Overlay',
+        'org.lynxsdk.lynx:xelement-viewpager'   : ':LynxXElement:ViewPager',
+        'org.lynxsdk.lynx:xelement-scroll-coordinator': ':LynxXElement:ScrollCoordinator',
+        'org.lynxsdk.lynx:xelement-svg'         : ':LynxXElement:SVG',
+        'org.lynxsdk.lynx:xelement-markdown'    : ':LynxXElement:Markdown',
+        'org.lynxsdk.lynx:xelement-refresh'     : ':LynxXElement:Refresh',
+        'org.lynxsdk.lynx:xelement-blur-view'   : ':LynxXElement:BlurView',
+        'org.lynxsdk.lynx:xelement-webview'     : ':LynxXElement:WebView',
+]

--- a/explorer/android/sparkling-runtime-allowlist.gradle
+++ b/explorer/android/sparkling-runtime-allowlist.gradle
@@ -1,0 +1,13 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+ext.sparklingRuntimeAllowlist = [
+        'org.lynxsdk.lynx:v8so'           : '11.1.277.4',
+        'org.lynxsdk.lynx:primjs'         : '3.8.0-alpha.6',
+        'org.lynxsdk.lynx:primjsWasm'     : '3.8.0-alpha.6',
+        'org.lynxsdk.lynx:debug-router'   : '0.0.20',
+        'org.lynxsdk.lynx:lynxtextra'     : '0.1.1',
+        'org.lynxsdk.lynx:serval_markdown': '0.1.1',
+        'org.lynxsdk.lynx:servalsvg'      : '0.0.2',
+]

--- a/explorer/lib/navigation.ts
+++ b/explorer/lib/navigation.ts
@@ -9,18 +9,38 @@ import {
 } from 'sparkling-navigation';
 import { addRecentUrl } from './recentHistory';
 
-const SPARKLING_PLATFORMS = ['iOS', 'Android'];
+function getGlobalProps(): Record<string, unknown> | undefined {
+  try {
+    return lynx.__globalProps as Record<string, unknown> | undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSparklingPipe(): boolean {
+  try {
+    if (typeof NativeModules === 'undefined') {
+      return false;
+    }
+    const modules = NativeModules as Record<string, unknown>;
+    const spkPipe = modules.spkPipe as { call?: unknown } | undefined;
+    return typeof spkPipe?.call === 'function';
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Returns true if the Sparkling SDK is loaded and the spkPipe module is
  * registered. Used for informational display (e.g. Settings page).
  */
 export function isSparklingAvailable(): boolean {
-  try {
-    return SPARKLING_PLATFORMS.includes(SystemInfo.platform);
-  } catch {
-    return false;
-  }
+  const props = getGlobalProps();
+  const hasNativeSignal =
+    props?.sparklingAvailable === true ||
+    props?.sparklingNavigation === true ||
+    (typeof props?.containerID === 'string' && props.containerID.length > 0);
+  return hasNativeSignal && hasSparklingPipe();
 }
 
 /**
@@ -29,12 +49,8 @@ export function isSparklingAvailable(): boolean {
  * so this returns false unless the native side explicitly sets the flag.
  */
 export function isSparkling(): boolean {
-  try {
-    const props = lynx.__globalProps as Record<string, unknown> | undefined;
-    return props?.sparklingNavigation === true;
-  } catch {
-    return false;
-  }
+  const props = getGlobalProps();
+  return isSparklingAvailable() && props?.sparklingNavigation === true;
 }
 
 const LOCAL_PREFIX = 'file://lynx?local://';


### PR DESCRIPTION
## Summary

This PR fixes the Android LynxExplorer Sparkling dependency ownership issue. LynxExplorer builds Lynx from local Gradle projects, while `com.tiktok.sparkling:sparkling` was published against released `org.lynxsdk.lynx` artifacts. The previous broad `org.lynxsdk.lynx` exclude avoided duplicate classes but did not make ownership, enablement, or runtime compatibility explicit.

## Changes

- Add explicit `withSparkling` and `withoutSparkling` Android flavors for LynxExplorer, with `withoutSparkling` as the default mode.
- Move Sparkling dependencies and `SparklingActivity` into the enabled flavor, and guard native startup with `BuildConfig.ENABLE_SPARKLING`.
- Add Lynx ownership and runtime allowlist verification for Sparkling-enabled classpaths.
- Compile the npm `sparkling-navigation` Android router source only in the enabled flavor and register `router.open` / `router.close` through `SparklingNavigationRegistrar`.
- Tighten Explorer JS Sparkling detection so it requires native global state plus `spkPipe` availability.
- Add APK artifact verification and Android instrumentation smoke coverage for enabled and disabled variants.
- Defer Gradle side-effecting work into task actions and add explicit dependencies for native CMake generation, Explorer generated assets, and Android Java CSS constants generation.

## Impact

Sparkling-disabled Explorer builds no longer carry Sparkling dependencies, manifest entries, or runtime startup paths. Sparkling-enabled builds continue to use local Lynx source projects as the canonical Lynx implementation while explicitly verifying allowed runtime artifacts and router integration.

The Gradle task changes also make generated files deterministic for clean builds: Java compilation no longer relies on GN/CMake configuration side effects to create `AutoGenStyleConstants.java`.

## Validation

- `git diff --check`
- `tools/env.sh -- buildtools/corepack/pnpm/pnpm --filter homepage build`
- `./gradlew :LynxAndroid:compileNoasanReleaseJavaWithJavac --rerun-tasks --no-daemon` after removing the ignored local `AutoGenStyleConstants.java`
- `./gradlew :LynxAndroid:compileDebugModeDebugJavaWithJavac :LynxAndroid:compileDebugModeReleaseJavaWithJavac :LynxAndroid:compileAsanDebugJavaWithJavac :LynxAndroid:compileAsanReleaseJavaWithJavac :LynxAndroid:compileNoasanDebugJavaWithJavac :LynxAndroid:compileNoasanReleaseJavaWithJavac :LynxAndroid:compileDevDebugJavaWithJavac :LynxAndroid:compileDevReleaseJavaWithJavac --rerun-tasks --no-daemon`
- `GRADLE_USER_HOME=$PWD/.gradle-local ./gradlew --no-daemon :LynxExplorer:verifySparklingAndroidRefactor -Penable_trace=perfetto -PabiList=x86,arm64-v8a -PIntegrationTest`
- `./gradlew --no-daemon :LynxExplorer:connectedWithSparklingNoasanDebugAndroidTest :LynxExplorer:connectedWithoutSparklingNoasanDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.lynx.explorer.SparklingRuntimeSmokeTest` on `Medium_Phone_API_35` / Android API 35

The connected smoke covers both Sparkling-enabled and disabled variants and includes a real `router.open` bridge call in the enabled variant.