### PR TITLE
[Infra] Use concurrency to save resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - CQ-*
       - cq-*
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     working-directory: lynx


### PR DESCRIPTION
Use concurrency to ensure that only a single job or workflow using the same concurrency group will run at a time.