### PR TITLE
[BugFix][iOS] Fix LynxServiceAPI header not found

### DIFF
--- a/platform/darwin/ios/lynx_service_api/BUILD.gn
+++ b/platform/darwin/ios/lynx_service_api/BUILD.gn
@@ -36,7 +36,10 @@ podspec_target("LynxServiceAPI_podspec") {
       CLANG_CXX_LANGUAGE_STANDARD = "gnu++17"
       OTHER_CPLUSPLUSFLAGS =
           "-fno-aligned-allocation -fno-c++-static-destructors -std=gnu++17"
-      HEADER_SEARCH_PATHS = [ "../../../.." ]
+      HEADER_SEARCH_PATHS = [
+        "../../../..",
+        "//",
+      ]
     }
     if (!is_debug) {
       pod_target_xcconfig.GCC_PREPROCESSOR_DEFINITIONS += [ "NDEBUG=1" ]


### PR DESCRIPTION
Add ${PODS_TARGET_SRCROOT} to HEADER_SEARCH_PATHS in the LynxServiceAPI podspec so that repo-root-relative includes (e.g.
service_api/service_api.h) can be resolved in a pod consumer's build environment.

Previously only the absolute local repo path was present, which only works in a source build and breaks for CocoaPod consumers.
