### PR TITLE
[BugFix][iOS] Support Lynx Explorer rotation

### DIFF
--- a/devtool/lynx_devtool/resources/devtool-switch/src/App.tsx
+++ b/devtool/lynx_devtool/resources/devtool-switch/src/App.tsx
@@ -14,15 +14,62 @@ import { CurrentJSEngine } from './sections/CurrentJSEngine';
 import { FSPScreenshot } from './sections/FSPScreenshot';
 
 export default function App() {
+  const safeArea = getSafeArea();
+  const horizontalSafeArea = safeArea.left + safeArea.right;
+
   return (
     <view className="container" style="height:100%;width:100%">
       <scroll-view scroll-y style="height:100%;width:100%">
-        <Header />
-        <LynxDebug experimental={true} />
-        <CurrentJSEngine />
+        <view
+          style={{
+            marginLeft: `${safeArea.left}px`,
+            marginRight: `${safeArea.right}px`,
+            width: `calc(100% - ${horizontalSafeArea}px)`,
+            paddingBottom: `${safeArea.bottom}px`,
+          }}
+        >
+          <Header />
+          <LynxDebug experimental={true} />
+          <CurrentJSEngine />
+        </view>
       </scroll-view>
     </view>
   );
+}
+
+function getSafeArea() {
+  const globalProps = lynx.__globalProps || {};
+  const screenWidth = Number(globalProps.screenWidth || 0);
+  const screenHeight = Number(globalProps.screenHeight || 0);
+  const isPortrait =
+    screenWidth > 0 && screenHeight > 0 ? screenHeight >= screenWidth : true;
+  const isIOS = SystemInfo.platform === 'iOS';
+  const isNotchScreen =
+    globalProps.isNotchScreen ||
+    (globalProps.safeAreaTop || 0) > 20 ||
+    (globalProps.safeAreaBottom || 0) > 0 ||
+    (globalProps.safeAreaLeft || 0) > 0 ||
+    (globalProps.safeAreaRight || 0) > 0;
+  const landscapeSideFallback = isIOS && isNotchScreen ? 54 : 0;
+
+  return {
+    top: Math.max(
+      globalProps.safeAreaTop || 0,
+      isPortrait && isNotchScreen ? 54 : 0
+    ),
+    bottom: Math.max(
+      globalProps.safeAreaBottom || 0,
+      isPortrait && isNotchScreen ? 34 : 0
+    ),
+    left: Math.max(
+      globalProps.safeAreaLeft || 0,
+      isPortrait ? 0 : landscapeSideFallback
+    ),
+    right: Math.max(
+      globalProps.safeAreaRight || 0,
+      isPortrait ? 0 : landscapeSideFallback
+    ),
+  };
 }
 
 interface Props {

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer.xcodeproj/project.pbxproj
@@ -701,7 +701,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -741,7 +741,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/AppDelegate.mm
@@ -40,8 +40,7 @@ static void InstallPrimJSWeakNodeApiBridge(void) {
 }
 
 NSString *const LOCAL_URL_PREFIX = @"file://lynx?local://";
-NSString *const HOMEPAGE_URL =
-    @"file://lynx?local://homepage.lynx.bundle?fullscreen=true&orientation=portrait";
+NSString *const HOMEPAGE_URL = @"file://lynx?local://homepage.lynx.bundle?fullscreen=true";
 
 @interface AppDelegate ()
 

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorer/LynxViewShellViewController.m
@@ -45,6 +45,13 @@ NSString *const kBackButtonImageDark = @"back_dark";
 @property(nonatomic, strong) UIView *previousViewControllerView;
 @property(nonatomic, copy) NSString *frontendTheme;
 @property(nonatomic, strong) LynxBackgroundRuntime *backgroundRuntime;
+@property(nonatomic, strong) LynxView *lynxView;
+@property(nonatomic, strong) UIView *statusView;
+@property(nonatomic, strong) UIView *barView;
+@property(nonatomic, strong) UILabel *titleLabel;
+@property(nonatomic, assign) CGSize currentScreenMetricsSize;
+@property(nonatomic, assign) CGSize currentViewportSize;
+@property(nonatomic, assign) UIEdgeInsets currentSafeAreaInsets;
 
 @end
 
@@ -58,6 +65,120 @@ static BOOL IsTruthyParam(id value) {
     return [s isEqualToString:@"1"] || [s isEqualToString:@"true"] || [s isEqualToString:@"yes"];
   }
   return NO;
+}
+
+- (BOOL)hasExplicitViewportSize {
+  return [self.params.allKeys containsObject:@"height"] &&
+         [self.params.allKeys containsObject:@"width"];
+}
+
+- (CGSize)screenSizeForCurrentBounds {
+  if ([self hasExplicitViewportSize]) {
+    NSNumber *width = [self.params objectForKey:@"width"];    // Physical pixel
+    NSNumber *height = [self.params objectForKey:@"height"];  // Physical pixel
+    CGFloat realScale = [[UIScreen mainScreen] scale];
+    return CGSizeMake([width intValue] / realScale, [height intValue] / realScale);
+  }
+  return self.view.bounds.size;
+}
+
+- (CGFloat)statusBarHeight {
+  CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+  if (statusBarHeight > 0) {
+    return statusBarHeight;
+  }
+  return [self statusBarHeightForCurrentLayout];
+}
+
+- (CGFloat)statusBarHeightForCurrentLayout {
+  if (@available(iOS 13.0, *)) {
+    UIWindowScene *windowScene =
+        self.view.window.windowScene ?: UIApplication.sharedApplication.keyWindow.windowScene;
+    CGFloat statusBarHeight = windowScene.statusBarManager.statusBarFrame.size.height;
+    if (statusBarHeight > 0) {
+      return statusBarHeight;
+    }
+  }
+  CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
+  if (statusBarHeight > 0) {
+    return statusBarHeight;
+  }
+  return [self isNotchScreen] ? 44 : 20;
+}
+
+- (UIEdgeInsets)safeAreaInsetsForCurrentLayout {
+  if (@available(iOS 11.0, *)) {
+    UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
+    if (!UIEdgeInsetsEqualToEdgeInsets(safeAreaInsets, UIEdgeInsetsZero)) {
+      return safeAreaInsets;
+    }
+    UIWindow *window = self.view.window ?: UIApplication.sharedApplication.keyWindow;
+    if (window) {
+      safeAreaInsets = window.safeAreaInsets;
+      if (!UIEdgeInsetsEqualToEdgeInsets(safeAreaInsets, UIEdgeInsetsZero)) {
+        return safeAreaInsets;
+      }
+    }
+  }
+  return UIEdgeInsetsMake([self statusBarHeightForCurrentLayout], 0, [self isNotchScreen] ? 34 : 0,
+                          0);
+}
+
+- (CGFloat)navigationBarHeight {
+  return self.navigationController.navigationBar.frame.size.height;
+}
+
+- (CGRect)lynxViewFrameForScreenSize:(CGSize)screenSize {
+  CGFloat y = 0;
+  CGFloat height = screenSize.height;
+  if (!self.fullScreen) {
+    CGFloat statusBarHeight = [self statusBarHeight];
+    y += statusBarHeight;
+    height -= statusBarHeight;
+    if (!self.hiddenNav) {
+      CGFloat navigationBarHeight = [self navigationBarHeight];
+      y += navigationBarHeight;
+      height -= navigationBarHeight;
+    }
+  }
+  return CGRectMake(0, y, screenSize.width, MAX(height, 0));
+}
+
+- (void)layoutNavigationForScreenSize:(CGSize)screenSize {
+  CGFloat statusH = [self statusBarHeight];
+  CGFloat navH = [self navigationBarHeight];
+
+  self.statusView.frame = CGRectMake(0, 0, screenSize.width, statusH);
+  self.barView.frame = CGRectMake(0, statusH, screenSize.width, navH);
+  self.titleLabel.frame = CGRectMake(navH, 0, MAX(screenSize.width - 2 * navH, 0), navH);
+}
+
+- (void)updateLynxViewLayoutIfNeeded {
+  if (!self.lynxView) {
+    return;
+  }
+
+  CGSize screenSize = [self screenSizeForCurrentBounds];
+  CGRect lynxViewFrame = [self lynxViewFrameForScreenSize:screenSize];
+  CGSize viewportSize = lynxViewFrame.size;
+  UIEdgeInsets safeAreaInsets = [self safeAreaInsetsForCurrentLayout];
+
+  [self layoutNavigationForScreenSize:screenSize];
+  self.lynxView.frame = lynxViewFrame;
+
+  if (CGSizeEqualToSize(self.currentScreenMetricsSize, screenSize) &&
+      CGSizeEqualToSize(self.currentViewportSize, viewportSize) &&
+      UIEdgeInsetsEqualToEdgeInsets(self.currentSafeAreaInsets, safeAreaInsets)) {
+    return;
+  }
+
+  self.currentScreenMetricsSize = screenSize;
+  self.currentViewportSize = viewportSize;
+  self.currentSafeAreaInsets = safeAreaInsets;
+  [self.lynxView updateScreenMetricsWithWidth:screenSize.width height:screenSize.height];
+  [self.lynxView updateViewportWithPreferredLayoutWidth:viewportSize.width
+                                  preferredLayoutHeight:viewportSize.height];
+  [self.lynxView updateGlobalPropsWithTemplateData:[self getGlobalPropsForScreenSize:screenSize]];
 }
 
 - (id)init {
@@ -130,21 +251,34 @@ static BOOL IsTruthyParam(id value) {
   return globalProps;
 }
 
-- (void)loadLynxViewWithUrl:(NSString *)url templateData:(NSData *)data {
-  CGRect screenFrame = self.view.frame;
-  CGRect statusRect = [[UIApplication sharedApplication] statusBarFrame];
-  CGRect navRect = self.navigationController.navigationBar.frame;
+- (LynxTemplateData *)getGlobalPropsForScreenSize:(CGSize)screenSize {
+  LynxTemplateData *globalProps = [self getGlobalPropsFromParams];
+  [globalProps updateBool:[self isNotchScreen] forKey:@"isNotchScreen"];
+  [globalProps updateDouble:screenSize.height forKey:@"screenHeight"];
+  [globalProps updateDouble:screenSize.width forKey:@"screenWidth"];
+  UIEdgeInsets safeAreaInsets = [self safeAreaInsetsForCurrentLayout];
+  [globalProps updateDouble:safeAreaInsets.top forKey:@"safeAreaTop"];
+  [globalProps updateDouble:safeAreaInsets.bottom forKey:@"safeAreaBottom"];
+  [globalProps updateDouble:safeAreaInsets.left forKey:@"safeAreaLeft"];
+  [globalProps updateDouble:safeAreaInsets.right forKey:@"safeAreaRight"];
 
-  // Specify LynxView width and height according to the query parameters.
-  CGSize screenSize = CGSizeZero;
-  if ([[_params allKeys] containsObject:@"height"] && [[_params allKeys] containsObject:@"width"]) {
-    NSNumber *width = [_params objectForKey:@"width"];    // Physical pixel
-    NSNumber *height = [_params objectForKey:@"height"];  // Physical pixel
-    CGFloat realScale = [[UIScreen mainScreen] scale];
-    screenSize = CGSizeMake([width intValue] / realScale, [height intValue] / realScale);
-  } else {
-    screenSize = screenFrame.size;
+  NSString *theme = @"Light";
+  if ([UIScreen mainScreen].traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+    theme = @"Dark";
   }
+  [globalProps updateObject:theme forKey:@"theme"];
+  [globalProps updateObject:self.frontendTheme forKey:@"frontendTheme"];
+
+  NSString *preferredTheme = [self getStorageItem:@"preferredTheme"];
+  if (preferredTheme) {
+    [globalProps updateObject:preferredTheme forKey:@"preferredTheme"];
+  }
+  return globalProps;
+}
+
+- (void)loadLynxViewWithUrl:(NSString *)url templateData:(NSData *)data {
+  CGSize screenSize = [self screenSizeForCurrentBounds];
+  CGRect lynxViewFrame = [self lynxViewFrameForScreenSize:screenSize];
   LynxThreadStrategyForRender threadStrategy =
       [LynxSettingManager sharedDataHandler].threadStrategy;
 
@@ -190,55 +324,21 @@ static BOOL IsTruthyParam(id value) {
 #if HAS_SPARKLING
   lynxView.containerID = containerID;
 #endif
-  lynxView.preferredLayoutWidth = screenSize.width;
+  lynxView.preferredLayoutWidth = lynxViewFrame.size.width;
   [lynxView setExtraTiming:extraTiming];
 #if HAS_SPARKLING
   // Connect Sparkling MethodPipe execution engine to this LynxView
   [SPKServiceRegistrar connectPipeTo:lynxView];
 #endif
 
-  if (self.fullScreen) {
-    lynxView.preferredLayoutHeight = screenSize.height;
-  } else if (self.hiddenNav) {
-    lynxView.preferredLayoutHeight = screenSize.height - statusRect.size.height;
-  } else {
-    lynxView.preferredLayoutHeight =
-        screenSize.height - statusRect.size.height - navRect.size.height;
-  }
+  lynxView.preferredLayoutHeight = lynxViewFrame.size.height;
   lynxView.layoutWidthMode = LynxViewSizeModeExact;
   lynxView.layoutHeightMode = LynxViewSizeModeExact;
+  lynxView.enableAutoLayout = YES;
   [self.view addSubview:lynxView];
+  self.lynxView = lynxView;
 
-  CGRect screenRect = [[UIScreen mainScreen] bounds];
-  CGFloat screenWidth = screenRect.size.width;
-  CGFloat screenHeight = screenRect.size.height;
-  LynxTemplateData *globalProps = [self getGlobalPropsFromParams];
-  [globalProps updateBool:[self isNotchScreen] forKey:@"isNotchScreen"];
-  [globalProps updateDouble:screenHeight forKey:@"screenHeight"];
-  [globalProps updateDouble:screenWidth forKey:@"screenWidth"];
-  if (@available(iOS 11.0, *)) {
-    UIWindow *window = UIApplication.sharedApplication.keyWindow;
-    UIEdgeInsets safeAreaInsets = window.safeAreaInsets;
-    [globalProps updateDouble:safeAreaInsets.top forKey:@"safeAreaTop"];
-    [globalProps updateDouble:safeAreaInsets.bottom forKey:@"safeAreaBottom"];
-  } else {
-    [globalProps updateDouble:0 forKey:@"safeAreaTop"];
-    [globalProps updateDouble:0 forKey:@"safeAreaBottom"];
-  }
-  NSString *theme = @"Light";
-  if ([UIScreen mainScreen].traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-    theme = @"Dark";
-  }
-  [globalProps updateObject:theme forKey:@"theme"];
-  [globalProps updateObject:self.frontendTheme forKey:@"frontendTheme"];
-
-  // Add the preferred theme from user defaults
-  NSString *preferredTheme = [self getStorageItem:@"preferredTheme"];
-  if (preferredTheme) {
-    [globalProps updateObject:preferredTheme forKey:@"preferredTheme"];
-  }
-
-  [lynxView updateGlobalPropsWithTemplateData:globalProps];
+  [lynxView updateGlobalPropsWithTemplateData:[self getGlobalPropsForScreenSize:screenSize]];
 
   LynxTemplateData *initData =
       [[LynxTemplateData alloc] initWithDictionary:@{@"mockData" : @"Hello Lynx Explorer"}];
@@ -248,20 +348,7 @@ static BOOL IsTruthyParam(id value) {
     [lynxView loadTemplateFromURL:url initData:initData];
   }
   [lynxView triggerLayout];
-
-  CGRect lynxViewFrame;
-  if (self.fullScreen) {
-    lynxViewFrame =
-        CGRectMake(0, 0, lynxView.intrinsicContentSize.width, lynxView.intrinsicContentSize.height);
-  } else if (self.hiddenNav) {
-    lynxViewFrame = CGRectMake(0, statusRect.size.height, lynxView.intrinsicContentSize.width,
-                               lynxView.intrinsicContentSize.height);
-  } else {
-    lynxViewFrame =
-        CGRectMake(0, statusRect.size.height + navRect.size.height,
-                   lynxView.intrinsicContentSize.width, lynxView.intrinsicContentSize.height);
-  }
-  lynxView.frame = lynxViewFrame;
+  [self updateLynxViewLayoutIfNeeded];
 }
 
 - (void)parseParameters {
@@ -323,6 +410,7 @@ static BOOL IsTruthyParam(id value) {
   UIView *statusView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, screenSize.width, statusH)];
   statusView.backgroundColor = self.barColor;
   [self.view addSubview:statusView];
+  self.statusView = statusView;
 
   if (self.hiddenNav) {
     return;
@@ -330,6 +418,7 @@ static BOOL IsTruthyParam(id value) {
   // create custom navigation bar
   UIView *barView = [[UIView alloc] initWithFrame:CGRectMake(0, statusH, screenSize.width, navH)];
   barView.backgroundColor = self.barColor;
+  self.barView = barView;
 
   UIButton *goBackButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, navH, navH)];
   UIImage *backImage = [self scaleImage:[UIImage imageNamed:self.backButtonImageName]
@@ -343,6 +432,7 @@ static BOOL IsTruthyParam(id value) {
   titleLabel.text = self.navTitle;
   titleLabel.textColor = self.titleColor;
   titleLabel.textAlignment = NSTextAlignmentCenter;
+  self.titleLabel = titleLabel;
 
   [barView addSubview:goBackButton];
   [barView addSubview:titleLabel];
@@ -350,7 +440,7 @@ static BOOL IsTruthyParam(id value) {
 }
 
 - (BOOL)shouldAutorotate {
-  return NO;
+  return YES;
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations {
@@ -362,12 +452,17 @@ static BOOL IsTruthyParam(id value) {
       return UIInterfaceOrientationMaskLandscape;
     }
   }
-  return UIInterfaceOrientationMaskAllButUpsideDown;
+  return UIInterfaceOrientationMaskAll;
 }
 
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
   [self setNavigationStatus];
+}
+
+- (void)viewDidLayoutSubviews {
+  [super viewDidLayoutSubviews];
+  [self updateLynxViewLayoutIfNeeded];
 }
 
 - (void)setNavigationStatus {
@@ -462,7 +557,8 @@ static BOOL IsTruthyParam(id value) {
   if (@available(iOS 11.0, *)) {
     UIWindow *window = UIApplication.sharedApplication.keyWindow;
     UIEdgeInsets safeAreaInsets = window.safeAreaInsets;
-    return safeAreaInsets.top > 20;
+    return safeAreaInsets.top > 20 || safeAreaInsets.bottom > 0 || safeAreaInsets.left > 0 ||
+           safeAreaInsets.right > 0;
   }
 
   return NO;

--- a/explorer/darwin/ios/lynx_explorer/LynxExplorerTests/LynxExplorerTests.m
+++ b/explorer/darwin/ios/lynx_explorer/LynxExplorerTests/LynxExplorerTests.m
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 #import <XCTest/XCTest.h>
+#import "LynxViewShellViewController.h"
 
 @interface LynxExplorerTests : XCTestCase
 
@@ -10,26 +11,25 @@
 
 @implementation LynxExplorerTests
 
-- (void)setUp {
-  // Put setup code here. This method is called before the invocation of each test method in the
-  // class.
+- (void)testShellViewControllerAllowsAutorotation {
+  LynxViewShellViewController *shellVC = [[LynxViewShellViewController alloc] init];
+  XCTAssertTrue([shellVC shouldAutorotate]);
 }
 
-- (void)tearDown {
-  // Put teardown code here. This method is called after the invocation of each test method in the
-  // class.
+- (void)testShellViewControllerSupportsLandscapeByDefault {
+  LynxViewShellViewController *shellVC = [[LynxViewShellViewController alloc] init];
+  shellVC.params = [NSMutableDictionary dictionary];
+  XCTAssertEqual([shellVC supportedInterfaceOrientations], UIInterfaceOrientationMaskAll);
 }
 
-- (void)testExample {
-  // This is an example of a functional test case.
-  // Use XCTAssert and related functions to verify your tests produce the correct results.
-}
+- (void)testShellViewControllerKeepsExplicitOrientationRestrictions {
+  LynxViewShellViewController *shellVC = [[LynxViewShellViewController alloc] init];
 
-- (void)testPerformanceExample {
-  // This is an example of a performance test case.
-  [self measureBlock:^{
-      // Put the code you want to measure the time of here.
-  }];
+  shellVC.params = [@{@"orientation" : @"portrait"} mutableCopy];
+  XCTAssertEqual([shellVC supportedInterfaceOrientations], UIInterfaceOrientationMaskPortrait);
+
+  shellVC.params = [@{@"orientation" : @"landscape"} mutableCopy];
+  XCTAssertEqual([shellVC supportedInterfaceOrientations], UIInterfaceOrientationMaskLandscape);
 }
 
 @end

--- a/explorer/homepage/components/homepage/index.scss
+++ b/explorer/homepage/components/homepage/index.scss
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-@import "../shared";
+@import '../shared';
 
 .logo {
   display: flex;
@@ -13,7 +13,7 @@
 .home-title__dark {
   @include title;
   margin-left: 6px;
-  color: var(--title-dark)
+  color: var(--title-dark);
 }
 
 .home-title__light {
@@ -37,28 +37,28 @@
 .input-card-url__light {
   @include box;
   flex-direction: column;
-  height: 24%;
-  justify-content: center;
-  margin-bottom: 3%;
+  height: 148px;
+  justify-content: flex-start;
+  margin-bottom: 12px;
   background: var(--box-light);
 }
 
 .input-card-url__dark {
   @include box;
   flex-direction: column;
-  height: 24%;
-  justify-content: center;
-  margin-bottom: 3%;
+  height: 148px;
+  justify-content: flex-start;
+  margin-bottom: 12px;
   background: var(--box-dark);
 }
 
 .input-box__light {
   display: flex;
   align-items: flex-start;
-  margin: 0% 5% 5% 5%;
+  margin: 0px 5% 8px 5%;
   border-width: 0px 0px 1px;
   border-color: #0000001a;
-  height: 20%;
+  height: 30px;
   width: 90%;
   color: var(--text-light);
 }
@@ -66,10 +66,10 @@
 .input-box__dark {
   display: flex;
   align-items: flex-start;
-  margin: 0% 5% 5% 5%;
+  margin: 0px 5% 8px 5%;
   border-width: 0px 0px 1px;
   border-color: #ffffff1a;
-  height: 20%;
+  height: 30px;
   width: 90%;
   color: var(--text-dark);
 }
@@ -77,25 +77,27 @@
 .bold-text__light {
   font-size: 14px;
   font-weight: 500;
-  height: 20%;
-  margin: 5%;
+  line-height: 20px;
+  height: 20px;
+  margin: 12px 5% 8px 5%;
 }
 
 .bold-text__dark {
   font-size: 14px;
   font-weight: 500;
-  height: 20%;
-  margin: 5%;
-  color: var(--text-dark)
+  line-height: 20px;
+  height: 20px;
+  margin: 12px 5% 8px 5%;
+  color: var(--text-dark);
 }
 
 @mixin connect-button {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 1% 5% 5% 5%;
+  margin: 0px 5% 10px 5%;
   border-radius: 8px;
-  height: 28%;
+  height: 42px;
   width: 90%;
 }
 
@@ -113,7 +115,7 @@
   @include box;
   margin-top: 0px;
   margin-bottom: 0px;
-  height: 8%;
+  height: 52px;
   background: var(--box-light);
 }
 
@@ -121,7 +123,7 @@
   @include box;
   margin-top: 0px;
   margin-bottom: 0px;
-  height: 8%;
+  height: 52px;
   background: var(--box-dark);
 }
 

--- a/explorer/homepage/components/homepage/index.tsx
+++ b/explorer/homepage/components/homepage/index.tsx
@@ -87,6 +87,10 @@ export default function HomePage(props: HomePageProps) {
   }
 
   const navigatorHeight = 48 + safeArea.bottom;
+  const horizontalSafeArea = safeArea.left + safeArea.right;
+  const isDesktop =
+    lynx.__globalProps.platform === 'macos' ||
+    lynx.__globalProps.platform === 'windows';
 
   return (
     <scroll-view
@@ -95,115 +99,120 @@ export default function HomePage(props: HomePageProps) {
       style={{ height: `calc(100% - ${navigatorHeight}px)` }}
     >
       <view
-        className="page-header"
-        style={{ marginTop: `${Math.max(safeArea.top, 10)}px` }}
-      >
-        <image src={getIcon('Explorer')} className="logo" mode="aspectFit" />
-        <text className={withTheme('home-title')}>Lynx Explorer</text>
-        <view className="scan">
-          {(() => {
-            if (SystemInfo.platform === 'iOS') {
-              return <></>;
-            }
-            return (
-              <image
-                src={getIcon('Scan')}
-                className="scan-icon"
-                bindtap={openScan}
-                accessibility-element={true}
-                accessibility-label="Open Scan"
-                accessibility-traits="button"
-              />
-            );
-          })()}
-        </view>
-      </view>
-
-      <view
-        className={withTheme('input-card-url')}
+        className="safe-area-content"
         style={{
-          height:
-            lynx.__globalProps.platform === 'macos' ||
-            lynx.__globalProps.platform === 'windows'
-              ? '40%'
-              : '28%',
+          marginLeft: `${safeArea.left}px`,
+          marginRight: `${safeArea.right}px`,
+          width: `calc(100% - ${horizontalSafeArea}px)`,
         }}
       >
-        <text className={withTheme('bold-text')}>Bundle URL</text>
-        <input
-          className={withTheme('input-box')}
-          bindinput={handleInput}
-          placeholder="Enter Bundle URL"
-          text-color={getTextColor()}
-        />
         <view
-          className={withTheme('connect-button')}
-          bindtap={openSchemaHandler}
-          accessibility-element={true}
-          accessibility-label="Open Schema"
-          accessibility-traits="button"
+          className="page-header"
+          style={{ marginTop: `${Math.max(safeArea.top, 10)}px` }}
         >
-          <text
-            style="line-height: 22px; color: #ffffff; font-size: 16px"
-            accessibility-element={false}
+          <image src={getIcon('Explorer')} className="logo" mode="aspectFit" />
+          <text className={withTheme('home-title')}>Lynx Explorer</text>
+          <view className="scan">
+            {(() => {
+              if (SystemInfo.platform === 'iOS') {
+                return <></>;
+              }
+              return (
+                <image
+                  src={getIcon('Scan')}
+                  className="scan-icon"
+                  bindtap={openScan}
+                  accessibility-element={true}
+                  accessibility-label="Open Scan"
+                  accessibility-traits="button"
+                />
+              );
+            })()}
+          </view>
+        </view>
+
+        <view
+          className={withTheme('input-card-url')}
+          style={{
+            height: isDesktop ? '40%' : '148px',
+          }}
+        >
+          <text className={withTheme('bold-text')}>Bundle URL</text>
+          <input
+            className={withTheme('input-box')}
+            bindinput={handleInput}
+            placeholder="Enter Bundle URL"
+            text-color={getTextColor()}
+          />
+          <view
+            className={withTheme('connect-button')}
+            bindtap={openSchemaHandler}
+            accessibility-element={true}
+            accessibility-label="Open Schema"
+            accessibility-traits="button"
           >
-            Go
-          </text>
-        </view>
-      </view>
-
-      <view
-        className={withTheme('showcase')}
-        bindtap={openShowcasePage}
-        accessibility-element={true}
-        accessibility-label="Open Show Cases"
-        accessibility-traits="button"
-      >
-        <image src={ShowcaseIcon} className="showcase-icon" />
-        <text className={withTheme('text')} accessibility-element={false}>
-          Showcase
-        </text>
-        <view style="margin: auto 5% auto auto; justify-content: center">
-          <image src={getIcon('Forward')} className="forward-icon" />
-        </view>
-      </view>
-
-      {recentUrls.length > 0 && (
-        <view className={withTheme('recent-panel')}>
-          <view className="recent-header">
-            <text className={withTheme('recent-title')}>Recently Opened</text>
             <text
-              className={withTheme('recent-clear')}
-              bindtap={handleClearRecent}
-              accessibility-element={true}
-              accessibility-label="Clear recent history"
-              accessibility-traits="button"
+              style="line-height: 22px; color: #ffffff; font-size: 16px"
+              accessibility-element={false}
             >
-              Clear
+              Go
             </text>
           </view>
-          {recentUrls.map((url) => (
-            <view
-              key={url}
-              className={withTheme('recent-item')}
-              bindtap={() => handleOpenRecent(url)}
-              accessibility-element={true}
-              accessibility-label={`Open ${url}`}
-              accessibility-traits="button"
-            >
-              <text
-                className={withTheme('recent-url')}
-                accessibility-element={false}
-              >
-                {url}
-              </text>
-              <view style="margin: auto 5% auto auto; justify-content: center">
-                <image src={getIcon('Forward')} className="forward-icon" />
-              </view>
-            </view>
-          ))}
         </view>
-      )}
+
+        <view
+          className={withTheme('showcase')}
+          bindtap={openShowcasePage}
+          accessibility-element={true}
+          accessibility-label="Open Show Cases"
+          accessibility-traits="button"
+        >
+          <image src={ShowcaseIcon} className="showcase-icon" />
+          <text className={withTheme('text')} accessibility-element={false}>
+            Showcase
+          </text>
+          <view style="margin: auto 5% auto auto; justify-content: center">
+            <image src={getIcon('Forward')} className="forward-icon" />
+          </view>
+        </view>
+
+        {recentUrls.length > 0 && (
+          <view className={withTheme('recent-panel')}>
+            <view className="recent-header">
+              <text className={withTheme('recent-title')}>Recently Opened</text>
+              <text
+                className={withTheme('recent-clear')}
+                bindtap={handleClearRecent}
+                accessibility-element={true}
+                accessibility-label="Clear recent history"
+                accessibility-traits="button"
+              >
+                Clear
+              </text>
+            </view>
+            {recentUrls.map((url) => (
+              <view
+                key={url}
+                className={withTheme('recent-item')}
+                bindtap={() => handleOpenRecent(url)}
+                accessibility-element={true}
+                accessibility-label={`Open ${url}`}
+                accessibility-traits="button"
+              >
+                <text
+                  className={withTheme('recent-url')}
+                  accessibility-element={false}
+                >
+                  {url}
+                </text>
+                <view style="margin: auto 5% auto auto; justify-content: center">
+                  <image src={getIcon('Forward')} className="forward-icon" />
+                </view>
+              </view>
+            ))}
+          </view>
+        )}
+      </view>
     </scroll-view>
   );
 }

--- a/explorer/homepage/components/settingspage/index.scss
+++ b/explorer/homepage/components/settingspage/index.scss
@@ -2,27 +2,27 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-@import "../shared";
+@import '../shared';
 
 .theme__dark {
   @include box;
   flex-direction: column;
-  margin-bottom: 3%;
-  height: 18%;
+  margin-bottom: 12px;
+  height: 132px;
   background: var(--box-dark);
 }
 
 .theme__light {
   @include box;
   flex-direction: column;
-  margin-bottom: 3%;
-  height: 18%;
+  margin-bottom: 12px;
+  height: 132px;
   background: var(--box-light);
 }
 
 .option-item {
   display: flex;
-  height: 33%;
+  height: 44px;
 }
 
 .option-icon {
@@ -86,14 +86,14 @@
 
 .devtool__light {
   @include box;
-  height: 8%;
+  height: 48px;
   justify-content: center;
   background: var(--box-light);
 }
 
 .devtool__dark {
   @include box;
-  height: 8%;
+  height: 48px;
   justify-content: center;
   background: var(--box-dark);
 }
@@ -101,20 +101,34 @@
 .info-section__light {
   @include box;
   flex-direction: column;
-  padding: 4% 0;
+  margin-bottom: 16px;
+  padding: 8px 0;
   background: var(--box-light);
 }
 
 .info-section__dark {
   @include box;
   flex-direction: column;
-  padding: 4% 0;
+  margin-bottom: 16px;
+  padding: 8px 0;
   background: var(--box-dark);
 }
 
 .info-row {
   display: flex;
   height: 40px;
+}
+
+.settings-columns {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+}
+
+.settings-column {
+  display: flex;
+  flex-direction: column;
+  width: 50%;
 }
 
 .info-value__light {

--- a/explorer/homepage/components/settingspage/index.tsx
+++ b/explorer/homepage/components/settingspage/index.tsx
@@ -60,29 +60,42 @@ export default function SettingsPage(props: SettingsPageProps) {
   }
 
   const navigatorHeight = 48 + safeArea.bottom;
+  const horizontalSafeArea = safeArea.left + safeArea.right;
+  const screenWidth = Number(lynx.__globalProps.screenWidth || 0);
+  const screenHeight = Number(lynx.__globalProps.screenHeight || 0);
+  const isLandscape =
+    screenWidth > 0 && screenHeight > 0 && screenWidth > screenHeight;
+  const labelStyle = 'margin: 0px 5% 0px 5%; height: 20px';
+  const labelWithGapStyle = `margin: ${
+    isLandscape ? 8 : 16
+  }px 5% 0px 5%; height: ${isLandscape ? 20 : 24}px`;
+  const optionItemStyle = { height: isLandscape ? '34px' : '44px' };
+  const themeStyle = { height: isLandscape ? '102px' : '132px' };
+  const rowCardStyle = { height: isLandscape ? '38px' : '48px' };
+  const renderCardStyle = {
+    height: isLandscape ? '38px' : '48px',
+    justifyContent: 'center',
+  };
+  const infoSectionStyle = {
+    marginBottom: isLandscape ? '0px' : '16px',
+    padding: isLandscape ? '4px 0' : '8px 0',
+  };
+  const infoRowStyle = { height: isLandscape ? '32px' : '40px' };
 
-  return (
-    <view
-      clip-radius="true"
-      className={withTheme('page')}
-      style={{ height: `calc(100% - ${navigatorHeight}px)` }}
-    >
+  const renderThemeSection = () => (
+    <>
       <view
-        className="page-header"
-        style={{ marginTop: `${Math.max(safeArea.top, 10)}px` }}
+        style={isLandscape ? labelStyle : 'margin: 0px 5% 0px 5%; height: 24px'}
       >
-        <text className={withTheme('title')}>Settings</text>
-      </view>
-
-      <view style="margin: 0px 5% 0px 5%; height: 5%">
         <text className={withTheme('sub-title')}>Theme</text>
       </view>
-      <view className={withTheme('theme')}>
+      <view className={withTheme('theme')} style={themeStyle}>
         {THEMES.map((theme) => {
           return (
             <view
               key={theme}
               className="option-item"
+              style={optionItemStyle}
               bindtap={() => setPreference(theme)}
               accessibility-element={true}
               accessibility-label={`Set Theme ${theme}`}
@@ -110,12 +123,17 @@ export default function SettingsPage(props: SettingsPageProps) {
           );
         })}
       </view>
+    </>
+  );
 
-      <view style="margin: 3% 5% 0px 5%; height: 5%">
+  const renderDevToolSection = () => (
+    <>
+      <view style={labelWithGapStyle}>
         <text className={withTheme('sub-title')}>DevTool</text>
       </view>
       <view
         className={withTheme('devtool')}
+        style={rowCardStyle}
         bindtap={openDevtoolSwitchPage}
         accessibility-element={true}
         accessibility-label="Lynx DevTool Switches"
@@ -128,16 +146,18 @@ export default function SettingsPage(props: SettingsPageProps) {
           <image src={getIcon('Forward')} className="forward-icon" />
         </view>
       </view>
+    </>
+  );
 
-      <view style="margin: 3% 5% 0px 5%; height: 5%">
+  const renderStrategySection = () => (
+    <>
+      <view style={isLandscape ? labelStyle : labelWithGapStyle}>
         <text className={withTheme('sub-title')}>Render Strategy</text>
       </view>
-      <view
-        className={withTheme('theme')}
-        style="height: 8%;justify-content:center"
-      >
+      <view className={withTheme('theme')} style={renderCardStyle}>
         <view
           className="option-item"
+          style={optionItemStyle}
           bindtap={() => {
             NativeModules.ExplorerModule.setThreadMode(
               !listAsyncRender ? 1 : 0
@@ -166,18 +186,22 @@ export default function SettingsPage(props: SettingsPageProps) {
           </view>
         </view>
       </view>
+    </>
+  );
 
-      <view style="margin: 3% 5% 0px 5%; height: 5%">
+  const renderSystemInfoSection = () => (
+    <>
+      <view style={labelWithGapStyle}>
         <text className={withTheme('sub-title')}>System Info</text>
       </view>
-      <view className={withTheme('info-section')}>
-        <view className="info-row">
+      <view className={withTheme('info-section')} style={infoSectionStyle}>
+        <view className="info-row" style={infoRowStyle}>
           <text className={withTheme('text')}>Lynx Engine</text>
           <text className={withTheme('info-value')}>
             {SystemInfo.engineVersion}
           </text>
         </view>
-        <view className="info-row">
+        <view className="info-row" style={infoRowStyle}>
           <text className={withTheme('text')}>Sparkling</text>
           <text
             className={`${withTheme('info-value')} ${
@@ -188,6 +212,52 @@ export default function SettingsPage(props: SettingsPageProps) {
           </text>
         </view>
       </view>
-    </view>
+    </>
+  );
+
+  return (
+    <scroll-view
+      scroll-y
+      clip-radius="true"
+      className={withTheme('page')}
+      style={{ height: `calc(100% - ${navigatorHeight}px)` }}
+    >
+      <view
+        className="safe-area-content"
+        style={{
+          marginLeft: `${safeArea.left}px`,
+          marginRight: `${safeArea.right}px`,
+          width: `calc(100% - ${horizontalSafeArea}px)`,
+        }}
+      >
+        <view
+          className="page-header"
+          style={{ marginTop: `${Math.max(safeArea.top, 10)}px` }}
+        >
+          <text className={withTheme('title')}>Settings</text>
+        </view>
+
+        {isLandscape ? (
+          <view className="settings-columns">
+            <view className="settings-column">
+              {renderThemeSection()}
+              {renderDevToolSection()}
+            </view>
+            <view className="settings-column">
+              {renderStrategySection()}
+              {renderSystemInfoSection()}
+            </view>
+          </view>
+        ) : (
+          <>
+            {renderThemeSection()}
+            {renderDevToolSection()}
+            {renderStrategySection()}
+            {renderSystemInfoSection()}
+          </>
+        )}
+        <view style={{ height: `${navigatorHeight}px` }} />
+      </view>
+    </scroll-view>
   );
 }

--- a/explorer/homepage/components/shared.scss
+++ b/explorer/homepage/components/shared.scss
@@ -64,10 +64,16 @@
 
 .page-header {
   display: flex;
+  align-items: center;
   margin-left: 5%;
-  padding-top: 4%;
+  margin-bottom: 6px;
   width: 90%;
-  height: 10%;
+  height: 40px;
+}
+
+.safe-area-content {
+  display: flex;
+  flex-direction: column;
 }
 
 .title__dark {

--- a/explorer/homepage/index.tsx
+++ b/explorer/homepage/index.tsx
@@ -10,7 +10,9 @@ import Navigator from '@components/navigator';
 import SettingsPage from '@components/settingspage';
 
 export default function Explorer() {
-  const [page, setPage] = useState<'home' | 'settings'>('home');
+  const initialPage =
+    lynx.__globalProps.initialPage === 'settings' ? 'settings' : 'home';
+  const [page, setPage] = useState<'home' | 'settings'>(initialPage);
 
   return (
     <AppContextProvider>

--- a/explorer/homepage/typing.d.ts
+++ b/explorer/homepage/typing.d.ts
@@ -45,8 +45,12 @@ declare module '@lynx-js/types' {
     frontendTheme?: string;
     theme: string;
     isNotchScreen: boolean;
+    screenHeight?: number;
+    screenWidth?: number;
     safeAreaTop?: number;
     safeAreaBottom?: number;
+    safeAreaLeft?: number;
+    safeAreaRight?: number;
   }
 
   interface IntrinsicElements extends Lynx.IntrinsicElements {

--- a/explorer/lib/context.tsx
+++ b/explorer/lib/context.tsx
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { createContext, useContext, useState } from '@lynx-js/react';
+import { createContext, useContext, useEffect, useState } from '@lynx-js/react';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,6 +25,8 @@ export interface ThemeContext {
 export interface SafeAreaContext {
   top: number;
   bottom: number;
+  left: number;
+  right: number;
 }
 
 interface AppContextValue {
@@ -79,10 +81,57 @@ export function AppContextProvider(props: { children: any }) {
       ? `${className}__dark`
       : `${className} ${className}__light`;
 
-  const safeArea: SafeAreaContext = {
-    top: lynx.__globalProps.safeAreaTop || 0,
-    bottom: lynx.__globalProps.safeAreaBottom || 0,
+  const getSafeArea = (): SafeAreaContext => {
+    const screenWidth = Number(lynx.__globalProps.screenWidth || 0);
+    const screenHeight = Number(lynx.__globalProps.screenHeight || 0);
+    const isPortrait =
+      screenWidth > 0 && screenHeight > 0 ? screenHeight >= screenWidth : true;
+    const isIOS = SystemInfo.platform === 'iOS';
+    const isNotchScreen =
+      lynx.__globalProps.isNotchScreen ||
+      (lynx.__globalProps.safeAreaTop || 0) > 20 ||
+      (lynx.__globalProps.safeAreaBottom || 0) > 0 ||
+      (lynx.__globalProps.safeAreaLeft || 0) > 0 ||
+      (lynx.__globalProps.safeAreaRight || 0) > 0;
+    const portraitTopFallback = isNotchScreen ? 54 : 20;
+    const portraitBottomFallback = isNotchScreen ? 34 : 0;
+    const landscapeSideFallback = isIOS ? 54 : 0;
+    return {
+      top: Math.max(
+        lynx.__globalProps.safeAreaTop || 0,
+        isPortrait ? portraitTopFallback : 0
+      ),
+      bottom: Math.max(
+        lynx.__globalProps.safeAreaBottom || 0,
+        isPortrait ? portraitBottomFallback : 0
+      ),
+      left: Math.max(
+        lynx.__globalProps.safeAreaLeft || 0,
+        isPortrait ? 0 : landscapeSideFallback
+      ),
+      right: Math.max(
+        lynx.__globalProps.safeAreaRight || 0,
+        isPortrait ? 0 : landscapeSideFallback
+      ),
+    };
   };
+  const [safeArea, setSafeArea] = useState<SafeAreaContext>(getSafeArea);
+
+  useEffect(() => {
+    const syncSafeArea = (data?: Record<string, unknown>) => {
+      Object.assign(lynx.__globalProps, data || {});
+      setSafeArea(getSafeArea());
+    };
+    const listener = (event: { data?: Record<string, unknown> }) => {
+      syncSafeArea(event.data);
+    };
+    const coreContext = lynx.getCoreContext();
+    coreContext.addEventListener('__NotifyGlobalPropsUpdated', listener);
+    syncSafeArea();
+    return () => {
+      coreContext.removeEventListener('__NotifyGlobalPropsUpdated', listener);
+    };
+  }, []);
 
   return (
     <AppContext.Provider


### PR DESCRIPTION
## Summary

Fix iOS Lynx Explorer orientation handling so the default homepage can rotate, while preserving explicit `orientation=portrait` and `orientation=landscape` restrictions for pages that request them.

Original issue: https://github.com/lynx-family/lynx/issues/7372

## Root Cause

The default Explorer homepage URL forced `orientation=portrait`, and `LynxViewShellViewController` disabled autorotation. The shell also kept the initial LynxView frame, viewport, screen metrics, and safe-area global props after bounds changed, so rotated devices did not propagate the new size or safe-area values into Lynx.

## Changes

- Remove the default homepage portrait lock.
- Allow the Explorer shell to autorotate by default, while keeping explicit orientation query restrictions intact.
- Recompute LynxView frame, viewport, screen metrics, and safe-area global props during layout.
- Update homepage/settings layouts to use stable dimensions, scrolling, and safe-area-aware content insets for portrait and landscape.
- Update the devtool switch page to respect the same iOS safe-area props/fallbacks.

## Validation

- `git diff --check`
- `git_lynx.py check --changed --verbose`
- `pnpm --filter homepage build`
- `pnpm --dir devtool/lynx_devtool/resources/devtool-switch build`
- `xcodebuild -quiet -workspace explorer/darwin/ios/lynx_explorer/LynxExplorer.xcworkspace -scheme LynxExplorer -configuration Debug -destination 'platform=iOS Simulator,id=30909DDB-22EA-4245-ACBA-ACDEDAE8C2C3' build`
- `xcodebuild -quiet -workspace explorer/darwin/ios/lynx_explorer/LynxExplorer.xcworkspace -scheme LynxExplorerTests -configuration Debug -destination 'platform=iOS Simulator,id=30909DDB-22EA-4245-ACBA-ACDEDAE8C2C3' test`
- Runtime checked Explorer home/settings in portrait and landscape on iPhone 16 Pro iOS 18.5 simulator.

Screenshots and videos are provided in the PR comments for before/after portrait and landscape comparison.
