### PR TITLE
[BugFix][Explorer] Allow Android Explorer homepage rotation

### DIFF
--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -54,7 +54,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
   private static final String URL_PREFIX = "file://lynx?local://";
   private static final String TAG = "LynxViewShellActivity";
   private static final String HOME_PAGE_URL =
-      "file://lynx?local://homepage.lynx.bundle?fullscreen=true&orientation=portrait";
+      "file://lynx?local://homepage.lynx.bundle?fullscreen=true";
   private static final String DEFAULT_TOP_BAR_COLOR = "#F0F2F5";
   private static final String DEFAULT_TOP_BAR_TITLE_COLOR = "#000000";
   private static final String DEFAULT_TOP_BAR_BACK_BUTTON_STYLE = "light";


### PR DESCRIPTION
## Summary

Allow the Android Lynx Explorer default homepage to follow device/emulator rotation instead of forcing portrait. Explicit `orientation=` URLs still keep the existing requested-orientation behavior.

Original issue: https://github.com/lynx-family/lynx/issues/7372

## Root Cause

The Android Explorer default homepage URL appended `orientation=portrait`. During launch, `LynxViewShellActivity` parses that query and calls `setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT)`, so the default homepage stayed locked to a portrait viewport even when the emulator/device was rotated to landscape.

## Changes

- Remove the default homepage `orientation=portrait` query from Android Explorer.
- Preserve explicit `orientation=portrait`, `orientation=landscape`, and `orientation=sensor` handling for pages that request it.

## Validation

- `git diff --check`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home ./gradlew :LynxExplorer:assembleWithoutSparklingNoasanDebug --no-daemon`
- Installed `LynxExplorer-withoutSparkling-noasan-debug.apk` onto Android emulator `emulator-5556`.
- Runtime checked Android Explorer home, Showcase, and Settings in portrait and landscape.
- Runtime checked iOS Explorer home and Showcase in portrait and landscape as a regression check; no iOS code changes.

Screenshots and videos for original and fixed portrait/landscape rendering will be added in PR comments.