### PR TITLE
[Infra][Release] Publish nightly release weekly

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,7 +20,7 @@ on:
         type: string
 
   schedule:
-    - cron: '0 22 * * *'
+    - cron: '0 22 * * 0'
 
   release:
     types: [published]


### PR DESCRIPTION
## Summary
- Change the scheduled publish-release trigger from daily to weekly.
- Keep the existing 22:00 UTC trigger time, so the scheduled nightly release runs at 06:00 Asia/Shanghai every Monday.

## Validation
- git diff --check