### PR TITLE
[Infra] Bundle Android SDK release artifacts into one ZIP file to upload.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,13 +454,13 @@ jobs:
       - name: Collect and zip artifacts
         run: |
           cd $GITHUB_WORKSPACE/lynx/platform/android
-          ./gradlew zipAllArtifacts
+          ./gradlew zipArtifacts -Pversion=0.0.1-alpha.1
       - name: upload zip artifact
         uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
         continue-on-error: true
         with:
           name: android-sdk-release
-          path: '${{ github.workspace }}/lynx/platform/android/build/artifacts-collection.zip'
+          path: '${{ github.workspace }}/lynx/platform/android/build/lynx-android-sdk-0.0.1-alpha.1.zip'
 
   android-e2e-test:
     timeout-minutes: 60
@@ -655,15 +655,15 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: lynx-family/integrating-lynx-demo-projects
-          ref: b106f7f21d5221acfed645f4afa9d829a1cc0cc2
+          ref: eedde50f700c0f7b2693c79b73c0d1b918d4f53f
           path: lynx
       - name: Cherry Pick Commit To Build With Local AAR
         run: |
           echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git fetch origin 12858f5a4f51454057f738f0b1d2bb001986dc91
-          git cherry-pick 12858f5a4f51454057f738f0b1d2bb001986dc91
+          git fetch origin 10e19c5c9dbbadc9960c1677dac6884a8a3f63c9
+          git cherry-pick 10e19c5c9dbbadc9960c1677dac6884a8a3f63c9
       - name: Download Lynx SDK Artifacts
         uses: lynx-infra/download-artifact@79d9914484f933089c2840552cf439bac85debad
         with:
@@ -693,8 +693,7 @@ jobs:
         run: |
           set -e
           pushd android/JavaEmptyProject/
-          python3 shell/prepare_package_with_local_aar.py $GITHUB_WORKSPACE/lynx/artifacts-collection.zip 0.0.1-alpha.1
-          ./gradlew publishAllZips
+          python3 shell/prepare_package_with_local_aar.py $GITHUB_WORKSPACE/lynx/lynx-android-sdk-0.0.1-alpha.1.zip 0.0.1-alpha.1
           ./gradlew :app:assembleDebug
           popd
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -269,7 +269,9 @@ jobs:
         run: |-
           cd $GITHUB_WORKSPACE/lynx
           pushd platform/android
-          ./gradlew zipArtifacts -Pversion=${{ needs.get-version.outputs.version }} getArtifactList
+          ./gradlew zipArtifacts -Pversion=${{ needs.get-version.outputs.version }}
+          ./gradlew zipDevArtifacts -Pversion=${{ needs.get-version.outputs.version }}-dev
+          ./gradlew getArtifactList -Pversion=${{ needs.get-version.outputs.version }}
           popd
           pushd platform/android/build
           artifact_list=$(<artifact-list)

--- a/.github/workflows/sdk-release-test.yml
+++ b/.github/workflows/sdk-release-test.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Collect and zip artifacts
         run: |
           cd $GITHUB_WORKSPACE/lynx/platform/android
-          ./gradlew zipAllArtifacts
+          ./gradlew zipArtifacts -Pversion=0.0.1-alpha.1
+          ./gradlew zipDevArtifacts -Pversion=0.0.1-alpha.1-dev
+          ./gradlew getArtifactList -Pversion=0.0.1-alpha.1
 
   ios-sdk-release-test:
     timeout-minutes: 15

--- a/platform/android/package.gradle
+++ b/platform/android/package.gradle
@@ -8,6 +8,46 @@ buildscript {
     }
 }
 
+def getPublishRepositoryVersionDir = { String version ->
+    file("$rootProject.buildDir/release/${version}")
+}
+
+def getModulePublishDir = { Project subproject, String version ->
+    def artifactGroup = subproject.findProperty("ARTIFACT_GROUP")
+    def artifactName = subproject.findProperty("ARTIFACT_NAME")
+    if (!artifactGroup || !artifactName) {
+        throw new GradleException("Missing ARTIFACT_GROUP or ARTIFACT_NAME for ${subproject.path}")
+    }
+    def groupPath = artifactGroup.replace('.', '/')
+    file("${getPublishRepositoryVersionDir(version)}/${groupPath}/${artifactName}/${version}")
+}
+
+def hasDevPublishModules = {
+    rootProject.subprojects.any { subproject ->
+        subproject.plugins.hasPlugin("maven-publish") &&
+                subproject.plugins.hasPlugin('com.android.library') &&
+                subproject.android.productFlavors.any { it.name == "dev" }
+    }
+}
+
+def zipPublishedRepository = { String version, File zipFile ->
+    def artifactPath = getPublishRepositoryVersionDir(version)
+    if (!artifactPath.exists()) {
+        throw new GradleException("No published artifacts found in ${artifactPath}. Please publish artifacts before zipping.")
+    }
+    ant.zip(destfile: zipFile, basedir: artifactPath)
+    return zipFile.absolutePath
+}
+
+def collectArtifactList = { String version ->
+    def artifacts = []
+    def artifactZip = file("${project.buildDir}/lynx-android-sdk-${version}.zip")
+    if (artifactZip.exists()) {
+        artifacts.add(artifactZip.absolutePath)
+    }
+    return artifacts
+}
+
 task assembleAllModulesRelease {
     rootProject.afterEvaluate {
         rootProject.subprojects.each { subproject ->
@@ -66,31 +106,30 @@ task publishAllModulesDevRelease {
     }
 }
 
-def artifactList = []
-
 task zipArtifacts {
     doLast {
         def version = findProperty("version")
-        def artifactPath
-        rootProject.subprojects.each { subproject ->
-            if(subproject.plugins.hasPlugin("maven-publish")) {
-                ant.zip(destfile: file("${project.buildDir}/${subproject.ARTIFACT_NAME}-${version}.zip"),
-                        basedir: "${subproject.buildDir}/release/${version}")
-                artifactList.add("${project.buildDir}/${subproject.ARTIFACT_NAME}-${version}.zip")
-                if(subproject.plugins.hasPlugin('com.android.library') && subproject.android.productFlavors.any { it.name == "dev" }) {
-                    def devVersion = "${version}-dev"
-                    ant.zip(destfile: file("${project.buildDir}/${subproject.ARTIFACT_NAME}-${devVersion}.zip"),
-                            basedir: "${subproject.buildDir}/release/${devVersion}")
-                    artifactList.add("${project.buildDir}/${subproject.ARTIFACT_NAME}-${devVersion}.zip")
-                }
-            }
+        def zipFile = file("${project.buildDir}/lynx-android-sdk-${version}.zip")
+        zipPublishedRepository(version, zipFile)
+    }
+}
+
+task zipDevArtifacts {
+    doLast {
+        def version = findProperty("version")
+        if (!hasDevPublishModules()) {
+            throw new GradleException("No dev publishable modules found.")
         }
+        def zipFile = file("${project.buildDir}/lynx-android-sdk-${version}.zip")
+        zipPublishedRepository(version, zipFile)
     }
 }
 
 task getArtifactList {
-    dependsOn(zipArtifacts)
     doLast {
+        def version = findProperty("version")
+        def artifactList = collectArtifactList(version)
+        artifactList.addAll(collectArtifactList("${version}-dev"))
         println "artifactInfo: ${artifactList}"
         def json = new groovy.json.JsonBuilder(artifactList).toString()
         File file = new File("${project.buildDir}/artifact-list")
@@ -111,8 +150,8 @@ task zipAllArtifacts {
 
         rootProject.subprojects.each { subproject ->
             if(subproject.plugins.hasPlugin("maven-publish")) {
-                def artifactPath = "${subproject.buildDir}/release"
                 def version = findProperty("version")
+                def artifactPath = getModulePublishDir(subproject, version)
                 def zipPath = file("${project.buildDir}/${subproject.ARTIFACT_NAME}-${version}.zip")
                 ant.zip(destfile: zipPath, basedir: artifactPath)
                 copy {

--- a/platform/android/publish.gradle
+++ b/platform/android/publish.gradle
@@ -27,6 +27,13 @@ def getAARPath(buildPath, boolean isDev = false) {
     return fileTree.files[0]
 }
 
+def getPublishRepositoryBaseDir = {
+    rootProject.file("${rootProject.buildDir}/release")
+}
+def getPublishRepositoryVersionDir = { String version ->
+    rootProject.file("${rootProject.buildDir}/release/${version}")
+}
+
 boolean isJavaModule() {
     boolean result = ((project.plugins.hasPlugin('java-library')
             || project.plugins.hasPlugin('java'))
@@ -264,14 +271,14 @@ afterEvaluate {
             }
             repositories {
                 maven {
-                    url = "$project.buildDir/release"
+                    url = getPublishRepositoryBaseDir()
                 }
             }
         }
     }
     tasks.withType(PublishToMavenRepository) { task ->
         task.doFirst {
-            repository.url = "$project.buildDir/release/${publication.version}"
+            repository.url = getPublishRepositoryVersionDir(publication.version.toString())
         }
     }
 }


### PR DESCRIPTION
…oad.

Package the published artifacts of the Android SDK into a single ZIP when uploading to maven central.

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
