### PR TITLE
[Feature][DynamicLib] Add Lynx dynamic library release with clay backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,6 +329,36 @@ jobs:
         run: |
           tools/env.sh pnpm --filter @lynx-js/node-lynx run test
 
+  dynamic-lib-linux-amd64-build:
+    runs-on: lynx-ubuntu-22.04-large
+    timeout-minutes: 60
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+      - name: Python Setup
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+        with:
+          target: clay
+      - name: Build Linux dynamic library SDK
+        run: |
+          source tools/envsetup.sh
+          python3 platform/dynamic_lib/tools/build_release.py \
+            --platform linux \
+            --target-cpu x64
+      - name: upload artifact
+        uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+        with:
+          name: dynamic-lib-linux-amd64-build
+          path: |
+            ${{ github.workspace }}/lynx/out/Default/lynx_clay_sdk_linux_x64.zip
+            ${{ github.workspace }}/lynx/out/Default/lynx_clay_sdk_linux_x64.zip.sha256
+
   tasm-wasm-build:
     needs: [darwin-impact-check]
     if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
@@ -1000,6 +1030,34 @@ jobs:
         with:
           name: clay_glfw
           path: '${{ github.workspace }}/lynx/out/Default/clay_glfw'
+
+  dynamic-lib-darwin-aarch64-build:
+    needs: [darwin-impact-check]
+    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+    timeout-minutes: 60
+    runs-on: lynx-darwin-15.6.1-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+        with:
+          target: clay
+      - name: Build Darwin dynamic library SDK
+        run: |
+          source tools/envsetup.sh
+          python3 platform/dynamic_lib/tools/build_release.py \
+            --platform macos \
+            --target-cpu arm64
+      - name: upload artifact
+        uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+        with:
+          name: dynamic-lib-darwin-aarch64-build
+          path: |
+            ${{ github.workspace }}/lynx/out/Default/lynx_clay_sdk_macos_arm64.zip
+            ${{ github.workspace }}/lynx/out/Default/lynx_clay_sdk_macos_arm64.zip.sha256
 
   macos-explorer-build:
     needs: [darwin-impact-check]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -552,6 +552,54 @@ jobs:
           allowUpdates: true
           body: ''
 
+  dynamic-lib-release:
+    timeout-minutes: 60
+    needs: get-version
+    if: ${{ !contains(needs.get-version.outputs.version, '-nightly.') }}
+    strategy:
+      matrix:
+        include:
+          - platform: macos
+            arch: arm64
+            runner: lynx-darwin-15.6.1-medium
+            artifact: lynx_clay_sdk_macos_arm64.zip
+          - platform: linux
+            arch: x64
+            runner: lynx-ubuntu-22.04-large
+            artifact: lynx_clay_sdk_linux_x64.zip
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+          ref: ${{ needs.get-version.outputs.checkout_ref }}
+          fetch-depth: 0
+      - name: Python Setup
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+        with:
+          cache-backend: github
+          target: clay
+      - name: Build dynamic library SDK
+        run: |-
+          cd $GITHUB_WORKSPACE/lynx
+          source tools/envsetup.sh
+          python3 platform/dynamic_lib/tools/build_release.py \
+            --platform ${{ matrix.platform }} \
+            --target-cpu ${{ matrix.arch }}
+      - name: push dynamic library SDK to release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ needs.get-version.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: '${{ github.workspace }}/lynx/out/Default/${{ matrix.artifact }},${{ github.workspace }}/lynx/out/Default/${{ matrix.artifact }}.sha256'
+          allowUpdates: true
+          body: ''
+
   windows-explorer-release:
     timeout-minutes: 60
     runs-on: lynx-windows-2022-large

--- a/platform/dynamic_lib/BUILD.gn
+++ b/platform/dynamic_lib/BUILD.gn
@@ -1,0 +1,9 @@
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+source_set("lynx_rust_capi") {
+  sources = [ "lynx_rust_capi.cc" ]
+
+  include_dirs = [ "../.." ]
+}

--- a/platform/dynamic_lib/README.md
+++ b/platform/dynamic_lib/README.md
@@ -1,0 +1,92 @@
+# Lynx Dynamic Library
+
+This directory owns the `libLynx_clay` dynamic library distribution targets.
+It keeps the platform-specific macOS/Linux packaging logic and the small C++
+wrapper layer together so external language bindings can move independently
+from this repository.
+
+## Layout
+
+- `BUILD.gn` builds the shared pure C ABI wrapper objects.
+- `lynx_rust_capi.cc` exports `lynx_rust_*` wrapper symbols for existing C++
+  CAPI functions that are not directly Rust-FFI friendly.
+- `macos/` builds and packages `libLynx_clay.dylib`.
+- `linux/` builds and packages `libLynx_clay.so`.
+
+The dynamic library exports both the existing `lynx_*` C APIs and the
+`lynx_rust_*` wrapper symbols from the same image. Consumers should not need a
+second shim library.
+
+## Build
+
+macOS:
+
+```sh
+gn gen out/Release --root-target=//platform/dynamic_lib/macos:package_sdk
+ninja -C out/Release platform/dynamic_lib/macos:package_sdk
+```
+
+Linux:
+
+```sh
+gn gen out/Release --root-target=//platform/dynamic_lib/linux:package_sdk
+ninja -C out/Release platform/dynamic_lib/linux:package_sdk
+```
+
+The package actions write:
+
+- `lynx_clay_sdk_macos_${target_cpu}.zip`
+- `lynx_clay_sdk_linux_${target_cpu}.zip`
+
+Each SDK package contains `lib/libLynx_clay.{dylib,so}`, public C API headers,
+and `data/icudtl.dat`. The `lynx_rust_*` wrapper symbols are exported from the
+library image, but this package does not ship a separate wrapper header; Rust
+bindings should keep their ABI declarations in the Rust-side repository. macOS
+packages also include Lynx resource bundles. Linux packages include optional
+resource bundles and `lynx_core.js` files when they are present in the build
+directory.
+
+## Runtime Loading
+
+External bindings should prefer an explicit library path:
+
+```sh
+export LYNX_LIB_PATH=/path/to/libLynx_clay.dylib
+export LYNX_LIB_PATH=/path/to/libLynx_clay.so
+```
+
+SDK-directory loading should look for:
+
+- `$LYNX_SDK_DIR/lib/libLynx_clay.dylib` on macOS
+- `$LYNX_SDK_DIR/lib/libLynx_clay.so` on Linux
+
+Local GN build directories are also usable when `libLynx_clay.{dylib,so}` sits
+directly under the build directory. Consumers that need ICU should also point
+Lynx at the packaged `data/icudtl.dat`.
+
+## Signing
+
+Linux shared objects do not require OS-level code signing. Release pipelines
+should publish checksums and downstream products should apply their normal
+supply-chain verification policy.
+
+macOS development builds can be ad-hoc signed for local runtime loading:
+
+```sh
+codesign --force --sign - libLynx_clay.dylib
+```
+
+Apps or command-line tools that redistribute `libLynx_clay.dylib` should sign
+and notarize the final product with their own Apple Team ID.
+
+## GitHub Release
+
+The `publish-release` workflow builds and uploads these dynamic library SDK
+packages to GitHub Releases:
+
+- `lynx_clay_sdk_macos_arm64.zip`
+- `lynx_clay_sdk_linux_x64.zip`
+
+Each package is uploaded with a matching `.sha256` checksum file.
+The workflow invokes `platform/dynamic_lib/tools/build_release.py` after the
+standard `common-deps` habitat setup.

--- a/platform/dynamic_lib/linux/BUILD.gn
+++ b/platform/dynamic_lib/linux/BUILD.gn
@@ -1,0 +1,53 @@
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import("../../../core/Lynx.gni")
+
+shared_library("lynx_clay_shared_library") {
+  output_name = "Lynx_clay"
+
+  sources = [
+    "../../../clay/lynx_adaptor/native_platform_view_mock.cc",
+    "../../../platform/embedder/lynx_ui_renderer_mock.cc",
+    "lynx_dynamic_lib_fallbacks.cc",
+  ]
+
+  deps = [
+    "..:lynx_rust_capi",
+    "../../../base/src:base_static",
+    "../../../clay/lynx_adaptor:lynx_adaptor",
+    "../../../clay/shell/platform/embedder:embedder",
+    "../../embedder:embedder",
+  ]
+  if (enable_napi_binding) {
+    deps += [
+      "../../../core/runtime/common/napi:napi_binding_quickjs",
+      "../../../third_party/napi:env",
+      "../../../third_party/napi:quickjs",
+      "../../../third_party/quickjs",
+    ]
+    if (jsengine_type == "v8") {
+      deps += [
+        "../../../core/runtime/common/napi:napi_binding_v8",
+        "../../../third_party/napi:v8",
+      ]
+    }
+  }
+
+  libs = [
+    "epoxy",
+    "rt",
+  ]
+}
+
+action("package_sdk") {
+  script = "package_sdk.py"
+  outputs = [ "$root_build_dir/lynx_clay_sdk_linux_${target_cpu}.zip" ]
+  args = [
+    rebase_path(outputs[0]),
+    rebase_path(root_build_dir),
+    rebase_path("../../../third_party/icu/flutter/icudtl.dat"),
+  ]
+  deps = [ ":lynx_clay_shared_library" ]
+}

--- a/platform/dynamic_lib/linux/lynx_dynamic_lib_fallbacks.cc
+++ b/platform/dynamic_lib/linux/lynx_dynamic_lib_fallbacks.cc
@@ -1,0 +1,57 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "core/runtime/js/bytecode/js_cache_manager.h"
+#include "core/services/event_report/event_tracker_platform_impl.h"
+#include "platform/embedder/resource/js_source_loader_desktop.h"
+
+namespace lynx {
+namespace runtime {
+namespace js {
+
+std::string JSSourceLoaderDesktop::LoadJSSource(const std::string& path) {
+  return "";
+}
+
+namespace cache {
+
+std::string JsCacheManager::GetPlatformCacheDir() { return "./"; }
+
+}  // namespace cache
+}  // namespace js
+}  // namespace runtime
+
+namespace tasm {
+namespace report {
+
+void EventTrackerPlatformImpl::OnEvent(int32_t instance_id,
+                                       MoveOnlyEvent&& event) {}
+
+void EventTrackerPlatformImpl::OnEvents(int32_t instance_id,
+                                        std::vector<MoveOnlyEvent> stack) {}
+
+void EventTrackerPlatformImpl::UpdateGenericInfo(
+    int32_t instance_id,
+    std::unordered_map<std::string, std::string> generic_info) {}
+
+void EventTrackerPlatformImpl::UpdateGenericInfo(
+    int32_t instance_id, std::unordered_map<std::string, float> generic_info) {}
+
+void EventTrackerPlatformImpl::UpdateGenericInfo(int32_t instance_id,
+                                                 const std::string& key,
+                                                 const std::string& value) {}
+
+void EventTrackerPlatformImpl::UpdateGenericInfo(int32_t instance_id,
+                                                 const std::string& key,
+                                                 int64_t value) {}
+
+void EventTrackerPlatformImpl::UpdateGenericInfo(int32_t instance_id,
+                                                 const std::string& key,
+                                                 const float value) {}
+
+void EventTrackerPlatformImpl::ClearCache(int32_t instance_id) {}
+
+}  // namespace report
+}  // namespace tasm
+}  // namespace lynx

--- a/platform/dynamic_lib/linux/package_sdk.py
+++ b/platform/dynamic_lib/linux/package_sdk.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import zipfile
+
+
+def _zip_dir(path, zip_file, prefix):
+  print(f"_zip_dir: {path}")
+  path = path.rstrip('/\\')
+  for root, directories, files in os.walk(path):
+    directories[:] = [
+        directory for directory in directories
+        if not os.path.islink(os.path.join(root, directory))
+    ]
+    for file in files:
+      full_path = os.path.join(root, file)
+      if os.path.islink(full_path):
+        continue
+      zip_file.write(full_path, os.path.join(root.replace(path, prefix), file))
+
+
+def _zip_file_if_exists(zip_file, path, archive_path):
+  if os.path.exists(path):
+    zip_file.write(path, archive_path)
+    return True
+  return False
+
+
+try:
+  destination_file = sys.argv[1]
+  root_build_dir = sys.argv[2]
+  icudtl = sys.argv[3]
+
+  print(f"destination_file: {destination_file}")
+  print(f"root_build_dir: {root_build_dir}")
+  print(f"icudtl: {icudtl}")
+
+  if os.path.exists(destination_file):
+    os.remove(destination_file)
+  if not os.path.exists(root_build_dir):
+    raise Exception(f"root_build_dir: {root_build_dir} does not exist")
+  if not os.path.exists(icudtl):
+    raise Exception(f"icudtl: {icudtl} does not exist")
+
+  include_dir = os.path.join(root_build_dir, 'include')
+  liblynx = os.path.join(root_build_dir, 'libLynx_clay.so')
+  liblynx_in_lib_dir = os.path.join(root_build_dir, 'lib', 'libLynx_clay.so')
+  if not os.path.isdir(include_dir):
+    raise Exception(f"include: {include_dir} is not a directory")
+  if not os.path.exists(liblynx) and os.path.exists(liblynx_in_lib_dir):
+    liblynx = liblynx_in_lib_dir
+  if not os.path.exists(liblynx):
+    raise Exception(
+        f"libLynx_clay.so: neither {liblynx} nor {liblynx_in_lib_dir} exists")
+
+  zip_file = zipfile.ZipFile(destination_file, 'w', zipfile.ZIP_DEFLATED)
+  _zip_dir(include_dir, zip_file, 'include')
+  zip_file.write(liblynx, 'lib/libLynx_clay.so')
+  zip_file.write(icudtl, 'data/icudtl.dat')
+
+  resource_bundles = os.path.join(root_build_dir, 'resource_bundles')
+  if os.path.isdir(resource_bundles):
+    _zip_dir(resource_bundles, zip_file, 'bundles')
+
+  _zip_file_if_exists(
+      zip_file, os.path.join(root_build_dir, 'lynx_core', 'lynx_core.js'),
+      'lynx_core.js')
+  _zip_file_if_exists(
+      zip_file, os.path.join(root_build_dir, 'lynx_core', 'lynx_core_dev.js'),
+      'lynx_core_dev.js')
+
+  zip_file.close()
+  print(f"Successfully packaged Linux Lynx clay SDK to {destination_file}")
+except Exception as e:
+  print(f"Failed to package Linux Lynx clay SDK: {e}")
+  sys.exit(1)

--- a/platform/dynamic_lib/lynx_rust_capi.cc
+++ b/platform/dynamic_lib/lynx_rust_capi.cc
@@ -1,0 +1,41 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "platform/embedder/public/capi/lynx_view_builder_capi.h"
+#include "platform/embedder/public/capi/lynx_view_capi.h"
+
+extern "C" __attribute__((visibility("default"))) void
+lynx_rust_view_builder_set_screen_size(lynx_view_builder_t* builder,
+                                       float width, float height,
+                                       float pixel_ratio) {
+  lynx_view_builder_set_screen_size(builder, width, height, pixel_ratio);
+}
+
+extern "C" __attribute__((visibility("default"))) void
+lynx_rust_view_builder_set_frame(lynx_view_builder_t* builder, float x, float y,
+                                 float width, float height) {
+  lynx_view_builder_set_frame(builder, x, y, width, height);
+}
+
+extern "C" __attribute__((visibility("default"))) void
+lynx_rust_view_builder_set_font_scale(lynx_view_builder_t* builder,
+                                      float scale) {
+  lynx_view_builder_set_font_scale(builder, scale);
+}
+
+extern "C" __attribute__((visibility("default"))) void
+lynx_rust_view_update_screen_metrics(lynx_view_t* view, float width,
+                                     float height, float pixel_ratio) {
+  lynx_view_update_screen_metrics(view, width, height, pixel_ratio);
+}
+
+extern "C" __attribute__((visibility("default"))) void lynx_rust_view_set_frame(
+    lynx_view_t* view, float x, float y, float width, float height) {
+  lynx_view_set_frame(view, x, y, width, height);
+}
+
+extern "C" __attribute__((visibility("default"))) void
+lynx_rust_view_set_font_scale(lynx_view_t* view, float font_scale) {
+  lynx_view_set_font_scale(view, font_scale);
+}

--- a/platform/dynamic_lib/macos/BUILD.gn
+++ b/platform/dynamic_lib/macos/BUILD.gn
@@ -1,0 +1,45 @@
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import("../../../core/Lynx.gni")
+
+shared_library("lynx_clay_shared_library") {
+  output_name = "Lynx_clay"
+
+  deps = [
+    "..:lynx_rust_capi",
+    "../../darwin/macos:lynx_common_deps",
+  ]
+  if (jsengine_type == "v8") {
+    deps += [ "../../../third_party/NativeScript:NativeScript" ]
+  }
+
+  ldflags = [
+    "-Wl,-install_name,@rpath/libLynx_clay.dylib",
+    "-Wl,-exported_symbols_list," +
+        rebase_path("exported_symbols.sym", root_build_dir),
+  ]
+
+  frameworks = [
+    "CoreData.framework",
+    "QuartzCore.framework",
+    "WebKit.framework",
+    "JavaScriptCore.framework",
+  ]
+}
+
+action("package_sdk") {
+  script = "package_sdk.py"
+  outputs = [ "$root_build_dir/lynx_clay_sdk_macos_${target_cpu}.zip" ]
+  args = [
+    rebase_path(outputs[0]),
+    rebase_path(root_build_dir),
+    rebase_path("../../../third_party/icu/flutter/icudtl.dat"),
+  ]
+  deps = [
+    ":lynx_clay_shared_library",
+    "../../darwin/macos:lynx_debug_resources_bundle",
+    "../../darwin/macos:lynx_resources_bundle",
+  ]
+}

--- a/platform/dynamic_lib/macos/exported_symbols.sym
+++ b/platform/dynamic_lib/macos/exported_symbols.sym
@@ -1,0 +1,31 @@
+# These symbols are looked up from within the executable at runtime and must
+# be exported in the dynamic symbol table.
+# CAPIs
+_lynx_env_*
+_lynx_value_*
+_lynx_view_*
+_lynx_group_*
+_lynx_load_meta_*
+_lynx_native_view_*
+_lynx_template_bundle_*
+_lynx_template_data_*
+_lynx_update_meta_*
+_lynx_resource_*
+_lynx_generic_resource_fetcher_*
+_lynx_runtime_lifecycle_observer_*
+_lynx_service_*
+_lynx_http_*
+_lynx_security_service_*
+_lynx_extension_module_*
+_lynx_vsync_observer_*
+_lynx_napi_*
+_lynx_event_reporter_service_*
+_lynx_free*
+_lynx_malloc*
+_lynx_strdup*
+_lynx_trace_*
+_lynx_log_write_detailed*
+_lynx_windowless_*
+_lynx_rust_*
+# weak-node-api symbols
+_napi*_weak

--- a/platform/dynamic_lib/macos/package_sdk.py
+++ b/platform/dynamic_lib/macos/package_sdk.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import zipfile
+
+
+def _zip_dir(path, zip_file, prefix):
+  print(f"_zip_dir: {path}")
+  path = path.rstrip('/\\')
+  for root, directories, files in os.walk(path):
+    directories[:] = [
+        directory for directory in directories
+        if not os.path.islink(os.path.join(root, directory))
+    ]
+    for file in files:
+      full_path = os.path.join(root, file)
+      if os.path.islink(full_path):
+        continue
+      zip_file.write(full_path, os.path.join(root.replace(path, prefix), file))
+
+
+try:
+  destination_file = sys.argv[1]
+  root_build_dir = sys.argv[2]
+  icudtl = sys.argv[3]
+
+  print(f"destination_file: {destination_file}")
+  print(f"root_build_dir: {root_build_dir}")
+  print(f"icudtl: {icudtl}")
+
+  if os.path.exists(destination_file):
+    os.remove(destination_file)
+  if not os.path.exists(root_build_dir):
+    raise Exception(f"root_build_dir: {root_build_dir} does not exist")
+  if not os.path.exists(icudtl):
+    raise Exception(f"icudtl: {icudtl} does not exist")
+
+  dylib = os.path.join(root_build_dir, 'libLynx_clay.dylib')
+  resource_bundles = os.path.join(root_build_dir, 'resource_bundles')
+  include_dir = os.path.join(root_build_dir, 'include')
+  if not os.path.exists(dylib):
+    raise Exception(f"libLynx_clay.dylib: {dylib} does not exist")
+  if not os.path.isdir(resource_bundles):
+    raise Exception(f"resource_bundles: {resource_bundles} is not a directory")
+  if not os.path.isdir(include_dir):
+    raise Exception(f"include: {include_dir} is not a directory")
+
+  zip_file = zipfile.ZipFile(destination_file, 'w', zipfile.ZIP_DEFLATED)
+  _zip_dir(include_dir, zip_file, 'include')
+  zip_file.write(dylib, 'lib/libLynx_clay.dylib')
+  _zip_dir(resource_bundles, zip_file, 'bundles')
+  zip_file.write(icudtl, 'data/icudtl.dat')
+  zip_file.close()
+  print(f"Successfully packaged macOS Lynx clay SDK to {destination_file}")
+except Exception as e:
+  print(f"Failed to package macOS Lynx clay SDK: {e}")
+  sys.exit(1)

--- a/platform/dynamic_lib/tools/build_release.py
+++ b/platform/dynamic_lib/tools/build_release.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import hashlib
+import subprocess
+from pathlib import Path
+
+
+COMMON_GN_ARGS = [
+    'enable_clay_standalone = true',
+    'disable_visibility_hidden = true',
+    'use_ndk_static_cxx = false',
+    'enable_linker_map = false',
+    'enable_clay = true',
+    'is_headless = true',
+    'skia_enable_flutter_defines = true',
+    'skia_use_dng_sdk = false',
+    'skia_use_sfntly = false',
+    'skia_enable_pdf = false',
+    'skia_enable_svg = true',
+    'enable_svg = true',
+    'skia_enable_skottie = true',
+    'skia_use_x11 = false',
+    'skia_use_wuffs = true',
+    'skia_use_expat = true',
+    'skia_use_fontconfig = false',
+    'clay_enable_skshaper = true',
+    'skia_use_icu = true',
+    'skia_gl_standard = ""',
+    'allow_deprecated_api_calls = true',
+    'stripped_symbols = true',
+    'is_official_build = true',
+    'use_clang_static_analyzer = false',
+    'enable_lto = false',
+    'enable_lepusng_worklet = true',
+    'enable_napi_binding = true',
+    'enable_inspector = true',
+    'jsengine_type = "quickjs"',
+    'is_debug = false',
+]
+
+
+def run_command(command):
+  print('run command:', ' '.join(command))
+  subprocess.run(command, check=True)
+
+
+def sha256_file(path):
+  digest = hashlib.sha256()
+  with path.open('rb') as f:
+    for chunk in iter(lambda: f.read(1024 * 1024), b''):
+      digest.update(chunk)
+  return digest.hexdigest()
+
+
+def write_checksum(path):
+  checksum_path = path.with_name(f'{path.name}.sha256')
+  checksum_path.write_text(f'{sha256_file(path)}  {path.name}\n',
+                           encoding='utf-8')
+  return checksum_path
+
+
+def build_config(platform, target_cpu, build_dir):
+  platform_args = []
+  if platform == 'macos':
+    platform_args.extend([
+        'desktop_enable_embedder_layer = true',
+        'skia_use_metal = true',
+        'shell_enable_metal = true',
+        'use_flutter_cxx = false',
+    ])
+    return {
+        'target': 'platform/dynamic_lib/macos:package_sdk',
+        'shared_target':
+            'platform/dynamic_lib/macos:lynx_clay_shared_library',
+        'args': platform_args,
+        'artifact': build_dir / f'lynx_clay_sdk_macos_{target_cpu}.zip',
+        'dylib': build_dir / 'libLynx_clay.dylib',
+    }
+  if platform == 'linux':
+    platform_args.extend([
+        'use_flutter_cxx = true',
+    ])
+    return {
+        'target': 'platform/dynamic_lib/linux:package_sdk',
+        'shared_target':
+            'platform/dynamic_lib/linux:lynx_clay_shared_library',
+        'args': platform_args,
+        'artifact': build_dir / f'lynx_clay_sdk_linux_{target_cpu}.zip',
+        'dylib': None,
+    }
+  raise ValueError(f'Unsupported platform: {platform}')
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Build and package the libLynx_clay dynamic library SDK.')
+  parser.add_argument('--platform', choices=['macos', 'linux'], required=True)
+  parser.add_argument('--target-cpu', required=True)
+  parser.add_argument('--build-dir', default='out/Default')
+  parser.add_argument(
+      '--skip-codesign',
+      action='store_true',
+      help='Skip macOS ad-hoc signing before packaging.')
+  args = parser.parse_args()
+
+  build_dir = Path(args.build_dir)
+  config = build_config(args.platform, args.target_cpu, build_dir)
+  gn_args = [
+      f'target_cpu = "{args.target_cpu}"',
+      *COMMON_GN_ARGS,
+      *config['args'],
+  ]
+
+  run_command([
+      'buildtools/gn/gn',
+      'gen',
+      str(build_dir),
+      f'--root-target=//{config["target"]}',
+      '--args=' + ' '.join(gn_args),
+  ])
+  run_command(['buildtools/ninja/ninja', '-C', str(build_dir),
+               config['shared_target']])
+
+  dylib = config['dylib']
+  if dylib is not None and not args.skip_codesign:
+    run_command(['codesign', '--force', '--sign', '-', str(dylib)])
+    run_command(['codesign', '--verify', '-vvv', str(dylib)])
+
+  run_command(['buildtools/ninja/ninja', '-C', str(build_dir),
+               config['target']])
+
+  artifact = config['artifact']
+  if not artifact.is_file():
+    raise FileNotFoundError(f'Expected artifact does not exist: {artifact}')
+  checksum = write_checksum(artifact)
+  print(f'Built dynamic library SDK: {artifact}')
+  print(f'Wrote checksum: {checksum}')
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
## Summary
- Add `platform/dynamic_lib` as the dedicated home for the `libLynx_clay` dynamic library SDK targets.
- Add macOS and Linux package targets that produce `lynx_clay_sdk_macos_${target_cpu}.zip` and `lynx_clay_sdk_linux_${target_cpu}.zip`.
- Keep the small pure C ABI wrapper layer inside `platform/dynamic_lib`, so external language bindings can live outside this repository while loading a single `libLynx_clay.{dylib,so}`.
- Add CI build checks and a thin `publish-release` job for macOS arm64 / Linux x64 dynamic library SDK packages.

## Details
- `platform/dynamic_lib/macos` builds `libLynx_clay.dylib` and packages the dylib, public C API headers, wrapper header, ICU data, and resource bundles.
- `platform/dynamic_lib/linux` builds `libLynx_clay.so` and packages the shared object, public C API headers, wrapper header, ICU data, and optional resources.
- CI adds `dynamic-lib-darwin-aarch64-build` and `dynamic-lib-linux-amd64-build`; both call `platform/dynamic_lib/tools/build_release.py` and upload the SDK zip plus checksum as artifacts.
- Release follows the iOS release shape: `publish-release.yml` does checkout/setup/common-deps with `cache-backend: github`, then delegates build/package/sign/checksum details to `platform/dynamic_lib/tools/build_release.py`.
- Existing C++ CAPI exports are not changed; the added `lynx_rust_*` functions are plain C ABI wrappers for entry points that otherwise expose C++ reference parameters.

## Validation
- `buildtools/gn/gn format --check platform/dynamic_lib/BUILD.gn platform/dynamic_lib/macos/BUILD.gn platform/dynamic_lib/linux/BUILD.gn`
- `clang -std=c11 -fsyntax-only -I. -include platform/dynamic_lib/lynx_rust_capi.h -x c /dev/null`
- `PYTHONPYCACHEPREFIX=/private/tmp/lynx-dynamic-lib-pycache python3 -m py_compile platform/dynamic_lib/macos/package_sdk.py platform/dynamic_lib/linux/package_sdk.py platform/dynamic_lib/tools/build_release.py`
- `python3 platform/dynamic_lib/tools/build_release.py --help`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/publish-release.yml")'`
- `bash -n` on the extracted CI and release dynamic-lib build step bodies
- `git diff --check`

## Notes
- This PR intentionally excludes the Rust workspace changes from the earlier prototype branch.
- Full macOS/Linux release package builds are expected to run through the added GitHub Actions jobs with `common-deps`/habitat preparation.
