### PR TITLE
[BugFix] Forward request headers and body in macOS Explorer HTTP service

### DIFF
--- a/explorer/darwin/macos/lynx_explorer/LynxExplorer/service/LynxHttpService.mm
+++ b/explorer/darwin/macos/lynx_explorer/LynxExplorer/service/LynxHttpService.mm
@@ -16,6 +16,17 @@ void LynxHttpServiceImpl::Request(std::shared_ptr<pub::LynxHttpRequest> http_req
   NSMutableURLRequest *nsRequest = [NSMutableURLRequest requestWithURL:url];
   nsRequest.HTTPMethod = [NSString stringWithUTF8String:http_request->GetMethod().c_str()];
 
+  const auto& headers = http_request->GetHeaders();
+  for (const auto& header : headers) {
+    [nsRequest setValue:[NSString stringWithUTF8String:header.second.c_str()]
+     forHTTPHeaderField:[NSString stringWithUTF8String:header.first.c_str()]];
+  }
+
+  const auto& body = http_request->GetBody();
+  if (!body.empty()) {
+    nsRequest.HTTPBody = [NSData dataWithBytes:body.data() length:body.size()];
+  }
+
   NSURLSession *session = [NSURLSession sharedSession];
   NSURLSessionDataTask *dataTask =
       [session dataTaskWithRequest:nsRequest


### PR DESCRIPTION
## Summary
The macOS LynxExplorer HTTP service implementation only forwarded the request URL and method, ignoring headers and body set on the C++ `LynxHttpRequest`. This caused `POST`/`PUT` requests and custom headers such as `Content-Type` to be silently dropped.

Add code to copy `http_request->GetHeaders()` into the `NSMutableURLRequest` and set `HTTPBody` from `http_request->GetBody()`, aligning the macOS implementation with the iOS, Android, and HarmonyOS HTTP services.

## Test plan
- [ ] Build LynxExplorer on macOS.
- [ ] Run a Lynx page that uses `fetch` with `method: 'POST'`, custom headers, and a JSON body.
- [ ] Verify the server receives the headers and body correctly.
- [ ] Verify the response status code, headers, and body are returned to the JS layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)