### PR TITLE
[Feature][DynamicLib] Add macOS windowless dynamic library embedder

### DIFF
--- a/platform/dynamic_lib/BUILD.gn
+++ b/platform/dynamic_lib/BUILD.gn
@@ -2,8 +2,129 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
-source_set("lynx_rust_capi") {
+import("../../core/Lynx.gni")
+import("../../testing/test.gni")
+
+lynx_core_source_set("lynx_rust_capi") {
   sources = [ "lynx_rust_capi.cc" ]
 
+  configs = [
+    "../embedder:config",
+    "../embedder:public_api",
+    "../../clay:config",
+  ]
+
+  deps = [ "../../third_party/skia" ]
+
   include_dirs = [ "../.." ]
+}
+
+config("windowless_embedder_config") {
+  defines = [ "ENABLE_WINDOWLESS" ]
+}
+
+lynx_core_source_set("dynamic_lib_windowless") {
+  sources = [
+    "../embedder/windowless/lynx_ui_renderer_windowless.cc",
+    "../embedder/windowless/lynx_ui_renderer_windowless.h",
+    "../embedder/windowless/lynx_windowless_renderer.cc",
+    "../embedder/windowless/lynx_windowless_renderer_priv.h",
+    "../embedder/windowless/windowless_ui_task_runner_delegate.cc",
+    "../embedder/windowless/windowless_ui_task_runner_delegate.h",
+  ]
+
+  public_configs = [
+    "../embedder:public_api",
+    "../embedder:config",
+    ":windowless_embedder_config",
+  ]
+
+  deps = [
+    "../../clay/lynx_adaptor:resource_loader_embedder",
+    "../../clay/shell/platform/headless:headless",
+    "../../clay/ui:ui",
+  ]
+  if (!is_mac) {
+    deps += [ "../../clay/shell/common:compositor_service_fallback" ]
+  }
+}
+
+lynx_core_source_set("windowless_embedder") {
+  sources = [
+    "../embedder/frame_timing_listener_impl.cc",
+    "../embedder/frame_timing_listener_impl.h",
+    "../embedder/lynx_env.cc",
+    "../embedder/lynx_group.cc",
+    "../embedder/lynx_group_priv.h",
+    "../embedder/lynx_load_meta.cc",
+    "../embedder/lynx_load_meta_priv.h",
+    "../embedder/lynx_log.cc",
+    "../embedder/lynx_native_view.cc",
+    "../embedder/lynx_runtime_lifecycle_observer_priv.h",
+    "../embedder/lynx_template_bundle.cc",
+    "../embedder/lynx_template_bundle_priv.h",
+    "../embedder/lynx_template_data.cc",
+    "../embedder/lynx_template_data_priv.h",
+    "../embedder/lynx_trace.cc",
+    "../embedder/lynx_update_meta.cc",
+    "../embedder/lynx_update_meta_priv.h",
+    "../embedder/lynx_view.cc",
+    "../embedder/lynx_view_builder.cc",
+    "../embedder/lynx_view_builder_priv.h",
+    "../embedder/lynx_view_client.cc",
+    "../embedder/lynx_view_client_priv.h",
+    "../embedder/lynx_view_clients.cc",
+    "../embedder/lynx_view_clients.h",
+    "../embedder/lynx_view_priv.h",
+    "../embedder/lynx_vsync_monitor.cc",
+    "../embedder/lynx_vsync_monitor_priv.h",
+    "../embedder/memory/lynx_memory.cc",
+  ]
+  if (is_win || is_mac) {
+    sources += [
+      "../embedder/native_view/lynx_texture_view.cc",
+      "../embedder/native_view/lynx_texture_view.h",
+    ]
+  }
+
+  deps = [
+    ":dynamic_lib_windowless",
+    "../../core:lynx_native",
+    "../embedder:public_headers",
+    "../embedder/core:renderer",
+    "../embedder/lynx_service:lynx_service",
+    "../embedder/resource:resource",
+  ]
+  if (enable_napi_binding) {
+    public_deps = [
+      "../../third_party/napi:weak_node_api_host",
+      "../embedder:lynx_runtime_lifecycle_observer",
+      "../embedder/module:module",
+    ]
+  }
+  if (enable_inspector) {
+    deps += [ "../embedder/lynx_devtool:lynx_devtool_logbox" ]
+  }
+
+  public_configs = [
+    "../embedder:public_api",
+    "../embedder:config",
+    ":windowless_embedder_config",
+  ]
+
+  if (!enable_unittests && !is_android && !is_harmony) {
+    sources += [
+      "../embedder/sysinfo_embedder.cc",
+      "../embedder/vsync_monitor_fallback.cc",
+      "../embedder/vsync_monitor_fallback.h",
+    ]
+  } else {
+    sources += [
+      "../../clay/lynx_adaptor/native_platform_view_mock.cc",
+      "../embedder/lynx_ui_renderer_mock.cc",
+    ]
+  }
+  if (is_win) {
+    sources += [ "../../core/renderer/utils/sys_lynx_env/sys_env_default.cc" ]
+  }
 }

--- a/platform/dynamic_lib/lynx_rust_capi.cc
+++ b/platform/dynamic_lib/lynx_rust_capi.cc
@@ -2,8 +2,28 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include "clay/lynx_adaptor/ui_delegate_clay.h"
+#include "clay/ui/component/page_view.h"
+#include "clay/ui/component/view_context.h"
+#include "platform/embedder/lynx_view_priv.h"
 #include "platform/embedder/public/capi/lynx_view_builder_capi.h"
 #include "platform/embedder/public/capi/lynx_view_capi.h"
+
+namespace {
+
+clay::PageView* GetPageView(lynx_view_t* view) {
+  if (!view || !view->lynx_ui_renderer) {
+    return nullptr;
+  }
+  auto* ui_delegate = view->lynx_ui_renderer->GetUIDelegate();
+  auto* clay_delegate = static_cast<lynx::tasm::UIDelegateClay*>(ui_delegate);
+  if (!clay_delegate || !clay_delegate->GetViewContext()) {
+    return nullptr;
+  }
+  return clay_delegate->GetViewContext()->GetPageView();
+}
+
+}  // namespace
 
 extern "C" __attribute__((visibility("default"))) void
 lynx_rust_view_builder_set_screen_size(lynx_view_builder_t* builder,
@@ -38,4 +58,15 @@ extern "C" __attribute__((visibility("default"))) void lynx_rust_view_set_frame(
 extern "C" __attribute__((visibility("default"))) void
 lynx_rust_view_set_font_scale(lynx_view_t* view, float font_scale) {
   lynx_view_set_font_scale(view, font_scale);
+}
+
+extern "C" __attribute__((visibility("default"))) bool
+lynx_rust_view_set_use_texture_backend(lynx_view_t* view,
+                                       bool use_texture_backend) {
+  auto* page_view = GetPageView(view);
+  if (!page_view) {
+    return false;
+  }
+  page_view->SetUseTextureBackend(use_texture_backend);
+  return true;
 }

--- a/platform/dynamic_lib/macos/BUILD.gn
+++ b/platform/dynamic_lib/macos/BUILD.gn
@@ -4,15 +4,56 @@
 
 import("../../../core/Lynx.gni")
 
+source_set("macos_common") {
+  sources = [
+    "../../darwin/macos/common/LynxUIRenderer.h",
+    "../../darwin/macos/common/LynxUIRenderer.mm",
+    "../../darwin/macos/common/vsync_monitor_macos.h",
+    "../../darwin/macos/common/vsync_monitor_macos.mm",
+  ]
+
+  configs += [
+    "../../../clay:config",
+    "../../../clay/shell/platform/darwin/common:framework_relative_headers",
+  ]
+
+  deps = [
+    "..:windowless_embedder",
+    "../../../clay/ui:ui",
+    "../../../third_party/rapidjson",
+  ]
+}
+
 shared_library("lynx_clay_shared_library") {
   output_name = "Lynx_clay"
 
   deps = [
+    ":macos_common",
     "..:lynx_rust_capi",
-    "../../darwin/macos:lynx_common_deps",
+    "..:windowless_embedder",
+    "../../../base/src:base_static",
+    "../../../clay/lynx_adaptor:lynx_adaptor",
+    "../../../clay/shell/platform/darwin/macos:flutter_framework_source",
+    "../../../clay/shell/platform/embedder:embedder",
+    "../../../core/runtime/common/napi:napi_binding_jsc",
   ]
+  if (enable_testbench_replay) {
+    deps += [ "../../../core/services/replay" ]
+  }
+  if (enable_napi_binding) {
+    deps += [
+      "../../../core/runtime/common/napi:napi_binding_quickjs",
+      "../../../third_party/napi:env",
+    ]
+  }
   if (jsengine_type == "v8") {
     deps += [ "../../../third_party/NativeScript:NativeScript" ]
+    if (enable_napi_binding) {
+      deps += [
+        "../../../core/runtime/common/napi:napi_binding_v8",
+        "../../../third_party/napi:v8",
+      ]
+    }
   }
 
   ldflags = [


### PR DESCRIPTION
## Summary

This PR wires the macOS `platform/dynamic_lib` target to the windowless embedder pieces needed by `libLynx_clay.dylib`.

- Adds dynamic-lib-local windowless embedder GN targets.
- Links the macOS dynamic library against the required embedder, Clay, NAPI, and macOS common dependencies directly.
- Adds a Rust C ABI helper for toggling the texture backend on the underlying Clay page view.

## Why

The macOS dynamic library target needs to expose a self-contained `libLynx_clay.dylib` for external bindings. Pulling in the windowless/embedder path directly keeps the exported C ABI surface in the dynamic library image instead of depending on a separate host app target.

## Validation

- `tools/hab sync . --target clay`
- `buildtools/ninja/ninja -C out/dynamic_lib_macos_arm64_clt platform/dynamic_lib/macos:package_sdk`

The build produced:

- `out/dynamic_lib_macos_arm64_clt/libLynx_clay.dylib`
- `out/dynamic_lib_macos_arm64_clt/lynx_clay_sdk_macos_arm64.zip`

`file out/dynamic_lib_macos_arm64_clt/libLynx_clay.dylib` reports `Mach-O 64-bit dynamically linked shared library arm64`.