### PR TITLE
[BugFix][Explorer][Android] Preserve safe-area rendering across rotation

### DIFF
--- a/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
+++ b/explorer/android/lynx_explorer/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
             android:name=".LynxViewShellActivity"
             android:windowSoftInputMode="adjustNothing"
             android:exported="true"
+            android:configChanges="orientation|screenSize|keyboardHidden"
             android:theme="@style/LynxShellTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
+++ b/explorer/android/lynx_explorer/src/main/java/com/lynx/explorer/LynxViewShellActivity.java
@@ -61,6 +61,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
   private ViewGroup mLynxContainer;
   private LynxView mLynxView;
   private String mFrontendTheme;
+  private QueryMapUtils mCurrentQueryMap;
   private TimingHandler.ExtraTimingInfo extraTimingInfo = new TimingHandler.ExtraTimingInfo();
 
   @Override
@@ -99,6 +100,20 @@ public class LynxViewShellActivity extends AppCompatActivity {
       mLynxView.destroy();
     }
     super.onDestroy();
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    if (mLynxView == null) {
+      return;
+    }
+
+    DisplayMetrics displayMetrics = DisplayMetricsHolder.getRealScreenDisplayMetrics(this);
+    mLynxView.updateScreenMetrics(displayMetrics.widthPixels, displayMetrics.heightPixels);
+    if (mCurrentQueryMap != null) {
+      mLynxView.updateGlobalProps(getGlobalProps(this, mCurrentQueryMap));
+    }
   }
 
   @Override
@@ -249,6 +264,7 @@ public class LynxViewShellActivity extends AppCompatActivity {
     } else {
       queryMap.parse(url);
     }
+    mCurrentQueryMap = queryMap;
 
     if (queryMap.contains("width") && queryMap.contains("height")) {
       builder.setPresetMeasuredSpec(

--- a/explorer/showcase/menu/components/menu/index.tsx
+++ b/explorer/showcase/menu/components/menu/index.tsx
@@ -3,7 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 
 import { ItemProps, MenuItem } from '@components/menu-item';
-import { useTheme } from '@explorer/lib';
+import { useSafeArea, useTheme } from '@explorer/lib';
 import './index.scss';
 
 interface MenuProps {
@@ -12,10 +12,23 @@ interface MenuProps {
 
 export function Menu(menu: MenuProps) {
   const { withTheme } = useTheme();
+  const safeArea = useSafeArea();
   const { items } = menu;
+  const horizontalSafeArea = safeArea.left + safeArea.right;
+  const bottomPadding = 30 + safeArea.bottom;
   return (
     <view clip-radius="true" className={withTheme('page')}>
-      <scroll-view scroll-y clip-radius="true" className="list">
+      <scroll-view
+        scroll-y
+        clip-radius="true"
+        className="list"
+        style={{
+          marginLeft: `${safeArea.left}px`,
+          marginRight: `${safeArea.right}px`,
+          width: `calc(100% - ${horizontalSafeArea}px)`,
+          paddingBottom: `${bottomPadding}px`,
+        }}
+      >
         {items.map((item: ItemProps) => {
           return <MenuItem {...item} />;
         })}

--- a/explorer/showcase/menu/typing.d.ts
+++ b/explorer/showcase/menu/typing.d.ts
@@ -11,5 +11,7 @@ declare module '@lynx-js/types' {
     theme: string;
     safeAreaTop?: number;
     safeAreaBottom?: number;
+    safeAreaLeft?: number;
+    safeAreaRight?: number;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #7455 for the Android Explorer portrait/landscape safe-area regression.

Original issue: https://github.com/lynx-family/lynx/issues/7372

## Root Cause

After Android Explorer homepage rotation support landed, an existing `LynxViewShellActivity` could still be destroyed and recreated during orientation changes. That left Showcase with a visible blank interval during rotation and could leave ReactLynx safe-area state based on stale screen metrics/global props. The Showcase menu also did not apply the horizontal and bottom safe-area handling already used by the homepage.

## Changes

- Handle `orientation`, `screenSize`, and `keyboardHidden` configuration changes in `LynxViewShellActivity`.
- Update the active `LynxView` screen metrics and global props on configuration changes.
- Apply horizontal and bottom safe-area offsets to the Showcase menu list.

## Validation

- `git diff --check`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home ./gradlew :LynxExplorer:assembleWithoutSparklingNoasanDebug --no-daemon`
- Installed `LynxExplorer-withoutSparkling-noasan-debug.apk` on Android emulator `emulator-5556`.
- Runtime validated Home and Showcase portrait/landscape rendering with framebuffer screenshots.
- Captured host video for the real Home -> Showcase -> landscape flow because emulator `adb shell screenrecord` produced encoder error `-38`.

Rendering evidence is attached in the PR conversation comment.
