### PR TITLE
[Infra] temporarily remove ios-unittests-check because of 429 error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,44 +188,44 @@ jobs:
           source tools/envsetup.sh
           tools/rtf/rtf native-ut run --names devtool
 
-  ios-unittests-check:
-    needs: [darwin-impact-check]
-    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
-    timeout-minutes: 60
-    runs-on: lynx-darwin-15.6.1-medium
-    steps:
-      - name: Download Source
-        uses: actions/checkout@v6
-        with:
-          path: lynx
-      - name: Install Common Dependencies
-        uses: ./lynx/.github/actions/common-deps
-      - name: Install iOS Dependencies
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: |
-            set -e
-            cd $GITHUB_WORKSPACE/lynx
-            source tools/envsetup.sh
-            pushd explorer/darwin/ios/lynx_explorer
-            git config --global url."https://github.com/".insteadOf "git@github.com:"
-            bash bundle_install.sh --skip-card-build
-            popd
-      - name: Run Unittests
-        run: |
-          set -e
-          source tools/envsetup.sh
-          pushd explorer/darwin/ios/lynx_explorer
-          xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
-          sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
-          echo $sdkVersion > sdk.txt
-          SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone" | grep -v "unavailable" | head -1 | grep -Eo "[0-9A-F-]{36}")
-          xcodebuild build-for-testing ARCHS=arm64 -workspace LynxExplorer.xcworkspace -scheme LynxExplorerTests -enableCodeCoverage YES -configuration Debug -sdk iphonesimulator$(cat sdk.txt) COMPILER_INDEX_STORE_ENABLE=NO -derivedDataPath iOSCoreBuild/DerivedData -destination "platform=iOS Simulator,id=$SIMULATOR_ID" SYMROOT=`pwd`/Build/Products -testPlan UTTest
-          chmod u+x xctestrunner
-          ./xctestrunner --xctestrun `pwd`/Build/Products/LynxExplorerTests_UTTest_iphonesimulator$(cat sdk.txt)-arm64.xctestrun --work_dir `pwd` --output_dir `pwd`/iOSCoreBuild/DerivedData test --id $SIMULATOR_ID --platform ios_simulator
-          popd
+  # ios-unittests-check:
+  #   needs: [darwin-impact-check]
+  #   if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+  #   timeout-minutes: 60
+  #   runs-on: lynx-darwin-15.6.1-medium
+  #   steps:
+  #     - name: Download Source
+  #       uses: actions/checkout@v6
+  #       with:
+  #         path: lynx
+  #     - name: Install Common Dependencies
+  #       uses: ./lynx/.github/actions/common-deps
+  #     - name: Install iOS Dependencies
+  #       uses: nick-fields/retry@v2
+  #       with:
+  #         timeout_minutes: 20
+  #         max_attempts: 3
+  #         command: |
+  #           set -e
+  #           cd $GITHUB_WORKSPACE/lynx
+  #           source tools/envsetup.sh
+  #           pushd explorer/darwin/ios/lynx_explorer
+  #           git config --global url."https://github.com/".insteadOf "git@github.com:"
+  #           bash bundle_install.sh --skip-card-build
+  #           popd
+  #     - name: Run Unittests
+  #       run: |
+  #         set -e
+  #         source tools/envsetup.sh
+  #         pushd explorer/darwin/ios/lynx_explorer
+  #         xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
+  #         sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
+  #         echo $sdkVersion > sdk.txt
+  #         SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone" | grep -v "unavailable" | head -1 | grep -Eo "[0-9A-F-]{36}")
+  #         xcodebuild build-for-testing ARCHS=arm64 -workspace LynxExplorer.xcworkspace -scheme LynxExplorerTests -enableCodeCoverage YES -configuration Debug -sdk iphonesimulator$(cat sdk.txt) COMPILER_INDEX_STORE_ENABLE=NO -derivedDataPath iOSCoreBuild/DerivedData -destination "platform=iOS Simulator,id=$SIMULATOR_ID" SYMROOT=`pwd`/Build/Products -testPlan UTTest
+  #         chmod u+x xctestrunner
+  #         ./xctestrunner --xctestrun `pwd`/Build/Products/LynxExplorerTests_UTTest_iphonesimulator$(cat sdk.txt)-arm64.xctestrun --work_dir `pwd` --output_dir `pwd`/iOSCoreBuild/DerivedData test --id $SIMULATOR_ID --platform ios_simulator
+  #         popd
 
   cocoapods-lynx-library-build:
     timeout-minutes: 10


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
