### PR TITLE
[Infra] Restore iOS CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,44 +188,53 @@ jobs:
           source tools/envsetup.sh
           tools/rtf/rtf native-ut run --names devtool
 
-  # ios-unittests-check:
-  #   needs: [darwin-impact-check]
-  #   if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
-  #   timeout-minutes: 60
-  #   runs-on: lynx-darwin-15.6.1-medium
-  #   steps:
-  #     - name: Download Source
-  #       uses: actions/checkout@v6
-  #       with:
-  #         path: lynx
-  #     - name: Install Common Dependencies
-  #       uses: ./lynx/.github/actions/common-deps
-  #     - name: Install iOS Dependencies
-  #       uses: nick-fields/retry@v2
-  #       with:
-  #         timeout_minutes: 20
-  #         max_attempts: 3
-  #         command: |
-  #           set -e
-  #           cd $GITHUB_WORKSPACE/lynx
-  #           source tools/envsetup.sh
-  #           pushd explorer/darwin/ios/lynx_explorer
-  #           git config --global url."https://github.com/".insteadOf "git@github.com:"
-  #           bash bundle_install.sh --skip-card-build
-  #           popd
-  #     - name: Run Unittests
-  #       run: |
-  #         set -e
-  #         source tools/envsetup.sh
-  #         pushd explorer/darwin/ios/lynx_explorer
-  #         xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
-  #         sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
-  #         echo $sdkVersion > sdk.txt
-  #         SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone" | grep -v "unavailable" | head -1 | grep -Eo "[0-9A-F-]{36}")
-  #         xcodebuild build-for-testing ARCHS=arm64 -workspace LynxExplorer.xcworkspace -scheme LynxExplorerTests -enableCodeCoverage YES -configuration Debug -sdk iphonesimulator$(cat sdk.txt) COMPILER_INDEX_STORE_ENABLE=NO -derivedDataPath iOSCoreBuild/DerivedData -destination "platform=iOS Simulator,id=$SIMULATOR_ID" SYMROOT=`pwd`/Build/Products -testPlan UTTest
-  #         chmod u+x xctestrunner
-  #         ./xctestrunner --xctestrun `pwd`/Build/Products/LynxExplorerTests_UTTest_iphonesimulator$(cat sdk.txt)-arm64.xctestrun --work_dir `pwd` --output_dir `pwd`/iOSCoreBuild/DerivedData test --id $SIMULATOR_ID --platform ios_simulator
-  #         popd
+  ios-unittests-check:
+    needs: [darwin-impact-check]
+    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+    timeout-minutes: 60
+    runs-on: lynx-darwin-15.6.1-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+      - name: Setup CocoaPods cache
+        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        with:
+          path: |
+            ~/.cocoapods/repos/trunk
+            ~/Library/Caches/CocoaPods
+          key: cocoapods-ios-explorer-${{ runner.os }}-${{ hashFiles('lynx/explorer/darwin/ios/lynx_explorer/Podfile') }}
+          restore-keys: |
+            cocoapods-ios-explorer-${{ runner.os }}-
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+      - name: Install iOS Dependencies
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: |
+            set -e
+            cd $GITHUB_WORKSPACE/lynx
+            source tools/envsetup.sh
+            pushd explorer/darwin/ios/lynx_explorer
+            git config --global url."https://github.com/".insteadOf "git@github.com:"
+            bash bundle_install.sh --skip-card-build
+            popd
+      - name: Run Unittests
+        run: |
+          set -e
+          source tools/envsetup.sh
+          pushd explorer/darwin/ios/lynx_explorer
+          xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
+          sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
+          echo $sdkVersion > sdk.txt
+          SIMULATOR_ID=$(xcrun simctl list devices | grep -E "iPhone" | grep -v "unavailable" | head -1 | grep -Eo "[0-9A-F-]{36}")
+          xcodebuild build-for-testing ARCHS=arm64 -workspace LynxExplorer.xcworkspace -scheme LynxExplorerTests -enableCodeCoverage YES -configuration Debug -sdk iphonesimulator$(cat sdk.txt) COMPILER_INDEX_STORE_ENABLE=NO -derivedDataPath iOSCoreBuild/DerivedData -destination "platform=iOS Simulator,id=$SIMULATOR_ID" SYMROOT=`pwd`/Build/Products -testPlan UTTest
+          chmod u+x xctestrunner
+          ./xctestrunner --xctestrun `pwd`/Build/Products/LynxExplorerTests_UTTest_iphonesimulator$(cat sdk.txt)-arm64.xctestrun --work_dir `pwd` --output_dir `pwd`/iOSCoreBuild/DerivedData test --id $SIMULATOR_ID --platform ios_simulator
+          popd
 
   cocoapods-lynx-library-build:
     timeout-minutes: 10
@@ -765,253 +774,278 @@ jobs:
       - name: Build Explorer App
         uses: ./lynx/.github/actions/harmony-explorer-build
 
-  # ios-explorer-build:
-  #   needs: [darwin-impact-check]
-  #   if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
-  #   timeout-minutes: 60
-  #   runs-on: lynx-darwin-15.6.1-medium
-  #   strategy:
-  #     matrix:
-  #       arch: [arm64, x86_64]
-  #   steps:
-  #     - name: Download Source
-  #       uses: actions/checkout@v6
-  #       with:
-  #         path: lynx
-  #     - name: Build Explorer App
-  #       uses: ./lynx/.github/actions/ios-explorer-build
-  #       with:
-  #         build-arch: ${{ matrix.arch }}
-  #         build-params: '--integration-test'
-  #     - name: upload artifact
-  #       uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
-  #       continue-on-error: true
-  #       with:
-  #         name: ios-explorer-build-${{ matrix.arch }}
-  #         path: '${{ github.workspace }}/lynx/LynxExplorer-${{ matrix.arch }}.app.tar.gz'
+  ios-explorer-build:
+    needs: [darwin-impact-check]
+    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+    timeout-minutes: 60
+    runs-on: lynx-darwin-15.6.1-medium
+    strategy:
+      matrix:
+        arch: [arm64, x86_64]
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+      - name: Setup CocoaPods cache
+        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        with:
+          path: |
+            ~/.cocoapods/repos/trunk
+            ~/Library/Caches/CocoaPods
+          key: cocoapods-ios-explorer-${{ runner.os }}-${{ hashFiles('lynx/explorer/darwin/ios/lynx_explorer/Podfile') }}
+          restore-keys: |
+            cocoapods-ios-explorer-${{ runner.os }}-
+      - name: Build Explorer App
+        uses: ./lynx/.github/actions/ios-explorer-build
+        with:
+          build-arch: ${{ matrix.arch }}
+          build-params: '--integration-test'
+      - name: upload artifact
+        uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+        continue-on-error: true
+        with:
+          name: ios-explorer-build-${{ matrix.arch }}
+          path: '${{ github.workspace }}/lynx/LynxExplorer-${{ matrix.arch }}.app.tar.gz'
 
-  # ios-integration-test:
-  #   needs: [darwin-impact-check]
-  #   if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
-  #   timeout-minutes: 30
-  #   runs-on: lynx-darwin-15.6.1-medium
-  #   env:
-  #     LOCAL_POD_NAME: 'local_pod'
-  #     POD_VERSION: '0.0.1-alpha.1'
-  #   steps:
-  #     - name: Download Source
-  #       uses: actions/checkout@v6
-  #       with:
-  #         fetch-depth: 2
-  #         ref: ${{ github.event.pull_request.head.sha }}
-  #         path: lynx
-  #     - name: Install Common Dependencies
-  #       uses: ./lynx/.github/actions/common-deps
-  #     - name: Prepare cocoapods publish source
-  #       run: |-
-  #         source tools/envsetup.sh
-  #         export LANG=en_US.UTF-8
-  #         bundle -v
-  #         bundle config set path .
-  #         SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install
-  #         python3 tools/ios_tools/cocoapods_publish_helper.py --prepare-source --tag $POD_VERSION --version $POD_VERSION --component all
-  #     - name: Publish to Local Pod Source
-  #       run: |-
-  #         cd $GITHUB_WORKSPACE/lynx
-  #         source tools/envsetup.sh
-  #         git config --global user.name "lynx.authors"
-  #         git config --global user.email "lynx.authors@users.noreply.github.com"
-  #         python3 tools/ios_tools/cocoapods_publish_helper.py --publish_local $LOCAL_POD_NAME --component all
-  #     - name: Download the Demo Project
-  #       uses: actions/checkout@v6
-  #       with:
-  #         path: demo
-  #         repository: lynx-family/integrating-lynx-demo-projects
-  #         ref: 0ab9340e1e560f07d3d4c4331f8b62b0702d067a
-  #     - name: Build the Demo Project
-  #       run: |-
-  #         cd $GITHUB_WORKSPACE
-  #         python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component Lynx --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
-  #         python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component LynxService --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
-  #         python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component XElement --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
-  #         python3 lynx/tools/ios_tools/process_podfile.py --action insert_pod_source --podfile demo/ios/HelloLynxObjc/Podfile --pod_source "file://$GITHUB_WORKSPACE/lynx/$LOCAL_POD_NAME"
-  #         cd demo/ios/HelloLynxObjc
-  #         export LANG=en_US.UTF-8
-  #         pod install --
-  #         rm -rf $GITHUB_WORKSPACE/lynx/*  # Prevent pods and header files from depending on local resources
-  #         xcodebuild -workspace Hello-Lynx-OC.xcworkspace/ -scheme Hello-Lynx-OC CODE_SIGNING_ALLOWED=NO build
+  ios-integration-test:
+    needs: [darwin-impact-check]
+    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+    timeout-minutes: 30
+    runs-on: lynx-darwin-15.6.1-medium
+    env:
+      LOCAL_POD_NAME: 'local_pod'
+      POD_VERSION: '0.0.1-alpha.1'
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: lynx
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+      - name: Prepare cocoapods publish source
+        run: |-
+          source tools/envsetup.sh
+          export LANG=en_US.UTF-8
+          bundle -v
+          bundle config set path .
+          SDKROOT=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk bundle install
+          python3 tools/ios_tools/cocoapods_publish_helper.py --prepare-source --tag $POD_VERSION --version $POD_VERSION --component all
+      - name: Publish to Local Pod Source
+        run: |-
+          cd $GITHUB_WORKSPACE/lynx
+          source tools/envsetup.sh
+          git config --global user.name "lynx.authors"
+          git config --global user.email "lynx.authors@users.noreply.github.com"
+          python3 tools/ios_tools/cocoapods_publish_helper.py --publish_local $LOCAL_POD_NAME --component all
+      - name: Download the Demo Project
+        uses: actions/checkout@v6
+        with:
+          path: demo
+          repository: lynx-family/integrating-lynx-demo-projects
+          ref: 0ab9340e1e560f07d3d4c4331f8b62b0702d067a
+      - name: Setup CocoaPods cache
+        uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+        with:
+          path: |
+            ~/.cocoapods/repos/trunk
+            ~/Library/Caches/CocoaPods
+          # This cache is for third-party pods' trunk/spec and download artifacts.
+          # The Podfile rewrite below only pins Lynx pods to a local source, so the
+          # original demo Podfile/Podfile.lock is sufficient to key third-party cache.
+          key: cocoapods-ios-integration-${{ runner.os }}-${{ hashFiles('demo/ios/HelloLynxObjc/Podfile', 'demo/ios/HelloLynxObjc/Podfile.lock') }}
+          restore-keys: |
+            cocoapods-ios-integration-${{ runner.os }}-
+      - name: Build the Demo Project
+        run: |-
+          cd $GITHUB_WORKSPACE
+          export LOCAL_POD_SOURCE="file://$HOME/.cocoapods/repos/$LOCAL_POD_NAME"
+          python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component Lynx --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
+          python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component LynxService --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
+          python3 lynx/tools/ios_tools/process_podfile.py --action replace_pod_version --component XElement --version $POD_VERSION --podfile demo/ios/HelloLynxObjc/Podfile
+          python3 lynx/tools/ios_tools/process_podfile.py --action insert_pod_source --podfile demo/ios/HelloLynxObjc/Podfile --pod_source "$LOCAL_POD_SOURCE"
+          python3 lynx/tools/ios_tools/process_podfile.py --action pin_pod_source --component Lynx --podfile demo/ios/HelloLynxObjc/Podfile --pod_source "$LOCAL_POD_SOURCE"
+          python3 lynx/tools/ios_tools/process_podfile.py --action pin_pod_source --component LynxService --podfile demo/ios/HelloLynxObjc/Podfile --pod_source "$LOCAL_POD_SOURCE"
+          python3 lynx/tools/ios_tools/process_podfile.py --action pin_pod_source --component XElement --podfile demo/ios/HelloLynxObjc/Podfile --pod_source "$LOCAL_POD_SOURCE"
+          cd demo/ios/HelloLynxObjc
+          export LANG=en_US.UTF-8
+          pod install
+          rm -rf $GITHUB_WORKSPACE/lynx/*  # Prevent pods and header files from depending on local resources
+          xcodebuild -workspace Hello-Lynx-OC.xcworkspace/ -scheme Hello-Lynx-OC CODE_SIGNING_ALLOWED=NO build
 
-  # ios-e2e-test:
-  #   timeout-minutes: 60
-  #   needs: [darwin-impact-check, ios-explorer-build]
-  #   if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
-  #   env:
-  #     APPIUM_TEST_SERVER_PORT: 4723
-  #     APPIUM_TEST_SERVER_HOST: 127.0.0.1
-  #   runs-on: lynx-darwin-15.6.1-medium
-  #   steps:
-  #     - name: Download Source
-  #       uses: actions/checkout@v6
-  #       with:
-  #         path: lynx
-  #     - name: Install Common Dependencies
-  #       uses: ./lynx/.github/actions/common-deps
-  #     - name: Get iOS simulator SDK version
-  #       run: |
-  #         xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
-  #         sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
-  #         echo "SDK_VERSION=$sdkVersion" >> $GITHUB_ENV
-  #     - name: Build WebDriverAgent
-  #       uses: nick-fields/retry@v3
-  #       with:
-  #         max_attempts: 2
-  #         retry_wait_seconds: 5
-  #         timeout_minutes: 5
-  #         command: |
-  #           pushd $GITHUB_WORKSPACE
-  #           git clone https://github.com/appium/WebDriverAgent.git
-  #           xcodebuild build-for-testing \
-  #             -project ./WebDriverAgent/WebDriverAgent.xcodeproj \
-  #             -scheme WebDriverAgentRunner \
-  #             -configuration Release \
-  #             -sdk iphonesimulator${{ env.SDK_VERSION }} \
-  #             -derivedDataPath ./WebDriverAgent/DerivedData \
-  #             -destination "platform=iOS Simulator,OS=${{ env.SDK_VERSION }},name=iPhone 17" \
-  #             SYMROOT=$GITHUB_WORKSPACE/Build/Products
-  #           popd
-  #     - name: Start iOS Simulator
-  #       run: |
-  #         xcrun simctl boot "iPhone 17"
-  #     - name: Install WebDriverAgent to Simulator
-  #       run: |
-  #         set -e
-  #         SIMULATOR_UDID=$(xcrun simctl list devices "iOS ${{ env.SDK_VERSION }}" | grep "iPhone 17 (" | grep -oE '[0-9A-F-]{36}')
-  #         echo "SIMULATOR_UDID=$SIMULATOR_UDID" >> $GITHUB_ENV
-  #         xcrun simctl install $SIMULATOR_UDID \
-  #           $GITHUB_WORKSPACE/Build/Products/Release-iphonesimulator/WebDriverAgentRunner-Runner.app
-  #     - name: Install Appium
-  #       run: |
-  #         pushd $GITHUB_WORKSPACE/lynx
-  #         source tools/envsetup.sh
-  #         pnpm install appium@2.11.2 -w
-  #         pnpm install appium-xcuitest-driver@7.24.18 -w
-  #         pnpm install appium-ios-simulator@6.2.6 -w
-  #         popd
-  #       env:
-  #         npm_config_store_dir: ~/.local/share/pnpm/store
-  #     - name: Download Explorer App
-  #       uses: lynx-infra/download-artifact@79d9914484f933089c2840552cf439bac85debad
-  #       with:
-  #         name: ios-explorer-build-arm64
-  #         path: lynx/explorer/darwin/ios/lynx_explorer/build_temp
-  #     - name: Install Explorer App
-  #       run: |
-  #         mkdir -p $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
-  #         tar -xzvf $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer-arm64.app.tar.gz -C $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
-  #         xcrun simctl install $SIMULATOR_UDID $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
-  #     - name: Start Appium server
-  #       run: |
-  #         pushd $GITHUB_WORKSPACE/lynx
-  #         source tools/envsetup.sh
-  #         pushd node_modules/appium/node_modules/.bin
-  #         ls
-  #         ./appium server \
-  #           --port=$APPIUM_TEST_SERVER_PORT \
-  #           --address=$APPIUM_TEST_SERVER_HOST \
-  #           --log-no-colors \
-  #           --log-timestamp \
-  #           2>&1 > "$GITHUB_WORKSPACE/lynx/appium.log" < /dev/null &
-  #         popd
-  #         popd
-  #     - name: Check if Appium Server is running
-  #       run: |
-  #         max_attempts=10
-  #         attempt=0
-  #         while [ $attempt -lt $max_attempts ]; do
-  #           if nc -z $APPIUM_TEST_SERVER_HOST $APPIUM_TEST_SERVER_PORT; then
-  #             echo "Appium Server is running."
-  #             break
-  #           else
-  #             attempt=$((attempt + 1))
-  #             echo "Attempt $attempt: Appium Server is not yet running. Retrying in 2 seconds..."
-  #             sleep 2
-  #           fi
-  #         done
-  #         if [ $attempt -eq $max_attempts ]; then
-  #           echo "Failed to start Appium Server."
-  #           exit 1
-  #         fi
-  #     - name: Run iOS E2E Test
-  #       uses: nick-fields/retry@v3
-  #       with:
-  #         max_attempts: 2
-  #         retry_wait_seconds: 5
-  #         timeout_minutes: 20
-  #         command: |
-  #           set -e
-  #           pushd $GITHUB_WORKSPACE/lynx
-  #           source tools/envsetup.sh
-  #           pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
-  #           export server_port=$APPIUM_TEST_SERVER_PORT
-  #           export platform=ios
-  #           export APPIUM_isHeadless=True
-  #           python3 manage.py runtest ios_test.core
-  #           echo "TASK_STATUS=success" >> $GITHUB_OUTPUT
-  #           popd
-  #           popd
-  #       id: run_test
-  #     - name: Collect Lynx-E2E execution logs
-  #       if: always()
-  #       run: |
-  #         TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
-  #         if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
-  #           echo "Test execution succeeded."
-  #         else
-  #           echo "Test execution failed, collecting logs..."
-  #           pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
-  #           ls | grep -E "^lynx_e2e_devtools_.*\.log$" | xargs cat
-  #           popd
-  #         fi
-  #     - name: Collect Appium Server logs
-  #       if: always()
-  #       run: |
-  #         TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
-  #         if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
-  #           echo "Test execution succeeded."
-  #         else
-  #           echo "Test execution failed, collecting logs..."
-  #           pushd $GITHUB_WORKSPACE/lynx/
-  #           if [ -f "appium.log" ]; then
-  #             cat appium.log
-  #           else
-  #             echo "Warning: appium.log file not found"
-  #           fi
-  #           popd
-  #         fi
-  #     - name: Collect Generated Resource Files
-  #       if: always()
-  #       run: |
-  #         TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
-  #         if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
-  #           echo "Test execution succeeded."
-  #         else
-  #           pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
-  #           if [ -d "screenshots" ]; then
-  #             zip -r screenshots.zip ./screenshots/
-  #             echo "Successfully created screenshots.zip"
-  #             echo "ZIP_RESOURCES=success" >> $GITHUB_OUTPUT
-  #           else
-  #             echo "Warning: screenshot directory not found"
-  #           fi
-  #         fi
-  #       id: collect_resource
-  #     - name: Upload Generated Resource Files
-  #       if: always() && steps.collect_resource.outputs.ZIP_RESOURCES == 'success'
-  #       uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
-  #       continue-on-error: true
-  #       with:
-  #         name: ios-e2e-resources
-  #         path: '${{ github.workspace }}/lynx/testing/integration_test/test_script/screenshots.zip'
+  ios-e2e-test:
+    timeout-minutes: 60
+    needs: [darwin-impact-check, ios-explorer-build]
+    if: ${{ needs.darwin-impact-check.outputs.darwin == 'true' }}
+    env:
+      APPIUM_TEST_SERVER_PORT: 4723
+      APPIUM_TEST_SERVER_HOST: 127.0.0.1
+    runs-on: lynx-darwin-15.6.1-medium
+    steps:
+      - name: Download Source
+        uses: actions/checkout@v6
+        with:
+          path: lynx
+      - name: Install Common Dependencies
+        uses: ./lynx/.github/actions/common-deps
+      - name: Get iOS simulator SDK version
+        run: |
+          xcodebuild -showsdks | grep -Eo -m 1 "iphonesimulator([0-9]{1,}\.)+[0-9]{1,}" > sdk.txt
+          sdkVersion=$(awk '{ sub(/iphonesimulator/,""); print $0 }' sdk.txt)
+          echo "SDK_VERSION=$sdkVersion" >> $GITHUB_ENV
+      - name: Build WebDriverAgent
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 5
+          timeout_minutes: 5
+          command: |
+            pushd $GITHUB_WORKSPACE
+            git clone https://github.com/appium/WebDriverAgent.git
+            xcodebuild build-for-testing \
+              -project ./WebDriverAgent/WebDriverAgent.xcodeproj \
+              -scheme WebDriverAgentRunner \
+              -configuration Release \
+              -sdk iphonesimulator${{ env.SDK_VERSION }} \
+              -derivedDataPath ./WebDriverAgent/DerivedData \
+              -destination "platform=iOS Simulator,OS=${{ env.SDK_VERSION }},name=iPhone 17" \
+              SYMROOT=$GITHUB_WORKSPACE/Build/Products
+            popd
+      - name: Start iOS Simulator
+        run: |
+          xcrun simctl boot "iPhone 17"
+      - name: Install WebDriverAgent to Simulator
+        run: |
+          set -e
+          SIMULATOR_UDID=$(xcrun simctl list devices "iOS ${{ env.SDK_VERSION }}" | grep "iPhone 17 (" | grep -oE '[0-9A-F-]{36}')
+          echo "SIMULATOR_UDID=$SIMULATOR_UDID" >> $GITHUB_ENV
+          xcrun simctl install $SIMULATOR_UDID \
+            $GITHUB_WORKSPACE/Build/Products/Release-iphonesimulator/WebDriverAgentRunner-Runner.app
+      - name: Install Appium
+        run: |
+          pushd $GITHUB_WORKSPACE/lynx
+          source tools/envsetup.sh
+          pnpm install appium@2.11.2 -w
+          pnpm install appium-xcuitest-driver@7.24.18 -w
+          pnpm install appium-ios-simulator@6.2.6 -w
+          popd
+        env:
+          npm_config_store_dir: ~/.local/share/pnpm/store
+      - name: Download Explorer App
+        uses: lynx-infra/download-artifact@79d9914484f933089c2840552cf439bac85debad
+        with:
+          name: ios-explorer-build-arm64
+          path: lynx/explorer/darwin/ios/lynx_explorer/build_temp
+      - name: Install Explorer App
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
+          tar -xzvf $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer-arm64.app.tar.gz -C $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
+          xcrun simctl install $SIMULATOR_UDID $GITHUB_WORKSPACE/lynx/explorer/darwin/ios/lynx_explorer/build_temp/LynxExplorer.app
+      - name: Start Appium server
+        run: |
+          pushd $GITHUB_WORKSPACE/lynx
+          source tools/envsetup.sh
+          pushd node_modules/appium/node_modules/.bin
+          ls
+          ./appium server \
+            --port=$APPIUM_TEST_SERVER_PORT \
+            --address=$APPIUM_TEST_SERVER_HOST \
+            --log-no-colors \
+            --log-timestamp \
+            2>&1 > "$GITHUB_WORKSPACE/lynx/appium.log" < /dev/null &
+          popd
+          popd
+      - name: Check if Appium Server is running
+        run: |
+          max_attempts=10
+          attempt=0
+          while [ $attempt -lt $max_attempts ]; do
+            if nc -z $APPIUM_TEST_SERVER_HOST $APPIUM_TEST_SERVER_PORT; then
+              echo "Appium Server is running."
+              break
+            else
+              attempt=$((attempt + 1))
+              echo "Attempt $attempt: Appium Server is not yet running. Retrying in 2 seconds..."
+              sleep 2
+            fi
+          done
+          if [ $attempt -eq $max_attempts ]; then
+            echo "Failed to start Appium Server."
+            exit 1
+          fi
+      - name: Run iOS E2E Test
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 2
+          retry_wait_seconds: 5
+          timeout_minutes: 20
+          command: |
+            set -e
+            pushd $GITHUB_WORKSPACE/lynx
+            source tools/envsetup.sh
+            pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
+            export server_port=$APPIUM_TEST_SERVER_PORT
+            export platform=ios
+            export APPIUM_isHeadless=True
+            python3 manage.py runtest ios_test.core
+            echo "TASK_STATUS=success" >> $GITHUB_OUTPUT
+            popd
+            popd
+        id: run_test
+      - name: Collect Lynx-E2E execution logs
+        if: always()
+        run: |
+          TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
+          if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
+            echo "Test execution succeeded."
+          else
+            echo "Test execution failed, collecting logs..."
+            pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
+            ls | grep -E "^lynx_e2e_devtools_.*\.log$" | xargs cat
+            popd
+          fi
+      - name: Collect Appium Server logs
+        if: always()
+        run: |
+          TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
+          if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
+            echo "Test execution succeeded."
+          else
+            echo "Test execution failed, collecting logs..."
+            pushd $GITHUB_WORKSPACE/lynx/
+            if [ -f "appium.log" ]; then
+              cat appium.log
+            else
+              echo "Warning: appium.log file not found"
+            fi
+            popd
+          fi
+      - name: Collect Generated Resource Files
+        if: always()
+        run: |
+          TASK_STATUS="${{ steps.run_test.outputs.TASK_STATUS }}"
+          if [ -n "$TASK_STATUS" ] && [ "$TASK_STATUS" = "success" ]; then
+            echo "Test execution succeeded."
+          else
+            pushd $GITHUB_WORKSPACE/lynx/testing/integration_test/test_script
+            if [ -d "screenshots" ]; then
+              zip -r screenshots.zip ./screenshots/
+              echo "Successfully created screenshots.zip"
+              echo "ZIP_RESOURCES=success" >> $GITHUB_OUTPUT
+            else
+              echo "Warning: screenshot directory not found"
+            fi
+          fi
+        id: collect_resource
+      - name: Upload Generated Resource Files
+        if: always() && steps.collect_resource.outputs.ZIP_RESOURCES == 'success'
+        uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+        continue-on-error: true
+        with:
+          name: ios-e2e-resources
+          path: '${{ github.workspace }}/lynx/testing/integration_test/test_script/screenshots.zip'
 
   clay-macos-build:
     needs: [darwin-impact-check]

--- a/tools/ios_tools/process_podfile.py
+++ b/tools/ios_tools/process_podfile.py
@@ -31,15 +31,56 @@ def replace_pod_version(component, version, podfile):
     else:
         print(f"Failed to write the new version {version} of {component} to {podfile} ")
 
+
+def pin_pod_source(component, source, podfile):
+    pod_pattern = re.compile(
+        rf"^(\s*pod\s+['\"]{re.escape(component)}['\"]\s*,\s*['\"][^'\"]+['\"])(.*)$"
+    )
+    source_pattern = re.compile(r"(\s*,\s*:source\s*=>\s*['\"])([^'\"]+)(['\"])")
+
+    success_write = 0
+    with open(podfile, "r", encoding="utf8") as f:
+        lines = f.readlines()
+
+    new_lines = []
+    for line in lines:
+        line_without_newline = line.rstrip("\n")
+        match = pod_pattern.match(line_without_newline)
+        if not match:
+            new_lines.append(line)
+            continue
+
+        pod_prefix, pod_suffix = match.groups()
+        if source_pattern.search(pod_suffix):
+            pod_suffix = source_pattern.sub(rf"\g<1>{source}\g<3>", pod_suffix)
+        else:
+            pod_suffix = f", :source => '{source}'{pod_suffix}"
+        new_lines.append(f"{pod_prefix}{pod_suffix}\n")
+        success_write = 1
+
+    with open(podfile, "w", encoding="utf8") as f:
+        f.writelines(new_lines)
+
+    if success_write:
+        print(f"Successfully wrote the new source {source} of {component} to {podfile} ")
+    else:
+        print(f"Failed to write the new source {source} of {component} to {podfile} ")
+
+
 def insert_source_to_podfile(source, podfile):
-    with open(podfile, "r") as f:
+    with open(podfile, "r", encoding="utf8") as f:
         content = f.read()
 
+    if re.search(rf'^source\s+["\']{re.escape(source)}["\']\s*$', content, re.MULTILINE):
+        print(f"Source {source} already exists in {podfile} ")
+        return
+
     new_content = f"source \"{source}\"\n" + content
-    
-    with open(podfile, "w") as f:
+
+    with open(podfile, "w", encoding="utf8") as f:
         f.write(new_content)
     print(f"Successfully wrote the source {source} to {podfile} ")
+
 
 def main():
     """
@@ -47,7 +88,13 @@ def main():
     like : python3 process_podfile.py  --component Lynx --version 3.4.0 --podfile ios/HelloLynxObjc/Podfile
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--action', type=str, choices=["replace_pod_version", "insert_pod_source"], help='the action for processing podfile', required=True)
+    parser.add_argument(
+        '--action',
+        type=str,
+        choices=["replace_pod_version", "insert_pod_source", "pin_pod_source"],
+        help='the action for processing podfile',
+        required=True,
+    )
     parser.add_argument('--component', type=str, help='the component need to be processed', required=False)
     parser.add_argument('--version', type=str, help='the component version', required=False)
     parser.add_argument('--pod_source', type=str, help='the pod source need to be insert to the top of podfile', required=False)
@@ -67,6 +114,13 @@ def main():
             exit(1)
         else:
             insert_source_to_podfile(args.pod_source, args.podfile)
+
+    elif args.action == 'pin_pod_source':
+        if not args.component or not args.pod_source or not args.podfile:
+            print('Please specify --component, --pod_source, --podfile')
+            exit(1)
+        else:
+            pin_pod_source(args.component, args.pod_source, args.podfile)
  
 
 if __name__ == '__main__':

--- a/tools/ios_tools/process_podfile_test.py
+++ b/tools/ios_tools/process_podfile_test.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import process_podfile
+
+
+class ProcessPodfileTest(unittest.TestCase):
+    """Covers Podfile rewrite regressions used by ios-integration-test.
+
+    These tests ensure we do not duplicate pod sources and that Lynx-related
+    pods are pinned to the local CocoaPods source instead of falling back to
+    trunk for spec resolution.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.podfile_path = os.path.join(self.temp_dir.name, 'Podfile')
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def write_podfile(self, content):
+        Path(self.podfile_path).write_text(content, encoding='utf8')
+
+    def read_podfile(self):
+        return Path(self.podfile_path).read_text(encoding='utf8')
+
+    def test_insert_source_to_podfile_skips_duplicate_source(self):
+        source = 'file:///Users/runner/.cocoapods/repos/local_pod'
+        self.write_podfile(
+            f"source '{source}'\n"
+            "source 'https://cdn.cocoapods.org/'\n"
+            "target 'Hello-Lynx-OC' do\n"
+            "  pod 'Lynx', '0.0.1-alpha.1'\n"
+            "end\n"
+        )
+
+        process_podfile.insert_source_to_podfile(source, self.podfile_path)
+
+        self.assertEqual(self.read_podfile().count(source), 1)
+
+    def test_pin_pod_source_adds_source_to_matching_component(self):
+        source = 'file:///Users/runner/.cocoapods/repos/local_pod'
+        self.write_podfile(
+            "source 'https://cdn.cocoapods.org/'\n"
+            "target 'Hello-Lynx-OC' do\n"
+            "  pod 'Lynx', '0.0.1-alpha.1', :subspecs => ['Framework']\n"
+            "  pod 'LynxService', '0.0.1-alpha.1', :subspecs => ['Image']\n"
+            "  pod 'SDWebImage', '5.15.5'\n"
+            "end\n"
+        )
+
+        process_podfile.pin_pod_source('Lynx', source, self.podfile_path)
+        process_podfile.pin_pod_source('LynxService', source, self.podfile_path)
+
+        content = self.read_podfile()
+        self.assertIn(
+            f"pod 'Lynx', '0.0.1-alpha.1', :source => '{source}', :subspecs => ['Framework']",
+            content,
+        )
+        self.assertIn(
+            f"pod 'LynxService', '0.0.1-alpha.1', :source => '{source}', :subspecs => ['Image']",
+            content,
+        )
+        self.assertIn("pod 'SDWebImage', '5.15.5'", content)
+
+    def test_pin_pod_source_replaces_existing_source(self):
+        source = 'file:///Users/runner/.cocoapods/repos/local_pod'
+        self.write_podfile(
+            "target 'Hello-Lynx-OC' do\n"
+            "  pod 'XElement', '0.0.1-alpha.1', :source => 'https://cdn.cocoapods.org/'\n"
+            "end\n"
+        )
+
+        process_podfile.pin_pod_source('XElement', source, self.podfile_path)
+
+        self.assertIn(
+            f"pod 'XElement', '0.0.1-alpha.1', :source => '{source}'",
+            self.read_podfile(),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
1. Restore ios-integration-test, ios-explorer-build and ios-unittests-check with CocoaPods cache.
2. ios-integration-test will not fetch Lynx spec anymore

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
