### PR TITLE
[Feature][Types] Add gradual inline style type safety

### DIFF
--- a/js_libraries/types/CHANGELOG.md
+++ b/js_libraries/types/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 4.4.0
+- Add explicit `CompatibleCSSProperties` and `StrictCSSProperties` contracts.
+- Add `StrictStyleSheet` for type-only module-level strict adoption.
+- Add the `@lynx-js/types/strict` entry for project-level JSX style checking.
+- Route public style props through `InlineStyleProperties` while keeping compatible defaults.
+
+## 4.3.0
+- Preserve `csstype` and 4.2 `CSSProperties` compatibility in the default inline-style type.
+- Add generated `LynxCSSProperties` for opt-in metadata-based checking.
+
 ## 4.2.0
 - Add `box-shadow` to `transition-property` typings.
 

--- a/js_libraries/types/README.md
+++ b/js_libraries/types/README.md
@@ -18,11 +18,84 @@ These three sections contain all of Lynx's publicly available features:
 
 # Usage
 
+## Inline style types
+
+Choose strict checking for one object, one style map, or an entire TypeScript project. The default remains backward compatible.
+
+`CSSProperties` and its explicit alias `CompatibleCSSProperties` preserve values from `csstype` and the Lynx inline-style surface from 4.2. TypeScript compatibility does not guarantee that the Lynx runtime accepts every value.
+
+`StrictCSSProperties` is the author-facing alias for the finite, generated `LynxCSSProperties` contract. Current Lynx CSS metadata does not encode every runtime value grammar, so the strict contract can reject values that the runtime accepts.
+
+### Adopt one style object
+
+Use `satisfies StrictCSSProperties` to check one object without changing its inferred type:
+
+```typescript
+import type {
+  CSSProperties,
+  StrictCSSProperties,
+} from '@lynx-js/types';
+
+const compatibleStyle: CSSProperties = {
+  flex: 1,
+  display: 'linear',
+};
+
+const checkedStyle = {
+  display: 'linear',
+  position: 'absolute',
+} satisfies StrictCSSProperties;
+```
+
+### Adopt a style map
+
+Use `StrictStyleSheet` to check every named style in a module:
+
+```typescript
+import type { StrictStyleSheet } from '@lynx-js/types';
+
+export const styles = {
+  root: {
+    display: 'linear',
+    position: 'absolute',
+  },
+  label: {
+    color: '#fff',
+    fontSize: '16px',
+  },
+} satisfies StrictStyleSheet;
+```
+
+This contract preserves the concrete `root` and `label` keys and each property's literal inference. It does not add a runtime wrapper.
+
+### Adopt an entire project
+
+Create a declaration file included by your `tsconfig.json`:
+
+```typescript
+// lynx-strict-styles.d.ts
+import '@lynx-js/types/strict';
+```
+
+This type-only entry changes Lynx JSX and element `style` objects to `StrictCSSProperties` across that TypeScript project. Explicit `CSSProperties` annotations stay compatible, and string styles remain accepted without object checking.
+
+Remove the declaration import to return the project to compatible JSX style objects.
+
 ## For Framework Developers
 
 ```json
 "peerDependencies": {
   "@lynx-js/types": "latest"
+}
+```
+
+Use `InlineStyleProperties` when a framework or component exposes a Lynx style prop. The type resolves to the compatible contract by default and follows a consumer's project-level strict entry:
+
+```typescript
+import type { InlineStyleProperties } from '@lynx-js/types';
+
+interface CustomViewProps {
+  style?: string | InlineStyleProperties;
 }
 ```
 
@@ -53,4 +126,3 @@ declare module '@lynx-js/types' {
 ```
 
 Once extended, it can be used anywhere in the package.
-

--- a/js_libraries/types/package.json
+++ b/js_libraries/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/types",
-  "version": "4.2.0",
+  "version": "4.4.0",
   "description": "",
   "keywords": [
     "lynx",
@@ -15,7 +15,8 @@
   "types": "types/index.d.ts",
   "main": "types/index.d.ts",
   "scripts": {
-    "test": "vitest --typecheck --run && tsc --noEmit"
+    "test": "vitest --typecheck --run && tsc --noEmit && pnpm test:strict",
+    "test:strict": "tsc --noEmit --project test-strict/tsconfig.json"
   },
   "exports": {
     ".": {
@@ -38,6 +39,9 @@
     },
     "./props": {
       "types": "./types/common/props.d.ts"
+    },
+    "./strict": {
+      "types": "./types/common/strict.d.ts"
     }
   },
   "typesVersions": {
@@ -56,6 +60,9 @@
       ],
       "props": [
         "./types/common/props.d.ts"
+      ],
+      "strict": [
+        "./types/common/strict.d.ts"
       ],
       "main-thread": [
         "./types/main-thread/index.d.ts"

--- a/js_libraries/types/test-strict/enable-strict.d.ts
+++ b/js_libraries/types/test-strict/enable-strict.d.ts
@@ -1,0 +1,5 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import '@lynx-js/types/strict';

--- a/js_libraries/types/test-strict/index.tsx
+++ b/js_libraries/types/test-strict/index.tsx
@@ -1,0 +1,53 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type {} from '@lynx-js/types/strict';
+import { assertType, expectTypeOf } from 'vitest';
+import type {
+  CSSProperties,
+  InlineStyleProperties,
+  IntrinsicElements,
+  StrictCSSProperties,
+} from '@lynx-js/types';
+
+expectTypeOf<InlineStyleProperties>().toEqualTypeOf<StrictCSSProperties>();
+
+assertType<CSSProperties>({
+  aspectRatio: 4 / 3,
+  position: 'static',
+  zIndex: '0',
+});
+
+assertType<InlineStyleProperties>({
+  display: 'linear',
+  position: 'absolute',
+});
+
+assertType<InlineStyleProperties>({
+  // @ts-expect-error: the project entry selects strict metadata
+  position: 'static',
+});
+
+assertType<IntrinsicElements['view']['style']>('display: linear');
+
+<view style={{ display: 'linear', position: 'absolute' }} />;
+<view
+  style={{
+    // @ts-expect-error: project-level strict mode reaches JSX style objects
+    position: 'static',
+  }}
+/>;
+
+const componentAttributes: JSX.IntrinsicAttributes = {
+  style: { position: 'absolute' },
+};
+assertType<JSX.IntrinsicAttributes>(componentAttributes);
+
+const invalidComponentAttributes: JSX.IntrinsicAttributes = {
+  style: {
+    // @ts-expect-error: strict mode reaches component intrinsic attributes
+    position: 'static',
+  },
+};
+assertType<JSX.IntrinsicAttributes>(invalidComponentAttributes);

--- a/js_libraries/types/test-strict/tsconfig.json
+++ b/js_libraries/types/test-strict/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "..",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "rootDir": "..",
+    "skipLibCheck": true
+  },
+  "include": ["./enable-strict.d.ts", "./index.tsx"]
+}

--- a/js_libraries/types/test/common/css.test-d.ts
+++ b/js_libraries/types/test/common/css.test-d.ts
@@ -1,9 +1,23 @@
+import type * as CSS from 'csstype';
 import { assertType, describe, expectTypeOf, it } from 'vitest';
-import { CSSProperties, CSSPropertiesWithLonghands, CSSPropertiesWithShorthands } from '../../types';
+import {
+  CompatibleCSSProperties,
+  CSSProperties,
+  CSSPropertiesWithLonghands,
+  CSSPropertiesWithShorthands,
+  InlineStyleProperties,
+  LynxCSSProperties,
+  StrictCSSProperties,
+  StrictStyleSheet,
+} from '../../types';
+import type { PreviousCSSProperties } from './fixtures/css-properties-head';
 
 declare const css: CSSProperties;
 declare const cssWithLonghands: CSSPropertiesWithLonghands;
 declare const cssWithShorthands: CSSPropertiesWithShorthands;
+declare const standardCSSProperties: CSS.Properties<string | number>;
+declare const lynxCSSProperties: LynxCSSProperties;
+declare const previousCSSProperties: PreviousCSSProperties;
 
 describe('CSSProperty Type Test', () => {
   it('example', () => {
@@ -51,7 +65,7 @@ describe('CSSProperty Type Test', () => {
     });
 
     assertType<CSSProperties>({
-      // @ts-expect-error: pointerEvents only accept 'auto' or 'none'
+      // @ts-expect-error: pointerEvents does not accept arbitrary values
       pointerEvents: 'xxx',
     });
 
@@ -113,5 +127,98 @@ describe('CSSProperty Type Test', () => {
     assertType<CSSPropertiesWithLonghands>(css);
 
     assertType<CSSPropertiesWithShorthands>(css);
+  });
+
+  it('preserves the complete csstype compatibility surface', () => {
+    assertType<CSSProperties>(standardCSSProperties);
+    assertType<CSSProperties>(previousCSSProperties);
+
+    assertType<CSSProperties>({
+      flex: 1,
+      aspectRatio: 4 / 3,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      zIndex: '0',
+      flexShrink: '0',
+      backgroundOrigin: 'border-box, padding-box',
+      backgroundRepeat: 'no-repeat, repeat',
+      paddingLeft: 10,
+      marginTop: 20,
+      layoutAnimationCreateProperty: 'width',
+      listMainAxisGap: '12px',
+    });
+
+    assertType<CSSProperties>({
+      // @ts-expect-error: unknown property names are not valid inline styles
+      definitelyNotAStyle: 'value',
+    });
+  });
+
+  it('offers generated Lynx style checking as an opt-in', () => {
+    assertType<LynxCSSProperties>({
+      display: 'linear',
+      position: 'absolute',
+      gridColumnSpan: 2,
+      pointerEvents: 'none',
+      transformOrigin: 'center',
+      XCaretWidth: 2,
+      XCaretHeight: 16,
+      XCaretRadius: 4,
+      listMainAxisGap: '12px',
+    });
+
+    assertType<LynxCSSProperties>({
+      // @ts-expect-error: static is outside the generated Lynx position values
+      position: 'static',
+    });
+
+    assertType<LynxCSSProperties>({
+      // @ts-expect-error: backdrop-filter is not supported by Lynx metadata
+      backdropFilter: 'blur(4px)',
+    });
+
+    assertType<LynxCSSProperties>({
+      // @ts-expect-error: arbitrary strings are outside generated keyword values
+      transformOrigin: 'not-a-transform-origin',
+    });
+
+    assertType<LynxCSSProperties>({
+      // @ts-expect-error: unitless numbers are outside strict padding metadata
+      paddingLeft: 10,
+      // @ts-expect-error: unitless numbers are outside strict margin metadata
+      marginTop: 20,
+    });
+
+    assertType<LynxCSSProperties>({
+      // @ts-expect-error: arbitrary properties are outside generated animation values
+      layoutAnimationCreateProperty: 'width',
+    });
+
+    assertType<CSSProperties>(lynxCSSProperties);
+  });
+
+  it('supports scoped strict style adoption', () => {
+    expectTypeOf<CompatibleCSSProperties>().toEqualTypeOf<CSSProperties>();
+    expectTypeOf<StrictCSSProperties>().toEqualTypeOf<LynxCSSProperties>();
+    expectTypeOf<InlineStyleProperties>().toEqualTypeOf<CSSProperties>();
+
+    const styles = {
+      root: {
+        display: 'linear',
+        position: 'absolute',
+      },
+    } satisfies StrictStyleSheet;
+
+    expectTypeOf(styles.root.display).toEqualTypeOf<'linear'>();
+    expectTypeOf(styles.root.position).toEqualTypeOf<'absolute'>();
+
+    assertType<StrictStyleSheet>({
+      invalid: {
+        // @ts-expect-error: compatible-only values remain outside strict metadata
+        position: 'static',
+      },
+    });
   });
 });

--- a/js_libraries/types/test/common/fixtures/css-properties-head.d.ts
+++ b/js_libraries/types/test/common/fixtures/css-properties-head.d.ts
@@ -1,0 +1,114 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import type * as CSS from 'csstype';
+
+type Modify<T, R> = Omit<T, keyof R> & R;
+
+/** Independent frozen reconstruction of the 4.2 public override surface. */
+type PreviousManualOverrides = {
+  position?: 'absolute' | 'relative' | 'fixed' | 'sticky';
+  boxSizing?: 'border-box' | 'content-box' | 'auto';
+  display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';
+  overflow?: 'hidden' | 'visible' | (string & {});
+  whiteSpace?: 'normal' | 'nowrap';
+  textAlign?: 'left' | 'center' | 'right' | 'start' | 'end';
+  textOverflow?: 'clip' | 'ellipsis';
+  fontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+  flexDirection?: 'column' | 'row' | 'row-reverse' | 'column-reverse';
+  flexWrap?: 'wrap' | 'nowrap' | 'wrap-reverse';
+  alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around' | 'start' | 'end';
+  justifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'start' | 'end';
+  fontStyle?: 'normal' | 'italic' | 'oblique';
+  transform?:
+    | 'translate'
+    | 'translateX'
+    | 'translateY'
+    | 'translateZ'
+    | 'translate'
+    | 'translate3d'
+    | 'translate3D'
+    | 'rotate'
+    | 'rotateX'
+    | 'rotateY'
+    | 'rotateZ'
+    | 'scale'
+    | 'scaleX'
+    | 'scaleY'
+    | (string & {});
+  animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  transformOrigin?: 'left' | 'right' | 'top' | 'bottom' | 'center' | (string & {});
+  linearDirection?: 'column' | 'row' | 'column-reverse' | 'row-reverse';
+  linearOrientation?: 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse';
+  linearWeight?: number;
+  linearGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'space-between' | 'start' | 'end' | 'center';
+  linearLayoutGravity?:
+    | 'none'
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'center-vertical'
+    | 'center-horizontal'
+    | 'fill-vertical'
+    | 'fill-horizontal'
+    | 'center'
+    | 'stretch'
+    | 'start'
+    | 'end';
+  layoutAnimationCreateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  layoutAnimationCreateProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
+  layoutAnimationDeleteTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  layoutAnimationDeleteProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
+  layoutAnimationUpdateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  textDecoration?: 'none' | 'underline' | 'line-through' | (string & {});
+  visibility?: 'hidden' | 'visible' | 'none' | 'collapse';
+  transitionProperty?:
+    | 'none'
+    | 'opacity'
+    | 'scaleX'
+    | 'scaleY'
+    | 'scaleXY'
+    | 'width'
+    | 'height'
+    | 'background-color'
+    | 'visibility'
+    | 'left'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'transform'
+    | 'box-shadow'
+    | 'all'
+    | (string & {});
+  transitionTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  borderLeftStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderRightStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderTopStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderBottomStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  overflowX?: 'hidden' | 'visible' | (string & {});
+  overflowY?: 'hidden' | 'visible' | (string & {});
+  wordBreak?: 'normal' | 'break-all' | 'keep-all';
+  outlineStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  verticalAlign?: 'baseline' | 'sub' | 'super' | 'top' | 'text-top' | 'middle' | 'bottom' | 'text-bottom' | (string & {});
+  direction?: 'normal' | 'lynx-rtl' | 'rtl' | 'ltr';
+  relativeCenter?: 'none' | 'vertical' | 'horizontal' | 'both';
+  linearCrossGravity?: 'none' | 'start' | 'end' | 'center' | 'stretch';
+  listMainAxisGap?: 'grayscale' | (string & {});
+  fontVariationSettings?: string;
+  fontFeatureSettings?: string;
+  fontOpticalSizing?: 'none' | 'auto';
+  XAutoFontSizeLineRanges?: string;
+  XCaretGradient?: string;
+  XCaretWidth?: number | (string & {});
+  XCaretHeight?: number | (string & {});
+  XCaretRadius?: number | (string & {});
+  pointerEvents?: 'auto' | 'none';
+};
+
+export type PreviousCSSProperties = Modify<
+  CSS.Properties<string | number>,
+  PreviousManualOverrides
+>;

--- a/js_libraries/types/test/pages/view.test-d.tsx
+++ b/js_libraries/types/test/pages/view.test-d.tsx
@@ -24,6 +24,7 @@ import {
   RequestAccessibilityFocusMethod,
   IsAnimatingMethod,
   ScrollIntoViewMethod,
+  LynxCSSProperties,
 } from '../../types';
 
 // Props Types Check
@@ -159,6 +160,18 @@ let a;
   // Style
   <view style="color: red;" />;
   <view style={{ color: 'red' }} />;
+  <view
+    style={{
+      display: 'linear',
+      position: 'absolute',
+    } satisfies LynxCSSProperties}
+  />;
+  <view
+    style={{
+      // @ts-expect-error: static is outside the generated Lynx position values
+      position: 'static',
+    } satisfies LynxCSSProperties}
+  />;
   assertType<string | import('../../types/common/csstype').CSSProperties | undefined>(a as IntrinsicElements['view']['style']);
 
   // iOS background shape layer

--- a/js_libraries/types/types/common/csstype-legacy-compat.d.ts
+++ b/js_libraries/types/types/common/csstype-legacy-compat.d.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Immutable snapshot of manual CSSProperties overrides published in 4.2.
+ * Change this snapshot only as an intentional compatibility decision.
+ */
+export type LegacyCSSCompatibilityV4_2 = {
+  position?: 'absolute' | 'relative' | 'fixed' | 'sticky';
+  boxSizing?: 'border-box' | 'content-box' | 'auto';
+  display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';
+  overflow?: 'hidden' | 'visible' | (string & {});
+  whiteSpace?: 'normal' | 'nowrap';
+  textAlign?: 'left' | 'center' | 'right' | 'start' | 'end';
+  textOverflow?: 'clip' | 'ellipsis';
+  fontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+  flexDirection?: 'column' | 'row' | 'row-reverse' | 'column-reverse';
+  flexWrap?: 'wrap' | 'nowrap' | 'wrap-reverse';
+  alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around' | 'start' | 'end';
+  justifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'start' | 'end';
+  fontStyle?: 'normal' | 'italic' | 'oblique';
+  transform?:
+    | 'translate'
+    | 'translateX'
+    | 'translateY'
+    | 'translateZ'
+    | 'translate'
+    | 'translate3d'
+    | 'translate3D'
+    | 'rotate'
+    | 'rotateX'
+    | 'rotateY'
+    | 'rotateZ'
+    | 'scale'
+    | 'scaleX'
+    | 'scaleY'
+    | (string & {});
+  animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  transformOrigin?: 'left' | 'right' | 'top' | 'bottom' | 'center' | (string & {});
+  linearDirection?: 'column' | 'row' | 'column-reverse' | 'row-reverse';
+  linearOrientation?: 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse';
+  linearWeight?: number;
+  linearGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'space-between' | 'start' | 'end' | 'center';
+  linearLayoutGravity?:
+    | 'none'
+    | 'top'
+    | 'bottom'
+    | 'left'
+    | 'right'
+    | 'center-vertical'
+    | 'center-horizontal'
+    | 'fill-vertical'
+    | 'fill-horizontal'
+    | 'center'
+    | 'stretch'
+    | 'start'
+    | 'end';
+  layoutAnimationCreateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  layoutAnimationCreateProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
+  layoutAnimationDeleteTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  layoutAnimationDeleteProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
+  layoutAnimationUpdateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  textDecoration?: 'none' | 'underline' | 'line-through' | (string & {});
+  visibility?: 'hidden' | 'visible' | 'none' | 'collapse';
+  transitionProperty?:
+    | 'none'
+    | 'opacity'
+    | 'scaleX'
+    | 'scaleY'
+    | 'scaleXY'
+    | 'width'
+    | 'height'
+    | 'background-color'
+    | 'visibility'
+    | 'left'
+    | 'top'
+    | 'right'
+    | 'bottom'
+    | 'transform'
+    | 'box-shadow'
+    | 'all'
+    | (string & {});
+  transitionTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
+  borderLeftStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderRightStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderTopStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  borderBottomStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  overflowX?: 'hidden' | 'visible' | (string & {});
+  overflowY?: 'hidden' | 'visible' | (string & {});
+  wordBreak?: 'normal' | 'break-all' | 'keep-all';
+  outlineStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
+  verticalAlign?: 'baseline' | 'sub' | 'super' | 'top' | 'text-top' | 'middle' | 'bottom' | 'text-bottom' | (string & {});
+  direction?: 'normal' | 'lynx-rtl' | 'rtl' | 'ltr';
+  relativeCenter?: 'none' | 'vertical' | 'horizontal' | 'both';
+  linearCrossGravity?: 'none' | 'start' | 'end' | 'center' | 'stretch';
+  listMainAxisGap?: 'grayscale' | (string & {});
+  fontVariationSettings?: string;
+  fontFeatureSettings?: string;
+  fontOpticalSizing?: 'none' | 'auto';
+  XAutoFontSizeLineRanges?: string;
+  XCaretGradient?: string;
+  XCaretWidth?: number | (string & {});
+  XCaretHeight?: number | (string & {});
+  XCaretRadius?: number | (string & {});
+  pointerEvents?: 'auto' | 'none';
+};

--- a/js_libraries/types/types/common/csstype.d.ts
+++ b/js_libraries/types/types/common/csstype.d.ts
@@ -2,139 +2,67 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import * as CSS from 'csstype';
+import type * as CSS from 'csstype';
+import type { LegacyCSSCompatibilityV4_2 } from './csstype-legacy-compat';
+import type {
+  Longhands,
+  LynxCSSProperties,
+  Shorthands,
+} from './csstype.generated';
+
+export type {
+  Longhands,
+  LynxCSSProperties,
+  Shorthands,
+} from './csstype.generated';
 
 export type Modify<T, R> = Omit<T, keyof R> & R;
 
-export type CSSProperties = Modify<
-  CSS.Properties<string | number>,
-  {
-    position?: 'absolute' | 'relative' | 'fixed' | 'sticky';
-    boxSizing?: 'border-box' | 'content-box' | 'auto';
-    display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';
-    overflow?: 'hidden' | 'visible' | (string & {});
-    whiteSpace?: 'normal' | 'nowrap';
-    textAlign?: 'left' | 'center' | 'right' | 'start' | 'end';
-    textOverflow?: 'clip' | 'ellipsis';
-    fontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
-    flexDirection?: 'column' | 'row' | 'row-reverse' | 'column-reverse';
-    flexWrap?: 'wrap' | 'nowrap' | 'wrap-reverse';
-    alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around' | 'start' | 'end';
-    justifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'start' | 'end';
-    fontStyle?: 'normal' | 'italic' | 'oblique';
-    transform?:
-      | 'translate'
-      | 'translateX'
-      | 'translateY'
-      | 'translateZ'
-      | 'translate'
-      | 'translate3d'
-      | 'translate3D'
-      | 'rotate'
-      | 'rotateX'
-      | 'rotateY'
-      | 'rotateZ'
-      | 'scale'
-      | 'scaleX'
-      | 'scaleY'
-      | (string & {});
-    animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
-    borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    transformOrigin?: 'left' | 'right' | 'top' | 'bottom' | 'center' | (string & {});
-    linearDirection?: 'column' | 'row' | 'column-reverse' | 'row-reverse';
-    linearOrientation?: 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse';
-    linearWeight?: number;
-    linearGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'space-between' | 'start' | 'end' | 'center';
-    linearLayoutGravity?:
-      | 'none'
-      | 'top'
-      | 'bottom'
-      | 'left'
-      | 'right'
-      | 'center-vertical'
-      | 'center-horizontal'
-      | 'fill-vertical'
-      | 'fill-horizontal'
-      | 'center'
-      | 'stretch'
-      | 'start'
-      | 'end';
-    layoutAnimationCreateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
-    layoutAnimationCreateProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
-    layoutAnimationDeleteTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
-    layoutAnimationDeleteProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | (string & {});
-    layoutAnimationUpdateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
-    textDecoration?: 'none' | 'underline' | 'line-through' | (string & {});
-    visibility?: 'hidden' | 'visible' | 'none' | 'collapse';
-    transitionProperty?:
-      | 'none'
-      | 'opacity'
-      | 'scaleX'
-      | 'scaleY'
-      | 'scaleXY'
-      | 'width'
-      | 'height'
-      | 'background-color'
-      | 'visibility'
-      | 'left'
-      | 'top'
-      | 'right'
-      | 'bottom'
-      | 'transform'
-      | 'box-shadow'
-      | 'all'
-      | (string & {});
-    transitionTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier' | (string & {});
-    borderLeftStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    borderRightStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    borderTopStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    borderBottomStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    overflowX?: 'hidden' | 'visible' | (string & {});
-    overflowY?: 'hidden' | 'visible' | (string & {});
-    wordBreak?: 'normal' | 'break-all' | 'keep-all';
-    outlineStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none' | (string & {});
-    verticalAlign?: 'baseline' | 'sub' | 'super' | 'top' | 'text-top' | 'middle' | 'bottom' | 'text-bottom' | (string & {});
-    direction?: 'normal' | 'lynx-rtl' | 'rtl' | 'ltr';
-    relativeCenter?: 'none' | 'vertical' | 'horizontal' | 'both';
-    linearCrossGravity?: 'none' | 'start' | 'end' | 'center' | 'stretch';
-    listMainAxisGap?: 'grayscale' | (string & {});
-    fontVariationSettings?: string;
-    fontFeatureSettings?: string;
-    fontOpticalSizing?: 'none' | 'auto';
-    XAutoFontSizeLineRanges?: string;
-    XCaretGradient?: string;
-    XCaretWidth?: number | (string & {});
-    XCaretHeight?: number | (string & {});
-    XCaretRadius?: number | (string & {});
-    pointerEvents?: 'auto' | 'none';
-  }
+type StandardCSSProperties = CSS.Properties<string | number>;
+
+type StylePropertyName =
+  | keyof StandardCSSProperties
+  | keyof LynxCSSProperties
+  | keyof LegacyCSSCompatibilityV4_2;
+
+type ValueAt<T, K extends PropertyKey> = K extends keyof T ? T[K] : never;
+
+/**
+ * The default inline style type preserves standard, generated, and previously
+ * published Lynx values. Use LynxCSSProperties for metadata-only checking.
+ */
+export type CSSProperties = {
+  [K in StylePropertyName]?:
+    | ValueAt<StandardCSSProperties, K>
+    | ValueAt<LynxCSSProperties, K>
+    | ValueAt<LegacyCSSCompatibilityV4_2, K>;
+};
+
+/** The explicit name for the backward-compatible inline-style contract. */
+export type CompatibleCSSProperties = CSSProperties;
+
+/** The metadata-derived contract for opt-in strict inline-style checking. */
+export type StrictCSSProperties = LynxCSSProperties;
+
+/** A type-only contract for checking every value in a named style map. */
+export type StrictStyleSheet = Readonly<
+  Record<string, StrictCSSProperties>
 >;
 
-export type Shorthands = 
-  // layout
-  "flexFlow" | "padding" | "margin" | "flex" | "backgroundPosition" |
-  // typography
-  "outline" | "textDecoration" |
-  // visual
-  "border" | "borderRight" | "borderLeft" | "borderTop" | "borderBottom" | "borderRadius" | "borderWidth" | "background" | "borderColor" | "borderStyle" |
-  // animation
-  "transition" | "animation" |
-  // other
-  "mask" | "gap" | "overflow" | "whiteSpace";
-export type Longhands = 
-  // layout
-  "marginInlineStart" | "marginInlineEnd" | "paddingInlineStart" | "paddingInlineEnd" | "gridTemplateColumns" | "gridTemplateRows" | "gridAutoColumns" | "gridAutoRows" | "gridColumnSpan" | "gridRowSpan" | "gridColumnStart" | "gridColumnEnd" | "gridRowStart" | "gridRowEnd" | "gridColumnGap" | "gridRowGap" | "gridAutoFlow" | "maskPosition" | "display" | "paddingLeft" | "paddingRight" | "paddingTop" | "paddingBottom" | "marginLeft" | "marginRight" | "marginTop" | "marginBottom" | "position" | "flexGrow" | "flexShrink" | "flexBasis" | "flexDirection" | "flexWrap" |
-  // typography
-  "outlineColor" | "outlineStyle" | "outlineWidth" | "textDecorationColor" | "linearCrossGravity" | "borderInlineStartColor" | "borderInlineEndColor" | "borderInlineStartWidth" | "borderInlineEndWidth" | "borderInlineStartStyle" | "borderInlineEndStyle" | "relativeAlignInlineStart" | "relativeAlignInlineEnd" | "relativeInlineStartOf" | "relativeInlineEndOf" | "insetInlineStart" | "insetInlineEnd" | "linearDirection" | "textIndent" | "textStroke" | "textStrokeWidth" | "textStrokeColor" | "XAutoFontSize" | "XAutoFontSizePresetSizes" | "XAutoFontSizeLineRanges" | "XCaretGradient" | "XCaretWidth" | "XCaretHeight" | "XCaretRadius" | "fontVariationSettings" | "fontFeatureSettings" | "fontOpticalSizing" | "textAlign" | "lineHeight" | "textOverflow" | "fontSize" | "fontWeight" | "fontFamily" | "fontStyle" | "lineSpacing" | "linearOrientation" | "linearWeightSum" | "linearWeight" | "linearGravity" | "linearLayoutGravity" | "adaptFontSize" | "textShadow" |
-  // visual
-  "borderTopColor" | "backgroundOrigin" | "backgroundRepeat" | "backgroundSize" | "borderBottomColor" | "borderLeftStyle" | "borderRightStyle" | "borderTopStyle" | "borderBottomStyle" | "backgroundClip" | "caretColor" | "borderTopLeftRadius" | "borderBottomLeftRadius" | "borderTopRightRadius" | "borderBottomRightRadius" | "borderStartStartRadius" | "borderEndStartRadius" | "borderStartEndRadius" | "borderEndEndRadius" | "borderLeftWidth" | "borderRightWidth" | "borderTopWidth" | "borderBottomWidth" | "XAnimationColorInterpolation" | "XHandleColor" | "color" | "backgroundColor" | "borderLeftColor" | "borderRightColor" | "backgroundImage" |
-  // animation
-  "transitionProperty" | "transitionDuration" | "transitionDelay" | "transitionTimingFunction" | "implicitAnimation" | "enterTransitionName" | "exitTransitionName" | "pauseTransitionName" | "resumeTransitionName" | "animationName" | "animationDuration" | "animationTimingFunction" | "animationDelay" | "animationIterationCount" | "animationDirection" | "animationFillMode" | "animationPlayState" | "layoutAnimationCreateDuration" | "layoutAnimationCreateTimingFunction" | "layoutAnimationCreateDelay" | "layoutAnimationCreateProperty" | "layoutAnimationDeleteDuration" | "layoutAnimationDeleteTimingFunction" | "layoutAnimationDeleteDelay" | "layoutAnimationDeleteProperty" | "layoutAnimationUpdateDuration" | "layoutAnimationUpdateTimingFunction" | "layoutAnimationUpdateDelay" |
-  // other
-  "top" | "visibility" | "content" | "overflowX" | "overflowY" | "wordBreak" | "verticalAlign" | "direction" | "relativeId" | "relativeAlignTop" | "relativeAlignRight" | "relativeAlignBottom" | "relativeAlignLeft" | "relativeTopOf" | "relativeRightOf" | "relativeBottomOf" | "relativeLeftOf" | "relativeLayoutOnce" | "relativeCenter" | "zIndex" | "maskImage" | "justifyItems" | "justifySelf" | "filter" | "listMainAxisGap" | "listCrossAxisGap" | "perspective" | "cursor" | "clipPath" | "left" | "maskRepeat" | "maskClip" | "maskOrigin" | "maskSize" | "columnGap" | "rowGap" | "imageRendering" | "hyphens" | "XAppRegion" | "XHandleSize" | "offsetDistance" | "offsetPath" | "offsetRotate" | "opacity" | "height" | "width" | "maxWidth" | "minWidth" | "right" | "maxHeight" | "minHeight" | "bottom" | "letterSpacing" | "alignItems" | "alignSelf" | "alignContent" | "justifyContent" | "boxSizing" | "transform" | "order" | "boxShadow" | "transformOrigin" | "aspectRatio" | "pointerEvents";
+/** Declaration-merging hook used by the optional strict package entry. */
+export interface InlineStyleTypeConfig {}
 
-// Since `Shorthands` and `Longhands` are auto generated, there may be properties
-// such as `gridColumnSpan` is not manually defined in `CSSProperties` yet.
-// Use `& keyof CSSProperties` to ensure only the defined keys are included to avoid type error.
-export type CSSPropertiesWithShorthands = Pick<CSSProperties, Shorthands & keyof CSSProperties>;
-export type CSSPropertiesWithLonghands = Pick<CSSProperties, Longhands & keyof CSSProperties>;
+/** The style-object contract consumed by Lynx element props. */
+export type InlineStyleProperties =
+  InlineStyleTypeConfig extends { strict: true }
+    ? StrictCSSProperties
+    : CompatibleCSSProperties;
+
+export type CSSPropertiesWithShorthands = Pick<
+  CSSProperties,
+  Shorthands & keyof CSSProperties
+>;
+export type CSSPropertiesWithLonghands = Pick<
+  CSSProperties,
+  Longhands & keyof CSSProperties
+>;

--- a/js_libraries/types/types/common/csstype.generated.d.ts
+++ b/js_libraries/types/types/common/csstype.generated.d.ts
@@ -1,0 +1,285 @@
+// Copyright 2024 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * This file is auto-generated from CSS define files in the css_defines directory.
+ * Each property's type is determined by:
+ * 1. For enum types: Uses the values array from the CSS define file
+ * 2. For length types: Uses string, plus number only when metadata allows it
+ * 3. For properties with keywords: Uses the keywords array as enum values
+ * 4. For other types: Uses string type
+ *
+ * LynxCSSProperties is the stricter metadata-derived opt-in type.
+ */
+
+export type LynxCSSProperties = {
+  // layout
+  flexFlow?: string;
+  marginInlineStart?: string;
+  marginInlineEnd?: string;
+  paddingInlineStart?: string;
+  paddingInlineEnd?: string;
+  gridTemplateColumns?: string;
+  gridTemplateRows?: string;
+  gridAutoColumns?: string;
+  gridAutoRows?: string;
+  gridColumnSpan?: number;
+  gridRowSpan?: number;
+  gridColumnStart?: string;
+  gridColumnEnd?: string;
+  gridRowStart?: string;
+  gridRowEnd?: string;
+  gridColumnGap?: string;
+  gridRowGap?: string;
+  gridAutoFlow?: 'row' | 'column' | 'dense' | 'row dense' | 'column dense';
+  maskPosition?: string;
+  gridColumn?: string;
+  gridRow?: string;
+  display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';
+  padding?: string;
+  paddingLeft?: string;
+  paddingRight?: string;
+  paddingTop?: string;
+  paddingBottom?: string;
+  margin?: string;
+  marginLeft?: string;
+  marginRight?: string;
+  marginTop?: string;
+  marginBottom?: string;
+  flex?: string;
+  position?: 'absolute' | 'relative' | 'fixed' | 'sticky';
+  flexGrow?: number;
+  flexShrink?: number;
+  flexBasis?: string;
+  flexDirection?: 'column' | 'row' | 'row-reverse' | 'column-reverse';
+  flexWrap?: 'wrap' | 'nowrap' | 'wrap-reverse';
+  backgroundPosition?: string;
+
+  // typography
+  outline?: string;
+  outlineColor?: string;
+  outlineStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  outlineWidth?: string;
+  textDecorationColor?: string;
+  linearCrossGravity?: 'none' | 'start' | 'end' | 'center' | 'stretch';
+  borderInlineStartColor?: string;
+  borderInlineEndColor?: string;
+  borderInlineStartWidth?: string;
+  borderInlineEndWidth?: string;
+  borderInlineStartStyle?: string;
+  borderInlineEndStyle?: string;
+  relativeAlignInlineStart?: string;
+  relativeAlignInlineEnd?: string;
+  relativeInlineStartOf?: number;
+  relativeInlineEndOf?: number;
+  insetInlineStart?: string;
+  insetInlineEnd?: string;
+  linearDirection?: string;
+  textIndent?: string;
+  textStroke?: string;
+  textStrokeWidth?: string;
+  textStrokeColor?: string;
+  XAutoFontSize?: string;
+  XAutoFontSizePresetSizes?: string;
+  fontVariationSettings?: string;
+  fontFeatureSettings?: string;
+  fontOpticalSizing?: 'none' | 'auto';
+  XPlaceholderFontFamily?: string;
+  XPlaceholderFontSize?: string;
+  XPlaceholderFontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+  XPlaceholderFontStyle?: 'normal' | 'italic' | 'oblique';
+  XAutoFontSizeLineRanges?: string;
+  textDecorationThickness?: string;
+  XTextDecorationWidth?: string;
+  XTextDecorationGap?: string;
+  textAlign?: 'left' | 'center' | 'right' | 'start' | 'end' | 'justify';
+  lineHeight?: string;
+  textOverflow?: 'clip' | 'ellipsis';
+  fontSize?: string;
+  fontWeight?: 'normal' | 'bold' | '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900';
+  fontFamily?: string;
+  fontStyle?: 'normal' | 'italic' | 'oblique';
+  lineSpacing?: string;
+  linearOrientation?: 'horizontal' | 'vertical' | 'horizontal-reverse' | 'vertical-reverse' | 'row' | 'column' | 'row-reverse' | 'column-reverse';
+  linearWeightSum?: number;
+  linearWeight?: number;
+  linearGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'space-between' | 'start' | 'end' | 'center';
+  linearLayoutGravity?: 'none' | 'top' | 'bottom' | 'left' | 'right' | 'center-vertical' | 'center-horizontal' | 'fill-vertical' | 'fill-horizontal' | 'center' | 'stretch' | 'start' | 'end';
+  adaptFontSize?: string;
+  textDecoration?: 'none' | 'underline' | 'line-through';
+  textShadow?: string;
+
+  // visual
+  borderTopColor?: string;
+  backgroundOrigin?: 'border-box' | 'content-box' | 'padding-box';
+  backgroundRepeat?: 'no-repeat' | 'repeat-x' | 'repeat-y' | 'repeat' | 'round' | 'space';
+  backgroundSize?: string;
+  border?: string;
+  borderRight?: string;
+  borderLeft?: string;
+  borderTop?: string;
+  borderBottom?: string;
+  borderBottomColor?: string;
+  borderLeftStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  borderRightStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  borderTopStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  borderBottomStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  borderRadius?: string;
+  backgroundClip?: 'border-box' | 'content-box' | 'padding-box' | 'text' | 'border-area';
+  caretColor?: string;
+  borderTopLeftRadius?: string;
+  borderBottomLeftRadius?: string;
+  borderTopRightRadius?: string;
+  borderBottomRightRadius?: string;
+  borderStartStartRadius?: string;
+  borderEndStartRadius?: string;
+  borderStartEndRadius?: string;
+  borderEndEndRadius?: string;
+  borderWidth?: string;
+  borderLeftWidth?: string;
+  borderRightWidth?: string;
+  borderTopWidth?: string;
+  borderBottomWidth?: string;
+  XAnimationColorInterpolation?: 'auto' | 'sRGB' | 'linearRGB';
+  XHandleColor?: string;
+  color?: string;
+  XPlaceholderColor?: string;
+  background?: string;
+  borderColor?: string;
+  backgroundColor?: string;
+  borderStyle?: 'solid' | 'dashed' | 'dotted' | 'double' | 'groove' | 'ridge' | 'inset' | 'outset' | 'hidden' | 'none';
+  borderLeftColor?: string;
+  borderRightColor?: string;
+  backgroundImage?: string;
+
+  // animation
+  transition?: string;
+  transitionProperty?: 'none' | 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY' | 'width' | 'height' | 'background-color' | 'visibility' | 'left' | 'top' | 'right' | 'bottom' | 'transform' | 'box-shadow' | 'all';
+  transitionDuration?: string;
+  transitionDelay?: string;
+  transitionTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier';
+  implicitAnimation?: string;
+  enterTransitionName?: string;
+  exitTransitionName?: string;
+  pauseTransitionName?: string;
+  resumeTransitionName?: string;
+  animation?: string;
+  animationName?: string;
+  animationDuration?: string;
+  animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier';
+  animationDelay?: string;
+  animationIterationCount?: string;
+  animationDirection?: 'normal' | 'reverse' | 'alternate' | 'alternate-reverse';
+  animationFillMode?: 'none' | 'forwards' | 'backwards' | 'both';
+  animationPlayState?: 'paused' | 'running';
+  layoutAnimationCreateDuration?: string;
+  layoutAnimationCreateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier';
+  layoutAnimationCreateDelay?: string;
+  layoutAnimationCreateProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY';
+  layoutAnimationDeleteDuration?: string;
+  layoutAnimationDeleteTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier';
+  layoutAnimationDeleteDelay?: string;
+  layoutAnimationDeleteProperty?: 'opacity' | 'scaleX' | 'scaleY' | 'scaleXY';
+  layoutAnimationUpdateDuration?: string;
+  layoutAnimationUpdateTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-ease-out' | 'ease' | 'ease-in-out' | 'square-bezier' | 'cubic-bezier';
+  layoutAnimationUpdateDelay?: string;
+
+  // other
+  top?: string;
+  visibility?: 'hidden' | 'visible' | 'none' | 'collapse';
+  content?: string;
+  overflowX?: 'hidden' | 'visible';
+  overflowY?: 'hidden' | 'visible';
+  wordBreak?: 'normal' | 'break-all' | 'keep-all';
+  verticalAlign?: 'baseline' | 'sub' | 'super' | 'top' | 'text-top' | 'middle' | 'bottom' | 'text-bottom';
+  direction?: 'normal' | 'lynx-rtl' | 'rtl' | 'ltr';
+  relativeId?: number;
+  relativeAlignTop?: string;
+  relativeAlignRight?: string;
+  relativeAlignBottom?: string;
+  relativeAlignLeft?: string;
+  relativeTopOf?: number;
+  relativeRightOf?: number;
+  relativeBottomOf?: number;
+  relativeLeftOf?: number;
+  relativeLayoutOnce?: string;
+  relativeCenter?: 'none' | 'vertical' | 'horizontal' | 'both';
+  zIndex?: number;
+  maskImage?: string;
+  justifyItems?: 'start' | 'end' | 'center' | 'stretch' | 'auto';
+  justifySelf?: 'start' | 'end' | 'center' | 'stretch' | 'auto';
+  filter?: string;
+  listMainAxisGap?: string;
+  listCrossAxisGap?: string;
+  perspective?: string;
+  cursor?: string;
+  clipPath?: string;
+  mask?: string;
+  left?: string;
+  maskRepeat?: string;
+  maskClip?: string;
+  maskOrigin?: string;
+  maskSize?: string;
+  gap?: string;
+  columnGap?: string;
+  rowGap?: string;
+  imageRendering?: 'auto' | 'crisp-edges' | 'pixelated';
+  hyphens?: 'none' | 'manual' | 'auto';
+  XAppRegion?: 'none' | 'drag' | 'no-drag';
+  XHandleSize?: string;
+  offsetDistance?: string;
+  offsetPath?: string;
+  offsetRotate?: string;
+  pointerEvents?: 'auto' | 'none';
+  maskComposite?: string;
+  opacity?: number;
+  XCaretGradient?: string;
+  XCaretWidth?: string | number;
+  XCaretHeight?: string | number;
+  XCaretRadius?: string | number;
+  overflow?: 'hidden' | 'visible';
+  height?: string;
+  width?: string;
+  maxWidth?: string;
+  minWidth?: string;
+  right?: string;
+  maxHeight?: string;
+  minHeight?: string;
+  bottom?: string;
+  whiteSpace?: 'normal' | 'nowrap';
+  letterSpacing?: string;
+  alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'auto' | 'start' | 'end' | 'baseline';
+  alignSelf?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'auto' | 'start' | 'end' | 'baseline';
+  alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around' | 'start' | 'end';
+  justifyContent?: 'flex-start' | 'center' | 'flex-end' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | 'start' | 'end';
+  boxSizing?: 'border-box' | 'content-box' | 'auto';
+  transform?: 'translate' | 'translateX' | 'translateY' | 'translateZ' | 'translate' | 'translate3d' | 'translate3D' | 'rotate' | 'rotateX' | 'rotateY' | 'rotateZ' | 'scale' | 'scaleX' | 'scaleY';
+  order?: number;
+  boxShadow?: string;
+  transformOrigin?: 'left' | 'right' | 'top' | 'bottom' | 'center';
+  aspectRatio?: string;
+};
+
+export type Shorthands =
+  // layout
+  "flexFlow" | "gridColumn" | "gridRow" | "padding" | "margin" | "flex" | "backgroundPosition" |
+  // typography
+  "outline" | "textDecoration" |
+  // visual
+  "border" | "borderRight" | "borderLeft" | "borderTop" | "borderBottom" | "borderRadius" | "borderWidth" | "background" | "borderColor" | "borderStyle" |
+  // animation
+  "transition" | "animation" |
+  // other
+  "mask" | "gap" | "overflow" | "whiteSpace";
+export type Longhands =
+  // layout
+  "marginInlineStart" | "marginInlineEnd" | "paddingInlineStart" | "paddingInlineEnd" | "gridTemplateColumns" | "gridTemplateRows" | "gridAutoColumns" | "gridAutoRows" | "gridColumnSpan" | "gridRowSpan" | "gridColumnStart" | "gridColumnEnd" | "gridRowStart" | "gridRowEnd" | "gridColumnGap" | "gridRowGap" | "gridAutoFlow" | "maskPosition" | "display" | "paddingLeft" | "paddingRight" | "paddingTop" | "paddingBottom" | "marginLeft" | "marginRight" | "marginTop" | "marginBottom" | "position" | "flexGrow" | "flexShrink" | "flexBasis" | "flexDirection" | "flexWrap" |
+  // typography
+  "outlineColor" | "outlineStyle" | "outlineWidth" | "textDecorationColor" | "linearCrossGravity" | "borderInlineStartColor" | "borderInlineEndColor" | "borderInlineStartWidth" | "borderInlineEndWidth" | "borderInlineStartStyle" | "borderInlineEndStyle" | "relativeAlignInlineStart" | "relativeAlignInlineEnd" | "relativeInlineStartOf" | "relativeInlineEndOf" | "insetInlineStart" | "insetInlineEnd" | "linearDirection" | "textIndent" | "textStroke" | "textStrokeWidth" | "textStrokeColor" | "XAutoFontSize" | "XAutoFontSizePresetSizes" | "fontVariationSettings" | "fontFeatureSettings" | "fontOpticalSizing" | "XPlaceholderFontFamily" | "XPlaceholderFontSize" | "XPlaceholderFontWeight" | "XPlaceholderFontStyle" | "XAutoFontSizeLineRanges" | "textDecorationThickness" | "XTextDecorationWidth" | "XTextDecorationGap" | "textAlign" | "lineHeight" | "textOverflow" | "fontSize" | "fontWeight" | "fontFamily" | "fontStyle" | "lineSpacing" | "linearOrientation" | "linearWeightSum" | "linearWeight" | "linearGravity" | "linearLayoutGravity" | "adaptFontSize" | "textShadow" |
+  // visual
+  "borderTopColor" | "backgroundOrigin" | "backgroundRepeat" | "backgroundSize" | "borderBottomColor" | "borderLeftStyle" | "borderRightStyle" | "borderTopStyle" | "borderBottomStyle" | "backgroundClip" | "caretColor" | "borderTopLeftRadius" | "borderBottomLeftRadius" | "borderTopRightRadius" | "borderBottomRightRadius" | "borderStartStartRadius" | "borderEndStartRadius" | "borderStartEndRadius" | "borderEndEndRadius" | "borderLeftWidth" | "borderRightWidth" | "borderTopWidth" | "borderBottomWidth" | "XAnimationColorInterpolation" | "XHandleColor" | "color" | "XPlaceholderColor" | "backgroundColor" | "borderLeftColor" | "borderRightColor" | "backgroundImage" |
+  // animation
+  "transitionProperty" | "transitionDuration" | "transitionDelay" | "transitionTimingFunction" | "implicitAnimation" | "enterTransitionName" | "exitTransitionName" | "pauseTransitionName" | "resumeTransitionName" | "animationName" | "animationDuration" | "animationTimingFunction" | "animationDelay" | "animationIterationCount" | "animationDirection" | "animationFillMode" | "animationPlayState" | "layoutAnimationCreateDuration" | "layoutAnimationCreateTimingFunction" | "layoutAnimationCreateDelay" | "layoutAnimationCreateProperty" | "layoutAnimationDeleteDuration" | "layoutAnimationDeleteTimingFunction" | "layoutAnimationDeleteDelay" | "layoutAnimationDeleteProperty" | "layoutAnimationUpdateDuration" | "layoutAnimationUpdateTimingFunction" | "layoutAnimationUpdateDelay" |
+  // other
+  "top" | "visibility" | "content" | "overflowX" | "overflowY" | "wordBreak" | "verticalAlign" | "direction" | "relativeId" | "relativeAlignTop" | "relativeAlignRight" | "relativeAlignBottom" | "relativeAlignLeft" | "relativeTopOf" | "relativeRightOf" | "relativeBottomOf" | "relativeLeftOf" | "relativeLayoutOnce" | "relativeCenter" | "zIndex" | "maskImage" | "justifyItems" | "justifySelf" | "filter" | "listMainAxisGap" | "listCrossAxisGap" | "perspective" | "cursor" | "clipPath" | "left" | "maskRepeat" | "maskClip" | "maskOrigin" | "maskSize" | "columnGap" | "rowGap" | "imageRendering" | "hyphens" | "XAppRegion" | "XHandleSize" | "offsetDistance" | "offsetPath" | "offsetRotate" | "pointerEvents" | "maskComposite" | "opacity" | "XCaretGradient" | "XCaretWidth" | "XCaretHeight" | "XCaretRadius" | "height" | "width" | "maxWidth" | "minWidth" | "right" | "maxHeight" | "minHeight" | "bottom" | "letterSpacing" | "alignItems" | "alignSelf" | "alignContent" | "justifyContent" | "boxSizing" | "transform" | "order" | "boxShadow" | "transformOrigin" | "aspectRatio";

--- a/js_libraries/types/types/common/element/attributes.d.ts
+++ b/js_libraries/types/types/common/element/attributes.d.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { CSSProperties } from '../csstype';
+import { InlineStyleProperties } from '../csstype';
 
 /**
  * IntrinsicAttributes specifies extra properties used by the JSX framework
@@ -29,7 +29,7 @@ export interface IntrinsicAttributes {
    *
    * Has no effect when `removeComponentElement` enabled.
    */
-  style?: string | CSSProperties;
+  style?: string | InlineStyleProperties;
 
   // /**
   //  * The CSS classes set to the view of component.

--- a/js_libraries/types/types/common/props.d.ts
+++ b/js_libraries/types/types/common/props.d.ts
@@ -2,7 +2,7 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import { CSSProperties } from './csstype';
+import { InlineStyleProperties } from './csstype';
 import { LynxEventProps } from './events';
 
 export interface StandardProps extends LynxEventProps {
@@ -265,7 +265,7 @@ export interface StandardProps extends LynxEventProps {
    * @Harmony
    * @PC
    */
-  style?: string | CSSProperties;
+  style?: string | InlineStyleProperties;
 
   /**
    * We use CAShapeLayer to accelerate rendering of the component's backgrounds on iOS.

--- a/js_libraries/types/types/common/strict.d.ts
+++ b/js_libraries/types/types/common/strict.d.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import './csstype';
+
+declare module './csstype' {
+  interface InlineStyleTypeConfig {
+    strict: true;
+  }
+}

--- a/tools/css_generator/CHANGELOG.md
+++ b/tools/css_generator/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.18
+- Separate the generated strict declaration from the handwritten compatibility façade.
+- Add explicit unitless-number metadata for inline length values that support JavaScript numbers.
+- Align metadata with schema validation and correct `list-main-axis-gap` metadata.
+
 ## 0.0.17
 - Add compat_data for `box-shadow` animations and the `transition-property: box-shadow` keyword.
 

--- a/tools/css_generator/README.md
+++ b/tools/css_generator/README.md
@@ -10,9 +10,9 @@ This package serves as the source of truth for all CSS APIs defined in the Lynx 
     - [Property vs Attribute](#property-vs-attribute)
     - [Vendor Prefix](#vendor-prefix)
     - [Adding a New Property](#adding-a-new-property)
-  - [TypeScript Type Generation](#typescript-type-generation)
-    - [Type Generation Rules](#type-generation-rules)
-    - [Build Process](#build-process)
+  - [TypeScript type generation](#typescript-type-generation)
+    - [Type generation rules](#type-generation-rules)
+    - [Build process](#build-process)
     - [Usage](#usage)
   - [Schema](#schema)
   - [Tutorial: Implementing a CSS Property](#tutorial-implementing-a-css-property)
@@ -51,34 +51,31 @@ Once you have decided to add a new property, you can follow the steps below:
    1. [Parser](../../core/renderer/css/parser/background_box_handler.h): The parser function is used to parse the value of the property.
    2. [ComputedCSSStyle](../../core/renderer/css/computed_css_style.cc): The setter and getter functions should be manually implemented according to the output of parser. If the property will be consumed by the platform UI layer, you have to add it to the macro `FOREACH_PLATFORM_PROPERTY` in the header file.
 
-## TypeScript Type Generation
+## TypeScript type generation
 
-### Type Generation Rules
+CSS definitions generate `js_libraries/types/types/common/csstype.generated.d.ts`, which exports `LynxCSSProperties`, `Shorthands`, and `Longhands`.
 
-The type definitions in `js_libraries/types/types/common/csstype.d.ts` are automatically generated from CSS define files in the `css_defines` directory. The generation process follows these rules:
+The stable, handwritten `js_libraries/types/types/common/csstype.d.ts` façade composes generated strict values, standard values from `csstype`, and the versioned `csstype-legacy-compat.d.ts` snapshot. The generator writes only the generated declaration. It never overwrites the façade or its compatibility policy.
 
-1. For enum types (properties with `"type": "enum"`):
-   - Uses the `values` array to generate a union type of string literals
-   - Example: `display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';`
+### Type generation rules
 
-2. For properties with keywords:
-   - Uses the `keywords` array to generate a union type of string literals
-   - Adds `(string & {})` for open-ended string types
-   - Example: `animationTimingFunction?: 'linear' | 'ease-in' | 'ease-out' | ... | (string & {});`
+The generator validates every CSS definition against the schema before it writes output. It then applies these rules:
 
-3. For other types:
-   - Uses `string` type
-   - Example: `color?: string;`
+1. `number` and `integer` definitions use `number`.
+2. Enum values use a union of string literals from the `values` array.
+3. Length definitions use `string`. They also use `number` when `allow_unitless_number` is `true` for that property.
+4. Keywords use a closed union of string literals.
+5. Other definitions use `string`.
 
-### Build Process
+### Build process
 
-The build process generates TypeScript type definitions and copies them to the types package:
+The build process generates the strict declaration and copies that file to the types package:
 
-1. `npm run gen:types` - Generates types in the `dist/` directory (gitignored)
-2. `npm run copy:types` - Copies generated types to `js_libraries/types/types/common/`
-3. `npm run build` - Runs both steps in sequence
+1. `npm run gen:types` generates `dist/csstype.generated.d.ts`.
+2. `npm run copy:types` copies only `csstype.generated.d.ts` to `js_libraries/types/types/common/`.
+3. `npm run build` runs both steps in sequence.
 
-Note: The `dist/` directory is gitignored because it's an intermediate build artifact. The final types are always in `js_libraries/types/types/common/csstype.d.ts`.
+Git ignores the intermediate `dist/` build directory. The build leaves the handwritten `csstype.d.ts` façade unchanged.
 
 ### Usage
 
@@ -89,10 +86,10 @@ npm run validate
 # Test validation with invalid CSS defines
 npm run test
 
-# Generate types and copy to types package
+# Generate and copy the strict declaration
 npm run build
 
-# Generate types in dist/ for testing (without copying)
+# Generate dist/csstype.generated.d.ts without copying it
 npm run gen:types
 ```
 

--- a/tools/css_generator/css_define_json_schema/css_define_with_doc.schema.json
+++ b/tools/css_generator/css_define_json_schema/css_define_with_doc.schema.json
@@ -191,7 +191,9 @@
         "enum": [
           "ios",
           "android",
+          "harmony",
           "clay_android",
+          "clay_ios",
           "clay_macos",
           "clay_windows",
           "web_lynx"
@@ -325,6 +327,10 @@
     "type": {
       "type": "string"
     },
+    "allow_unitless_number": {
+      "type": "boolean",
+      "description": "Whether TypeScript inline style values may use a JavaScript number for this length property. This does not describe general CSS parser support."
+    },
     "default_value": {
       "type": "string"
     },
@@ -407,16 +413,13 @@
             "type": "string"
           },
           "level": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "tip",
-                "info",
-                "warning",
-                "danger"
-              ]
-            }
+            "type": "string",
+            "enum": [
+              "tip",
+              "info",
+              "warning",
+              "danger"
+            ]
           }
         },
         "required": [

--- a/tools/css_generator/css_defines/187-list-main-axis-gap.json
+++ b/tools/css_generator/css_defines/187-list-main-axis-gap.json
@@ -6,9 +6,6 @@
   "version": "2.2",
   "author": "huangsu, yangqingchuan",
   "consumption_status": "skip",
-  "keywords": [
-    "grayscale"
-  ],
   "desc": "",
   "is_shorthand": false
 }

--- a/tools/css_generator/css_defines/191-cursor.json
+++ b/tools/css_generator/css_defines/191-cursor.json
@@ -52,6 +52,10 @@
       },
       "default": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -82,6 +86,10 @@
       },
       "none": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -112,6 +120,10 @@
       },
       "context-menu": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -142,6 +154,10 @@
       },
       "help": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -172,6 +188,10 @@
       },
       "pointer": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -202,6 +222,10 @@
       },
       "progress": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -232,6 +256,10 @@
       },
       "wait": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -262,6 +290,10 @@
       },
       "crosshair": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -292,6 +324,10 @@
       },
       "text": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -322,6 +358,10 @@
       },
       "vertical-text": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -352,6 +392,10 @@
       },
       "alias": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -382,6 +426,10 @@
       },
       "copy": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -412,6 +460,10 @@
       },
       "move": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -442,6 +494,10 @@
       },
       "no-drop": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -472,6 +528,10 @@
       },
       "not-allowed": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -502,6 +562,10 @@
       },
       "grab": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -532,6 +596,10 @@
       },
       "grabbing": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -562,6 +630,10 @@
       },
       "col-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -592,6 +664,10 @@
       },
       "row-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -622,6 +698,10 @@
       },
       "n-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -652,6 +732,10 @@
       },
       "e-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -682,6 +766,10 @@
       },
       "s-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -712,6 +800,10 @@
       },
       "w-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -742,6 +834,10 @@
       },
       "ne-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -772,6 +868,10 @@
       },
       "nw-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -802,6 +902,10 @@
       },
       "se-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -832,6 +936,10 @@
       },
       "sw-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -862,6 +970,10 @@
       },
       "ew-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -892,6 +1004,10 @@
       },
       "ns-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -922,6 +1038,10 @@
       },
       "nesw-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false
@@ -952,6 +1072,10 @@
       },
       "nwse-resize": {
         "__compat": {
+          "status": {
+            "deprecated": false,
+            "experimental": false
+          },
           "support": {
             "android": {
               "version_added": false

--- a/tools/css_generator/css_defines/193-clip-path.json
+++ b/tools/css_generator/css_defines/193-clip-path.json
@@ -46,7 +46,7 @@
           }
         }
       },
-      "circle()": {
+      "circle": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -80,7 +80,7 @@
           }
         }
       },
-      "inset()": {
+      "inset": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -114,7 +114,7 @@
           }
         }
       },
-      "ellipse()": {
+      "ellipse": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -148,7 +148,7 @@
           }
         }
       },
-      "path()": {
+      "path": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -182,7 +182,7 @@
           }
         }
       },
-      "polygon()": {
+      "polygon": {
         "__compat": {
           "status": {
             "deprecated": false,

--- a/tools/css_generator/css_defines/215-offset-path.json
+++ b/tools/css_generator/css_defines/215-offset-path.json
@@ -46,7 +46,7 @@
           }
         }
       },
-      "circle()": {
+      "circle": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -80,7 +80,7 @@
           }
         }
       },
-      "inset()": {
+      "inset": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -114,7 +114,7 @@
           }
         }
       },
-      "ellipse()": {
+      "ellipse": {
         "__compat": {
           "status": {
             "deprecated": false,
@@ -148,7 +148,7 @@
           }
         }
       },
-      "path()": {
+      "path": {
         "__compat": {
           "status": {
             "deprecated": false,

--- a/tools/css_generator/css_defines/231-x-caret-width.json
+++ b/tools/css_generator/css_defines/231-x-caret-width.json
@@ -2,6 +2,7 @@
   "name": "-x-caret-width",
   "id": 231,
   "type": "length",
+  "allow_unitless_number": true,
   "default_value": "0px",
   "version": "4.0",
   "author": "fanjinsong",

--- a/tools/css_generator/css_defines/232-x-caret-height.json
+++ b/tools/css_generator/css_defines/232-x-caret-height.json
@@ -2,6 +2,7 @@
   "name": "-x-caret-height",
   "id": 232,
   "type": "length",
+  "allow_unitless_number": true,
   "default_value": "0px",
   "version": "4.0",
   "author": "fanjinsong",

--- a/tools/css_generator/css_defines/233-x-caret-radius.json
+++ b/tools/css_generator/css_defines/233-x-caret-radius.json
@@ -2,6 +2,7 @@
   "name": "-x-caret-radius",
   "id": 233,
   "type": "length",
+  "allow_unitless_number": true,
   "default_value": "0px",
   "version": "4.0",
   "author": "fanjinsong",

--- a/tools/css_generator/package.json
+++ b/tools/css_generator/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@lynx-js/css-defines",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Property definitions of Lynx Styling module",
   "scripts": {
     "gen:types": "ts-node scripts/generate-types.ts",
-    "copy:types": "cp dist/csstype.d.ts ../../js_libraries/types/types/common/",
+    "copy:types": "cp dist/csstype.generated.d.ts ../../js_libraries/types/types/common/",
     "build": "npm run gen:types && npm run copy:types",
     "validate": "ts-node scripts/validate.ts",
     "lint:compat-keys": "node scripts/lint-compat-keys.js",

--- a/tools/css_generator/scripts/generate-types.ts
+++ b/tools/css_generator/scripts/generate-types.ts
@@ -10,6 +10,7 @@ interface CSSDefine {
   values?: Array<{ value: string; version: string; desc?: string }>;
   default_value: string;
   keywords?: string[];
+  allow_unitless_number?: boolean;
   is_shorthand: boolean;
 }
 
@@ -25,6 +26,13 @@ function generateTypeDefinition(property: CSSDefine): string {
   // Handle numeric types
   if (property.type === 'number' || property.type === 'integer') {
     return `${camelName}?: number;`;
+  }
+
+  // Handle length types, including explicitly supported unitless numbers
+  if (property.type === 'length') {
+    return property.allow_unitless_number
+      ? `${camelName}?: string | number;`
+      : `${camelName}?: string;`;
   }
 
   // Handle enum types from values array
@@ -43,7 +51,7 @@ function generateTypeDefinition(property: CSSDefine): string {
   // Handle properties with keywords
   if (property.keywords && Array.isArray(property.keywords)) {
     const keywords = property.keywords.map((k) => `'${k}'`).join(' | ');
-    return `${camelName}?: ${keywords} | (string & {});`;
+    return `${camelName}?: ${keywords};`;
   }
 
   // Default to string type
@@ -118,7 +126,8 @@ function generateTypeDefinitions(): string {
   const cssDefinesDir = path.join(__dirname, '..', 'css_defines');
   const files = fs
     .readdirSync(cssDefinesDir)
-    .filter((f: string) => f.endsWith('.json'));
+    .filter((f: string) => f.endsWith('.json'))
+    .sort();
 
   const cssDefines = files.map((file: string) => {
     const filePath = path.join(cssDefinesDir, file);
@@ -161,19 +170,19 @@ function generateTypeDefinitions(): string {
  * This file is auto-generated from CSS define files in the css_defines directory.
  * Each property's type is determined by:
  * 1. For enum types: Uses the values array from the CSS define file
- * 2. For properties with keywords: Uses the keywords array as enum values, with (string & {}) for open-ended types
- * 3. For other types: Uses string type
+ * 2. For length types: Uses string, plus number only when metadata allows it
+ * 3. For properties with keywords: Uses the keywords array as enum values
+ * 4. For other types: Uses string type
+ *
+ * LynxCSSProperties is the stricter metadata-derived opt-in type.
  */
 
-export type CSSProperties = {
+export type LynxCSSProperties = {
 ${typeDefinitions}
 };
 
-export type Shorthands = ${shorthandDefinitions};
-export type Longhands = ${longhandsDefinitions};
-
-export type CSSPropertiesWithShorthands = Pick<CSSProperties, Shorthands>;
-export type CSSPropertiesWithLonghands = Pick<CSSProperties, Longhands>;
+export type Shorthands =${shorthandDefinitions};
+export type Longhands =${longhandsDefinitions};
 `;
 }
 
@@ -185,6 +194,6 @@ if (!fs.existsSync(distDir)) {
 
 // Generate and write the type definitions
 const typeDefinitions = generateTypeDefinitions();
-fs.writeFileSync(path.join(distDir, 'csstype.d.ts'), typeDefinitions);
+fs.writeFileSync(path.join(distDir, 'csstype.generated.d.ts'), typeDefinitions);
 
 console.log('Type definitions generated successfully!');


### PR DESCRIPTION
## Summary

- Follow up on #1024 by separating the generated Lynx CSS contract from the backward-compatible public contract.
- Keep `CSSProperties` and default JSX inline styles compatible with `csstype` and the Lynx 4.2 surface.
- Add opt-in strict adoption for individual objects, named style maps, and whole TypeScript projects.
- Validate CSS metadata before generation and keep the generated declaration reproducible.

## Motivation

#1024 established metadata-driven CSS type generation, but making the generated metadata contract the default `CSSProperties` surface rejects values that existing Lynx applications receive from `csstype`. That makes strengthening metadata an accidental breaking change.

This follow-up makes strictness explicit and adoptable while preserving the default contract:

- `CSSProperties` and `CompatibleCSSProperties` remain the compatible escape hatch.
- `StrictCSSProperties` represents the generated Lynx metadata contract.
- `StrictStyleSheet` checks every style object in a named style map while preserving literal inference.
- Importing `@lynx-js/types/strict` in a project declaration switches Lynx element object styles to the strict contract.
- `InlineStyleProperties` is the framework-facing contract that propagates project adoption to JSX.

String styles remain accepted and are outside object-style type checking. Removing the strict side-effect import rolls a project back to compatible mode.

## Validation

- 24/24 type-test files and 87/87 assertions pass with no type errors.
- Default and project-level strict TypeScript compiler projects pass independently.
- All 236 CSS definitions validate; all 3 invalid-schema fixtures are rejected as expected.
- Generator compatibility-key lint and TypeScript compilation pass.
- Two consecutive generations leave the generated declaration and handwritten adoption boundaries unchanged.
- The published package dry-run contains the declaration-only strict entry.
- External consumers resolve strict mode through both `exports` and `typesVersions`.

## Review focus

- Confirm that default `CSSProperties` and JSX behavior remain backward compatible.
- Review the declaration-merging boundary used by `@lynx-js/types/strict`.
- Review the metadata schema and generator boundary for future CSS additions.

## AI-assisted development

Codex (GPT-5) assisted with analysis of #1024, implementation, tests, documentation, and verification. The prompts focused on preserving compatibility while adding scoped and project-level strict adoption.
