### PR TITLE
[Feature][Harmony] Support global library Autolink

### DIFF
--- a/explorer/harmony/hvigor/hvigor-config.json5
+++ b/explorer/harmony/hvigor/hvigor-config.json5
@@ -1,6 +1,7 @@
 {
   "modelVersion": "5.0.0",
   "dependencies": {
+    "@lynx/lynx-library-plugin": "file:../../../platform/harmony/lynx_library_plugin"
   },
   "execution": {
     // "analyze": "default",                    /* Define the build analyze mode. Value: [ "default" | "verbose" | false ]. Default: "default" */

--- a/explorer/harmony/hvigorconfig.ts
+++ b/explorer/harmony/hvigorconfig.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import * as hvigorApi from '@ohos/hvigor';
+import { enableHarmonyLynxAutolink } from '@lynx/lynx-library-plugin';
+
+enableHarmonyLynxAutolink(hvigorApi, {
+  moduleName: 'lynx_explorer',
+});

--- a/explorer/harmony/lynx_explorer/hvigorfile.ts
+++ b/explorer/harmony/lynx_explorer/hvigorfile.ts
@@ -2,5 +2,5 @@ import { hapTasks } from '@ohos/hvigor-ohos-plugin';
 
 export default {
   system: hapTasks /* Built-in plugin of Hvigor. It cannot be modified. */,
-  plugins: [] /* Custom plugin to extend the functionality of Hvigor. */,
+  plugins: [],
 };

--- a/platform/harmony/api/lynx_harmony.api
+++ b/platform/harmony/api/lynx_harmony.api
@@ -1367,6 +1367,27 @@ export class LynxBackgroundRuntime extends lynx.LynxRuntimeWrapper {
   templateResourceFetcher(): LynxTemplateResourceFetcher;
 }
 
+export class LynxLibraryRegistry {
+  constructor(packageName: string);
+  registerBehavior(name: string, behavior: Behavior): void;
+  registerModule(name: string, wrapper: ModuleClassWrapper): void;
+  registerService(serviceType: LynxServiceType, service: IServiceProvider): void;
+  registerInitializer(initializer: LynxLibraryInitializer): void;
+  static setupGlobal(entries: LynxLibraryProviderEntry[]): void;
+}
+
+export interface LynxLibraryProvider {
+  register(registry: LynxLibraryRegistry): void;
+}
+
+export interface LynxLibraryProviderEntry {
+  packageName: string;
+  provider: LynxLibraryProvider;
+}
+
+export type LynxLibraryInitializer = () => void {
+}
+
 export interface LynxImageConfig {
   enableImageLoadCallback?: boolean;
   enableRedirectUrl?: boolean;

--- a/platform/harmony/lynx_harmony/src/main/ets/Index.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/Index.ets
@@ -149,6 +149,10 @@ export { MessageHandler } from './devtool_wrapper/MessageHandler'
 
 export {LynxBackgroundRuntime, LynxBackgroundRuntimeClient} from './tasm/LynxBackgroundRuntime'
 
+export {
+  LynxLibraryInitializer, LynxLibraryProvider, LynxLibraryProviderEntry, LynxLibraryRegistry
+} from './library/LynxLibraryRegistry'
+
 export { LynxImageConfig } from './tasm/image/LynxImageConfig'
 
 export { LynxImageLoadInfo } from './tasm/image/LynxImageLoadInfo'

--- a/platform/harmony/lynx_harmony/src/main/ets/library/LynxLibraryRegistry.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/library/LynxLibraryRegistry.ets
@@ -1,0 +1,202 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { ModuleClassWrapper } from '../jsbridge/LynxModule';
+import { LynxModuleManager } from '../jsbridge/LynxModuleManager';
+import { Behavior, BUILTIN_BEHAVIORS } from '../tasm/behavior/Behavior';
+import { IServiceProvider } from '../tasm/service/IServiceProvider';
+import { LynxServiceCenter, LynxServiceType } from '../tasm/service/LynxServiceCenter';
+
+export type LynxLibraryInitializer = () => void;
+
+export interface LynxLibraryProvider {
+  register(registry: LynxLibraryRegistry): void;
+}
+
+export interface LynxLibraryProviderEntry {
+  packageName: string;
+  provider: LynxLibraryProvider;
+}
+
+const GLOBAL_MODULES: Map<string, ModuleClassWrapper> = new Map();
+const REGISTERED_PACKAGES: Set<string> = new Set();
+const BEHAVIOR_OWNERS: Map<string, string> = new Map();
+const MODULE_OWNERS: Map<string, string> = new Map();
+const SERVICE_OWNERS: Map<LynxServiceType, string> = new Map();
+let globalModulesFrozen: boolean = false;
+
+/** Collects one library's global registrations before they are committed. */
+export class LynxLibraryRegistry {
+  private packageName: string;
+  private behaviors: Map<string, Behavior> = new Map();
+  private modules: Map<string, ModuleClassWrapper> = new Map();
+  private services: Map<LynxServiceType, IServiceProvider> = new Map();
+  private initializers: LynxLibraryInitializer[] = [];
+
+  constructor(packageName: string) {
+    this.packageName = packageName;
+  }
+
+  registerBehavior(name: string, behavior: Behavior): void {
+    const normalizedName = this.assertNameAvailable(
+      name,
+      this.behaviors,
+      'Behavior'
+    );
+    this.behaviors.set(normalizedName, behavior);
+  }
+
+  registerModule(name: string, wrapper: ModuleClassWrapper): void {
+    const normalizedName = this.assertNameAvailable(
+      name,
+      this.modules,
+      'Native Module'
+    );
+    this.modules.set(normalizedName, wrapper);
+  }
+
+  registerService(serviceType: LynxServiceType, service: IServiceProvider): void {
+    if (this.services.has(serviceType)) {
+      throw new Error(
+        `Duplicate Service type ${serviceType} in Lynx library ${this.packageName}`
+      );
+    }
+    this.services.set(serviceType, service);
+  }
+
+  registerInitializer(initializer: LynxLibraryInitializer): void {
+    this.initializers.push(initializer);
+  }
+
+  static setupGlobal(entries: LynxLibraryProviderEntry[]): void {
+    const stagedRegistries: LynxLibraryRegistry[] = [];
+
+    for (const entry of entries) {
+      const packageName = entry.packageName.trim();
+      if (packageName.length === 0) {
+        throw new Error('Lynx library packageName must not be empty');
+      }
+      if (REGISTERED_PACKAGES.has(packageName)) {
+        continue;
+      }
+
+      const registry = new LynxLibraryRegistry(packageName);
+      entry.provider.register(registry);
+      stagedRegistries.push(registry);
+    }
+
+    LynxLibraryRegistry.validate(stagedRegistries);
+
+    for (const registry of stagedRegistries) {
+      registry.runInitializers();
+    }
+    for (const registry of stagedRegistries) {
+      registry.commit();
+    }
+  }
+
+  private static validate(registries: LynxLibraryRegistry[]): void {
+    const behaviorOwners = new Map<string, string>(BEHAVIOR_OWNERS);
+    const moduleOwners = new Map<string, string>(MODULE_OWNERS);
+    const serviceOwners = new Map<LynxServiceType, string>(SERVICE_OWNERS);
+    const packageNames: Set<string> = new Set();
+
+    for (const registry of registries) {
+      if (
+        REGISTERED_PACKAGES.has(registry.packageName)
+        || packageNames.has(registry.packageName)
+      ) {
+        throw new Error(`Duplicate Lynx library package ${registry.packageName}`);
+      }
+      packageNames.add(registry.packageName);
+      if (globalModulesFrozen && registry.modules.size > 0) {
+        throw new Error(
+          `Cannot register Native Modules from ${registry.packageName} after a Lynx Runtime has been created`
+        );
+      }
+
+      registry.behaviors.forEach((_behavior, name) => {
+        const owner = behaviorOwners.get(name);
+        if (owner !== undefined) {
+          throw new Error(
+            `Duplicate global Behavior "${name}" from ${registry.packageName}; already registered by ${owner}`
+          );
+        }
+        if (BUILTIN_BEHAVIORS.has(name)) {
+          throw new Error(
+            `Duplicate global Behavior "${name}" from ${registry.packageName}; already registered by Lynx`
+          );
+        }
+        behaviorOwners.set(name, registry.packageName);
+      });
+
+      registry.modules.forEach((_module, name) => {
+        const owner = moduleOwners.get(name);
+        if (owner !== undefined) {
+          throw new Error(
+            `Duplicate global Native Module "${name}" from ${registry.packageName}; already registered by ${owner}`
+          );
+        }
+        moduleOwners.set(name, registry.packageName);
+      });
+
+      registry.services.forEach((_service, serviceType) => {
+        const owner = serviceOwners.get(serviceType);
+        if (owner !== undefined) {
+          throw new Error(
+            `Duplicate global Service type ${serviceType} from ${registry.packageName}; already registered by ${owner}`
+          );
+        }
+        serviceOwners.set(serviceType, registry.packageName);
+      });
+    }
+  }
+
+  private assertNameAvailable<T>(
+    name: string,
+    values: Map<string, T>,
+    kind: string
+  ): string {
+    const normalizedName = name.trim();
+    if (normalizedName.length === 0) {
+      throw new Error(`${kind} name must not be empty in Lynx library ${this.packageName}`);
+    }
+    if (values.has(normalizedName)) {
+      throw new Error(
+        `Duplicate ${kind} "${normalizedName}" in Lynx library ${this.packageName}`
+      );
+    }
+    return normalizedName;
+  }
+
+  private runInitializers(): void {
+    for (const initializer of this.initializers) {
+      initializer();
+    }
+  }
+
+  private commit(): void {
+    this.behaviors.forEach((behavior, name) => {
+      BUILTIN_BEHAVIORS.set(name, behavior);
+      BEHAVIOR_OWNERS.set(name, this.packageName);
+    });
+    this.modules.forEach((wrapper, name) => {
+      GLOBAL_MODULES.set(name, wrapper);
+      MODULE_OWNERS.set(name, this.packageName);
+    });
+    this.services.forEach((service, serviceType) => {
+      LynxServiceCenter.registerService(serviceType, service);
+      SERVICE_OWNERS.set(serviceType, this.packageName);
+    });
+    REGISTERED_PACKAGES.add(this.packageName);
+  }
+}
+
+/** Registers all global modules before explicit runtime-specific modules. */
+export function registerGlobalLynxModules(moduleManager: LynxModuleManager): void {
+  globalModulesFrozen = true;
+  GLOBAL_MODULES.forEach((wrapper, name) => {
+    moduleManager.registerModule(name, wrapper);
+  });
+}

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxBackgroundRuntime.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxBackgroundRuntime.ets
@@ -16,6 +16,7 @@ import { ModuleClassWrapper, SendableModuleClassWrapper } from '../jsbridge/Lynx
 import { LLog, LynxEnv, MetaData, TemplateBundle } from '../Index';
 import { TemplateData } from './MetaData';
 import { SessionStorageCallback } from './SessionStorage';
+import { registerGlobalLynxModules } from '../library/LynxLibraryRegistry';
 
 const TAG = 'LynxBackgroundRuntime';
 const INVALID_SESSION_STORAGE_LISTENER_ID = -1;
@@ -43,6 +44,7 @@ export class LynxBackgroundRuntime extends lynx.LynxRuntimeWrapper {
     super();
     this.providers = [genericResourceFetcher, mediaResourceFetcher, templateResourceFetcher];
     this.backgroundRuntimeOptions = new LynxBackgroundRuntimeOptions(backgroundRuntimeOptions);
+    registerGlobalLynxModules(this.moduleManager);
     modules?.forEach((v, k) => {
       this.moduleManager.registerModule(k, v);
     });

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxView.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxView.ets
@@ -48,6 +48,7 @@ import { ILogBox } from '../devtool_wrapper/ILogBox';
 import { LynxDevTool } from '../devtool_wrapper/LynxDevTool';
 import { ILynxDevToolService } from './service/ILynxDevToolService';
 import { LynxImageConfig } from './image/LynxImageConfig';
+import { registerGlobalLynxModules } from '../library/LynxLibraryRegistry';
 
 export enum MeasureMode {
   INDEFINITE = 0,
@@ -329,6 +330,8 @@ export struct LynxView {
       this.genericResourceFetcher = this.genericResourceFetcher ?? this.backgroundRuntime.genericResourceFetcher;
       this.mediaResourceFetcher = this.mediaResourceFetcher ?? this.backgroundRuntime.mediaResourceFetcher;
       this.templateResourceFetcher = this.templateResourceFetcher ?? this.backgroundRuntime.templateResourceFetcher;
+    } else {
+      registerGlobalLynxModules(this.moduleManager);
     }
 
     this.modules.forEach((v, k) => {

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/behavior/HarmonyUIRenderer.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/behavior/HarmonyUIRenderer.ets
@@ -146,13 +146,17 @@ export class HarmonyUIRenderer implements LynxUIRenderer {
     perfController: PerformanceController) {
     TraceEvent.beginSection(TraceCategory.Lynx, TraceEventDef.TEMPLATE_RENDER_INIT);
 
+    const mergedBehaviors: BehaviorRegistryMap = new Map();
     BUILTIN_BEHAVIORS.forEach((value, key) => {
-      behaviors.set(key, value);
+      mergedBehaviors.set(key, value);
+    });
+    behaviors.forEach((value, key) => {
+      mergedBehaviors.set(key, value);
     });
     // todo(renzhongyue): context here and contextDelegate in UIBase should be merged, they do the same thing.
-    this.uiOwner = new UIOwner(behaviors, uiContext, context, perfController);
+    this.uiOwner = new UIOwner(mergedBehaviors, uiContext, context, perfController);
     context.setUIOwner(this.uiOwner);
-    this.shadowNodeOwner = new ShadowNodeOwner(context, behaviors, rootSize);
+    this.shadowNodeOwner = new ShadowNodeOwner(context, mergedBehaviors, rootSize);
 
     TraceEvent.beginSection(TraceCategory.Lynx, TraceEventDef.TEMPLATE_RENDER_CREATE_TASM);
     this.embedderPlatform =
@@ -267,4 +271,3 @@ export class HarmonyUIRenderer implements LynxUIRenderer {
     this.uiOwner.onEnterBackground();
   }
 }
-

--- a/platform/harmony/lynx_library_plugin/README.md
+++ b/platform/harmony/lynx_library_plugin/README.md
@@ -1,0 +1,40 @@
+<!-- cspell:ignore hvigorconfig -->
+
+# @lynx/lynx-library-plugin
+
+Hvigor configuration plugin for HarmonyOS Lynx library Autolink.
+
+Add the plugin to the project root `hvigor/hvigor-config.json5`:
+
+```json5
+{
+  "modelVersion": "5.0.0",
+  "dependencies": {
+    "@lynx/lynx-library-plugin": "^0.1.0",
+  },
+}
+```
+
+Enable it once in the project root `hvigorconfig.ts`:
+
+```ts
+import * as hvigorApi from '@ohos/hvigor';
+import { enableHarmonyLynxAutolink } from '@lynx/lynx-library-plugin';
+
+enableHarmonyLynxAutolink(hvigorApi, { moduleName: 'entry' });
+```
+
+`moduleName` can be omitted when exactly one entry or feature HAP module depends
+on `@lynx/lynx`.
+
+Before Hvigor creates the module graph, the plugin discovers installed npm
+packages that declare `platforms.harmony` in `lynx.lib.json`, generates a
+Registry HAR under the project's ignored
+`.hvigor/lynx-autolink/<moduleName>` cache directory, and includes the Registry
+and library HAR nodes through the Hvigor config API. JSON5 project metadata is
+parsed by Hvigor's public `parseJsonFile` API, so the plugin has no runtime npm
+dependencies. After the target HAP is evaluated, the plugin adds the generated
+dependency, resource directory, and AppStartup profile through HAP model APIs.
+A generated Hvigor task restores the HAP-local AppStartup sources after `clean`
+and before each target's `PreBuild`.
+Application source files and checked-in build profiles are not modified.

--- a/platform/harmony/lynx_library_plugin/package.json
+++ b/platform/harmony/lynx_library_plugin/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@lynx/lynx-library-plugin",
+  "version": "0.1.0",
+  "description": "HarmonyOS Hvigor plugin for Lynx library Autolink",
+  "license": "Apache-2.0",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.d.ts",
+      "require": "./src/index.js",
+      "default": "./src/index.js"
+    }
+  },
+  "files": [
+    "README.md",
+    "src"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "json5": "^2.2.3"
+  },
+  "peerDependencies": {
+    "@ohos/hvigor": ">=5.0.0",
+    "@ohos/hvigor-ohos-plugin": ">=5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/platform/harmony/lynx_library_plugin/src/core.js
+++ b/platform/harmony/lynx_library_plugin/src/core.js
@@ -1,0 +1,1112 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REGISTRY_PACKAGE_NAME = '@lynx/lynx_autolink_registry';
+const STARTUP_PROFILE_NAME = 'lynx_autolink_startup';
+const STARTUP_TASK_NAME = 'LynxAutolinkStartupTask';
+const GENERATION_TASK_NAME = 'generateLynxAutolink';
+const REGISTRY_MODULE_NAME = 'lynx_autolink_registry';
+const HAP_PLUGIN_ID = 'com.ohos.hap';
+const CONFIGURED_HVIGOR_CONFIGS = new WeakSet();
+
+/** Finds and validates all Harmony-enabled Lynx libraries visible to a HAP. */
+function discoverHarmonyLibraries(startPath, readJson5File) {
+  requireJson5FileReader(readJson5File);
+  const packageRoots = [];
+  const seenNodeModules = new Set();
+  const seenPackages = new Set();
+
+  for (const nodeModulesDir of findAncestorNodeModules(startPath)) {
+    collectPackageRoots(
+      nodeModulesDir,
+      packageRoots,
+      seenNodeModules,
+      seenPackages
+    );
+  }
+
+  const libraries = [];
+  for (const packageRoot of packageRoots) {
+    const manifestPath = path.join(packageRoot, 'lynx.lib.json');
+    if (!fs.existsSync(manifestPath)) {
+      continue;
+    }
+
+    const manifest = readJson(manifestPath);
+    const harmony = manifest?.platforms?.harmony;
+    if (harmony === undefined) {
+      continue;
+    }
+    if (!isObject(harmony)) {
+      throw new Error(`${manifestPath}: platforms.harmony must be an object`);
+    }
+
+    libraries.push(readHarmonyLibrary(packageRoot, harmony, readJson5File));
+  }
+
+  libraries.sort((left, right) =>
+    compareText(left.npmPackageName, right.npmPackageName)
+  );
+  validateUniqueLibraries(libraries);
+  return libraries;
+}
+
+/** Registers generated HAR nodes before Hvigor initializes the module graph. */
+function setupHarmonyAutolink(
+  hvigorConfig,
+  lifecycle,
+  options = {},
+  parseJsonFile
+) {
+  if (
+    hvigorConfig === undefined ||
+    typeof hvigorConfig.getRootNodeDescriptor !== 'function' ||
+    typeof hvigorConfig.getAllNodeDescriptor !== 'function' ||
+    typeof hvigorConfig.includeNode !== 'function'
+  ) {
+    throw new Error('Harmony Lynx Autolink requires the Hvigor config API');
+  }
+  if (
+    lifecycle === undefined ||
+    typeof lifecycle.afterNodeEvaluate !== 'function' ||
+    typeof lifecycle.nodesEvaluated !== 'function'
+  ) {
+    throw new Error('Harmony Lynx Autolink requires the Hvigor lifecycle API');
+  }
+  if (CONFIGURED_HVIGOR_CONFIGS.has(hvigorConfig)) {
+    throw new Error(
+      'Harmony Lynx Autolink is already enabled for this project'
+    );
+  }
+
+  const prepared = prepareHarmonyAutolink(
+    hvigorConfig,
+    options,
+    createJson5FileReader(parseJsonFile)
+  );
+  CONFIGURED_HVIGOR_CONFIGS.add(hvigorConfig);
+  let hapConfigured = false;
+
+  lifecycle.afterNodeEvaluate((node) => {
+    if (node.getNodeName() !== prepared.moduleName) {
+      return;
+    }
+    const context = node.getContext(HAP_PLUGIN_ID);
+    if (context === undefined || context === null) {
+      throw new Error(
+        `Harmony Lynx Autolink requires ${prepared.moduleName} to use the HarmonyOS HAP plugin`
+      );
+    }
+    const generation = configureHarmonyAutolinkHap(context, prepared);
+    registerHapGenerationTask(node, prepared, generation);
+    hapConfigured = true;
+  });
+  lifecycle.nodesEvaluated(() => {
+    if (!hapConfigured) {
+      throw new Error(
+        `Harmony Lynx Autolink could not configure HAP module ${prepared.moduleName}`
+      );
+    }
+  });
+
+  return prepared;
+}
+
+/** Generates the Registry HAR and adds all required dynamic Hvigor nodes. */
+function prepareHarmonyAutolink(hvigorConfig, options = {}, readJson5File) {
+  requireJson5FileReader(readJson5File);
+  const rootDescriptor = hvigorConfig.getRootNodeDescriptor();
+  const projectPath = resolveComparablePath(
+    requireNonEmptyString(
+      rootDescriptor?.srcPath,
+      'Hvigor root project source path'
+    )
+  );
+  const target = resolveTargetHap(
+    hvigorConfig,
+    projectPath,
+    options.moduleName,
+    readJson5File
+  );
+  const modulePath = target.modulePath;
+  const scanRoot = path.resolve(options.projectRoot ?? modulePath);
+  const outputBase = path.join(projectPath, '.hvigor', 'lynx-autolink');
+  const outputRoot = path.resolve(outputBase, target.moduleName);
+  assertPathInside(outputBase, outputRoot, 'generated output directory');
+
+  const libraries = discoverHarmonyLibraries(scanRoot, readJson5File);
+  fs.rmSync(outputRoot, { force: true, recursive: true });
+  const registryDir = path.join(outputRoot, 'registry');
+  const generatedHapRoot = path.join(
+    modulePath,
+    'build',
+    'generated',
+    'lynx-autolink'
+  );
+  fs.rmSync(generatedHapRoot, { force: true, recursive: true });
+  const generatedSourceRoot = path.join(generatedHapRoot, 'src', 'main');
+  generateRegistryHar(
+    registryDir,
+    libraries,
+    rebaseFileDependency(modulePath, registryDir, target.lynxDependency)
+  );
+  addHarNodesToHvigorConfig(
+    hvigorConfig,
+    projectPath,
+    registryDir,
+    libraries,
+    readJson5File
+  );
+
+  return {
+    ...target,
+    libraries,
+    outputRoot,
+    registryDir,
+    generatedSourceRoot,
+    readJson5File,
+  };
+}
+
+/** Applies generated dependencies and AppStartup configuration to the HAP. */
+function configureHarmonyAutolinkHap(context, prepared) {
+  const modulePath = resolveComparablePath(context.getModulePath());
+  if (
+    resolveComparablePath(modulePath) !==
+    resolveComparablePath(prepared.modulePath)
+  ) {
+    throw new Error(
+      `Harmony Lynx Autolink expected HAP module ${prepared.modulePath}, got ${modulePath}`
+    );
+  }
+  const moduleType = context.getModuleType();
+  if (moduleType !== 'entry' && moduleType !== 'feature') {
+    throw new Error(
+      `Harmony Lynx Autolink requires an entry or feature HAP module, got ${moduleType}`
+    );
+  }
+
+  const dependencies = { ...(context.getDependenciesOpt() ?? {}) };
+  const lynxDependency = dependencies['@lynx/lynx'];
+  if (
+    typeof lynxDependency !== 'string' ||
+    lynxDependency.trim().length === 0
+  ) {
+    throw new Error(
+      'Harmony Lynx Autolink requires @lynx/lynx in the HAP module dependencies'
+    );
+  }
+  generateRegistryHar(
+    prepared.registryDir,
+    prepared.libraries,
+    rebaseFileDependency(modulePath, prepared.registryDir, lynxDependency)
+  );
+
+  const moduleJson = context.getModuleJsonOpt();
+  const buildProfile = context.getBuildProfileOpt();
+  const existingStartup = readExistingStartup(
+    modulePath,
+    moduleJson,
+    buildProfile,
+    prepared.readJson5File
+  );
+  generateHapStartup(modulePath, prepared.generatedSourceRoot, existingStartup);
+
+  dependencies[REGISTRY_PACKAGE_NAME] = toFileDependency(
+    modulePath,
+    prepared.registryDir
+  );
+  context.setDependenciesOpt(dependencies);
+  context.setBuildProfileOpt(
+    addGeneratedResourceDirectory(
+      modulePath,
+      buildProfile,
+      prepared.generatedSourceRoot
+    )
+  );
+  context.setModuleJsonOpt(setAppStartupProfile(moduleJson));
+
+  return {
+    existingStartup,
+    targetNames: readHapTargetNames(context),
+  };
+}
+
+function registerHapGenerationTask(node, prepared, generation) {
+  if (typeof node.registerTask !== 'function') {
+    throw new Error('Harmony Lynx Autolink requires the Hvigor task API');
+  }
+  node.registerTask({
+    name: GENERATION_TASK_NAME,
+    run() {
+      generateHapStartup(
+        prepared.modulePath,
+        prepared.generatedSourceRoot,
+        generation.existingStartup
+      );
+    },
+    postDependencies: generation.targetNames.map(
+      (targetName) => `${targetName}@PreBuild`
+    ),
+  });
+}
+
+function readHapTargetNames(context) {
+  if (typeof context.targets !== 'function') {
+    throw new Error('Harmony Lynx Autolink requires the HAP target API');
+  }
+  const targetNames = [];
+  context.targets((target) => {
+    targetNames.push(
+      requireNonEmptyString(target?.getTargetName?.(), 'HAP target name')
+    );
+  });
+  if (targetNames.length === 0) {
+    throw new Error('Harmony Lynx Autolink requires at least one HAP target');
+  }
+  return [...new Set(targetNames)];
+}
+
+/** Emits the deterministic Registry HAR consumed by the generated startup task. */
+function generateRegistryHar(outputDir, libraries, lynxDependency) {
+  const sortedLibraries = sortLibraries(libraries);
+  fs.mkdirSync(path.join(outputDir, 'src', 'main', 'ets'), {
+    recursive: true,
+  });
+
+  const dependencies = { '@lynx/lynx': lynxDependency };
+  for (const library of sortedLibraries) {
+    dependencies[library.ohPackageName] = toFileDependency(
+      outputDir,
+      library.harmonyPackageDir
+    );
+  }
+
+  writeJson(path.join(outputDir, 'oh-package.json5'), {
+    name: REGISTRY_PACKAGE_NAME,
+    version: '0.0.0',
+    license: 'Apache-2.0',
+    main: 'Index.ets',
+    dependencies,
+  });
+  writeJson(path.join(outputDir, 'build-profile.json5'), {
+    apiType: 'stageMode',
+    buildOption: {
+      arkOptions: { byteCodeHar: false },
+    },
+    targets: [{ name: 'default' }],
+  });
+  writeJson(path.join(outputDir, 'src', 'main', 'module.json5'), {
+    module: {
+      name: REGISTRY_MODULE_NAME,
+      type: 'har',
+      deviceTypes: ['default', 'tablet', '2in1'],
+    },
+  });
+  fs.writeFileSync(
+    path.join(outputDir, 'hvigorfile.ts'),
+    "import { harTasks } from '@ohos/hvigor-ohos-plugin';\n\n" +
+      'export default { system: harTasks, plugins: [] };\n'
+  );
+  fs.writeFileSync(
+    path.join(outputDir, 'Index.ets'),
+    generateRegistrySource(sortedLibraries)
+  );
+}
+
+/** Returns the stable ArkTS provider list for a generated Registry HAR. */
+function generateRegistrySource(libraries) {
+  const sortedLibraries = sortLibraries(libraries);
+  const imports = sortedLibraries.map(
+    (library, index) =>
+      `import { LynxLibraryProviderImpl as Provider${index} } from '${library.ohPackageName}';`
+  );
+  const entries = sortedLibraries.map(
+    (library, index) =>
+      `  { packageName: ${JSON.stringify(library.npmPackageName)}, provider: new Provider${index}() }`
+  );
+
+  return `// Generated by @lynx/lynx-library-plugin. Do not edit.
+import { LynxLibraryProviderEntry, LynxLibraryRegistry } from '@lynx/lynx';
+${imports.length > 0 ? `${imports.join('\n')}\n` : ''}
+const PROVIDERS: LynxLibraryProviderEntry[] = [
+${entries.join(',\n')}
+];
+
+export function setupGlobal(): void {
+  LynxLibraryRegistry.setupGlobal(PROVIDERS);
+}
+`;
+}
+
+function sortLibraries(libraries) {
+  return [...libraries].sort((left, right) =>
+    compareText(left.npmPackageName, right.npmPackageName)
+  );
+}
+
+function readHarmonyLibrary(packageRoot, harmony, readJson5File) {
+  const npmPackageJsonPath = path.join(packageRoot, 'package.json');
+  const npmPackageJson = readJson(npmPackageJsonPath);
+  const npmPackageName = requireNonEmptyString(
+    npmPackageJson.name,
+    `${npmPackageJsonPath}: name`
+  );
+  const packageDirValue = harmony.packageDir ?? 'harmony';
+  const packageDir = requireNonEmptyString(
+    packageDirValue,
+    `${path.join(packageRoot, 'lynx.lib.json')}: platforms.harmony.packageDir`
+  );
+  const harmonyPackageDir = path.resolve(packageRoot, packageDir);
+  assertPathInside(
+    packageRoot,
+    harmonyPackageDir,
+    'platforms.harmony.packageDir'
+  );
+  if (
+    !fs.existsSync(harmonyPackageDir) ||
+    !fs.statSync(harmonyPackageDir).isDirectory()
+  ) {
+    throw new Error(
+      `${npmPackageName}: Harmony package directory does not exist: ${harmonyPackageDir}`
+    );
+  }
+  assertRealPathInside(
+    packageRoot,
+    harmonyPackageDir,
+    'Harmony package directory'
+  );
+
+  const ohPackagePath = path.join(harmonyPackageDir, 'oh-package.json5');
+  const ohPackage = readJson5File(ohPackagePath);
+  const ohPackageName = requireNonEmptyString(
+    ohPackage.name,
+    `${ohPackagePath}: name`
+  );
+  const entry =
+    ohPackage.main === undefined || ohPackage.main === ''
+      ? 'Index.ets'
+      : requireNonEmptyString(ohPackage.main, `${ohPackagePath}: main`);
+  const entryPath = path.resolve(harmonyPackageDir, entry);
+  assertPathInside(harmonyPackageDir, entryPath, 'Harmony package main entry');
+  if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+    throw new Error(
+      `${npmPackageName}: Harmony package main entry does not exist: ${entryPath}`
+    );
+  }
+  assertRealPathInside(
+    harmonyPackageDir,
+    entryPath,
+    'Harmony package main entry'
+  );
+
+  const moduleJsonPath = path.join(
+    harmonyPackageDir,
+    'src',
+    'main',
+    'module.json5'
+  );
+  const moduleJson = readJson5File(moduleJsonPath);
+  if (moduleJson?.module?.type !== 'har') {
+    throw new Error(`${moduleJsonPath}: module.type must be "har"`);
+  }
+  const harmonyModuleName = requireNonEmptyString(
+    moduleJson.module.name,
+    `${moduleJsonPath}: module.name`
+  );
+  const harmonyBuildProfilePath = path.join(
+    harmonyPackageDir,
+    'build-profile.json5'
+  );
+  const harmonyBuildProfile = readJson5File(harmonyBuildProfilePath);
+  const targetNames = readHarTargetNames(
+    harmonyBuildProfile,
+    harmonyBuildProfilePath
+  );
+
+  return {
+    npmPackageName,
+    packageRoot,
+    harmonyPackageDir,
+    ohPackageName,
+    harmonyModuleName,
+    targetNames,
+  };
+}
+
+function readHarTargetNames(buildProfile, buildProfilePath) {
+  if (
+    !Array.isArray(buildProfile?.targets) ||
+    buildProfile.targets.length === 0
+  ) {
+    throw new Error(`${buildProfilePath}: targets must be a non-empty array`);
+  }
+  const targetNames = [];
+  const seen = new Set();
+  for (const target of buildProfile.targets) {
+    const name = requireNonEmptyString(
+      target?.name,
+      `${buildProfilePath}: target.name`
+    );
+    if (seen.has(name)) {
+      throw new Error(`${buildProfilePath}: duplicate target name "${name}"`);
+    }
+    seen.add(name);
+    targetNames.push(name);
+  }
+  return targetNames;
+}
+
+function validateUniqueLibraries(libraries) {
+  const npmNames = new Map();
+  const ohPackageNames = new Map();
+  const moduleNames = new Map();
+
+  for (const library of libraries) {
+    assertUniqueLibraryName(
+      npmNames,
+      library.npmPackageName,
+      library.packageRoot,
+      'npm package name'
+    );
+    assertUniqueLibraryName(
+      ohPackageNames,
+      library.ohPackageName,
+      library.packageRoot,
+      'OHPM package name'
+    );
+    assertUniqueLibraryName(
+      moduleNames,
+      library.harmonyModuleName,
+      library.packageRoot,
+      'Harmony module name'
+    );
+    if (library.ohPackageName === REGISTRY_PACKAGE_NAME) {
+      throw new Error(
+        `${library.npmPackageName}: OHPM package name ${REGISTRY_PACKAGE_NAME} is reserved`
+      );
+    }
+    if (library.harmonyModuleName === REGISTRY_MODULE_NAME) {
+      throw new Error(
+        `${library.npmPackageName}: Harmony module name ${REGISTRY_MODULE_NAME} is reserved`
+      );
+    }
+  }
+}
+
+function assertUniqueLibraryName(values, name, packageRoot, kind) {
+  const previousRoot = values.get(name);
+  if (previousRoot !== undefined) {
+    throw new Error(
+      `Duplicate ${kind} "${name}" in ${previousRoot} and ${packageRoot}`
+    );
+  }
+  values.set(name, packageRoot);
+}
+
+function findAncestorNodeModules(startPath) {
+  const result = [];
+  let current = path.resolve(startPath);
+  if (fs.existsSync(current) && fs.statSync(current).isFile()) {
+    current = path.dirname(current);
+  }
+
+  while (true) {
+    const candidate = path.join(current, 'node_modules');
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isDirectory()) {
+      result.push(candidate);
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  return result;
+}
+
+function collectPackageRoots(
+  nodeModulesDir,
+  packageRoots,
+  seenNodeModules,
+  seenPackages
+) {
+  const realNodeModules = fs.realpathSync(nodeModulesDir);
+  if (seenNodeModules.has(realNodeModules)) {
+    return;
+  }
+  seenNodeModules.add(realNodeModules);
+
+  for (const entry of fs
+    .readdirSync(nodeModulesDir, { withFileTypes: true })
+    .sort((left, right) => compareText(left.name, right.name))) {
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+    const entryPath = path.join(nodeModulesDir, entry.name);
+    if (entry.name.startsWith('@') && isDirectoryOrSymlink(entryPath)) {
+      for (const scopedEntry of fs
+        .readdirSync(entryPath, { withFileTypes: true })
+        .sort((left, right) => compareText(left.name, right.name))) {
+        const packagePath = path.join(entryPath, scopedEntry.name);
+        if (isDirectoryOrSymlink(packagePath)) {
+          collectOnePackage(
+            packagePath,
+            packageRoots,
+            seenNodeModules,
+            seenPackages
+          );
+        }
+      }
+    } else if (isDirectoryOrSymlink(entryPath)) {
+      collectOnePackage(entryPath, packageRoots, seenNodeModules, seenPackages);
+    }
+  }
+}
+
+function collectOnePackage(
+  packagePath,
+  packageRoots,
+  seenNodeModules,
+  seenPackages
+) {
+  const packageRoot = fs.realpathSync(packagePath);
+  if (
+    !seenPackages.has(packageRoot) &&
+    fs.existsSync(path.join(packageRoot, 'package.json'))
+  ) {
+    seenPackages.add(packageRoot);
+    packageRoots.push(packageRoot);
+  }
+  const nestedNodeModules = path.join(packageRoot, 'node_modules');
+  if (
+    fs.existsSync(nestedNodeModules) &&
+    fs.statSync(nestedNodeModules).isDirectory()
+  ) {
+    collectPackageRoots(
+      nestedNodeModules,
+      packageRoots,
+      seenNodeModules,
+      seenPackages
+    );
+  }
+}
+
+function isDirectoryOrSymlink(filePath) {
+  const stat = fs.lstatSync(filePath);
+  return stat.isDirectory() || stat.isSymbolicLink();
+}
+
+function resolveTargetHap(
+  hvigorConfig,
+  projectPath,
+  moduleName,
+  readJson5File
+) {
+  const descriptors = hvigorConfig.getAllNodeDescriptor();
+  if (!Array.isArray(descriptors)) {
+    throw new Error('Hvigor config did not provide module descriptors');
+  }
+
+  if (moduleName !== undefined) {
+    const targetName = requireNonEmptyString(
+      moduleName,
+      'Harmony Lynx Autolink moduleName'
+    );
+    const descriptor =
+      hvigorConfig.getNodeDescriptorByName?.(targetName) ??
+      descriptors.find((candidate) => candidate?.name === targetName);
+    if (descriptor === undefined) {
+      throw new Error(
+        `Harmony Lynx Autolink cannot find module ${targetName} in the Hvigor project`
+      );
+    }
+    return readLynxHapDescriptor(projectPath, descriptor, true, readJson5File);
+  }
+
+  const candidates = descriptors
+    .map((descriptor) =>
+      readLynxHapDescriptor(projectPath, descriptor, false, readJson5File)
+    )
+    .filter((candidate) => candidate !== undefined);
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+  if (candidates.length === 0) {
+    throw new Error(
+      'Harmony Lynx Autolink cannot find an entry or feature HAP module that depends on @lynx/lynx'
+    );
+  }
+  throw new Error(
+    `Harmony Lynx Autolink found multiple Lynx HAP modules (${candidates
+      .map((candidate) => candidate.moduleName)
+      .join(', ')}); set moduleName explicitly`
+  );
+}
+
+function readLynxHapDescriptor(
+  projectPath,
+  descriptor,
+  required,
+  readJson5File
+) {
+  const moduleName = requireNonEmptyString(
+    descriptor?.name,
+    'Hvigor module name'
+  );
+  const srcPath = requireNonEmptyString(
+    descriptor?.srcPath,
+    `Hvigor module ${moduleName} source path`
+  );
+  const modulePath = path.resolve(projectPath, srcPath);
+  const modulePathLabel = `Hvigor module ${moduleName} source path`;
+  assertPathInside(projectPath, modulePath, modulePathLabel);
+  const moduleJsonPath = path.join(modulePath, 'src', 'main', 'module.json5');
+  if (!fs.existsSync(moduleJsonPath)) {
+    if (!required) {
+      return undefined;
+    }
+    throw new Error(
+      `Harmony Lynx Autolink cannot find ${moduleJsonPath} for module ${moduleName}`
+    );
+  }
+  assertRealPathInside(projectPath, modulePath, modulePathLabel);
+
+  const moduleType = readJson5File(moduleJsonPath)?.module?.type;
+  if (moduleType !== 'entry' && moduleType !== 'feature') {
+    if (!required) {
+      return undefined;
+    }
+    throw new Error(
+      `Harmony Lynx Autolink requires module ${moduleName} to be an entry or feature HAP module`
+    );
+  }
+
+  const ohPackagePath = path.join(modulePath, 'oh-package.json5');
+  if (!fs.existsSync(ohPackagePath)) {
+    if (!required) {
+      return undefined;
+    }
+    throw new Error(
+      `Harmony Lynx Autolink cannot find ${ohPackagePath} for module ${moduleName}`
+    );
+  }
+  const lynxDependency =
+    readJson5File(ohPackagePath)?.dependencies?.['@lynx/lynx'];
+  if (
+    typeof lynxDependency !== 'string' ||
+    lynxDependency.trim().length === 0
+  ) {
+    if (!required) {
+      return undefined;
+    }
+    throw new Error(
+      `Harmony Lynx Autolink requires @lynx/lynx in module ${moduleName} dependencies`
+    );
+  }
+
+  return { moduleName, modulePath, moduleType, lynxDependency };
+}
+
+function addHarNodesToHvigorConfig(
+  hvigorConfig,
+  projectPath,
+  registryDir,
+  libraries,
+  readJson5File
+) {
+  const productNames = readProjectProductNames(projectPath, readJson5File);
+  addHvigorNode(
+    hvigorConfig,
+    projectPath,
+    REGISTRY_MODULE_NAME,
+    registryDir,
+    ['default'],
+    productNames
+  );
+  for (const library of libraries) {
+    addHvigorNode(
+      hvigorConfig,
+      projectPath,
+      library.harmonyModuleName,
+      library.harmonyPackageDir,
+      library.targetNames,
+      productNames
+    );
+  }
+}
+
+function readProjectProductNames(projectPath, readJson5File) {
+  const buildProfilePath = path.join(projectPath, 'build-profile.json5');
+  const buildProfile = readJson5File(buildProfilePath);
+  if (
+    !Array.isArray(buildProfile?.app?.products) ||
+    buildProfile.app.products.length === 0
+  ) {
+    throw new Error(
+      `${buildProfilePath}: app.products must be a non-empty array`
+    );
+  }
+
+  const result = [];
+  const seen = new Set();
+  for (const product of buildProfile.app.products) {
+    const name = requireNonEmptyString(
+      product?.name,
+      `${buildProfilePath}: app product name`
+    );
+    if (seen.has(name)) {
+      throw new Error(`${buildProfilePath}: duplicate product name "${name}"`);
+    }
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
+function addHvigorNode(
+  hvigorConfig,
+  projectPath,
+  moduleName,
+  modulePath,
+  targetNames,
+  productNames
+) {
+  const resolvedModulePath = resolveComparablePath(modulePath);
+  const conflicts = hvigorConfig.getAllNodeDescriptor().filter((descriptor) => {
+    const descriptorPath =
+      typeof descriptor?.srcPath === 'string'
+        ? resolveComparablePath(projectPath, descriptor.srcPath)
+        : undefined;
+    return (
+      descriptor?.name === moduleName || descriptorPath === resolvedModulePath
+    );
+  });
+  if (conflicts.length > 0) {
+    const matches = conflicts.every(
+      (descriptor) =>
+        descriptor.name === moduleName &&
+        resolveComparablePath(projectPath, descriptor.srcPath) ===
+          resolvedModulePath
+    );
+    if (!matches) {
+      throw new Error(
+        `Harmony module conflict for ${moduleName} at ${resolvedModulePath}`
+      );
+    }
+    return;
+  }
+
+  hvigorConfig.includeNode(
+    moduleName,
+    toModuleRelativePath(projectPath, resolvedModulePath),
+    {
+      targets: targetNames.map((name) => ({
+        name,
+        applyToProducts: productNames,
+      })),
+    }
+  );
+}
+
+function readExistingStartup(
+  modulePath,
+  moduleJson,
+  buildProfile,
+  readJson5File
+) {
+  const appStartup = moduleJson?.module?.appStartup;
+  if (appStartup === undefined) {
+    return undefined;
+  }
+  if (typeof appStartup !== 'string' || !appStartup.startsWith('$profile:')) {
+    throw new Error(
+      'module.appStartup must use a $profile: resource reference'
+    );
+  }
+  const profileName = appStartup.slice('$profile:'.length);
+  const candidates = new Set([
+    path.join(modulePath, 'src', 'main', 'resources'),
+    ...readConfiguredResourceDirs(modulePath, buildProfile),
+  ]);
+  const matches = [];
+  for (const resourcesDir of candidates) {
+    const candidate = path.join(
+      resourcesDir,
+      'base',
+      'profile',
+      `${profileName}.json`
+    );
+    if (fs.existsSync(candidate)) {
+      matches.push(candidate);
+    }
+  }
+  if (matches.length === 0) {
+    throw new Error(`Cannot resolve existing AppStartup profile ${appStartup}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `AppStartup profile ${appStartup} resolves to multiple resource directories`
+    );
+  }
+  const startup = readJson5File(matches[0]);
+  if (!Array.isArray(startup.startupTasks)) {
+    throw new Error(`${matches[0]}: startupTasks must be an array`);
+  }
+  if (
+    typeof startup.configEntry !== 'string' ||
+    startup.configEntry.length === 0
+  ) {
+    throw new Error(`${matches[0]}: configEntry must be a non-empty string`);
+  }
+  return startup;
+}
+
+function readConfiguredResourceDirs(modulePath, buildProfile) {
+  const result = [];
+  for (const target of buildProfile?.targets ?? []) {
+    for (const directory of target?.resource?.directories ?? []) {
+      result.push(path.resolve(modulePath, directory));
+    }
+  }
+  return result;
+}
+
+function generateHapStartup(modulePath, sourceRoot, existingStartup) {
+  const etsDir = path.join(sourceRoot, 'ets', 'lynx_autolink');
+  const profileDir = path.join(sourceRoot, 'resources', 'base', 'profile');
+  const taskEntry = toStartupEntry(
+    modulePath,
+    path.join(etsDir, `${STARTUP_TASK_NAME}.ets`)
+  );
+  const configEntry = toStartupEntry(
+    modulePath,
+    path.join(etsDir, 'LynxAutolinkStartupConfig.ets')
+  );
+  fs.mkdirSync(etsDir, { recursive: true });
+  fs.mkdirSync(profileDir, { recursive: true });
+
+  fs.writeFileSync(
+    path.join(etsDir, `${STARTUP_TASK_NAME}.ets`),
+    `// Generated by @lynx/lynx-library-plugin. Do not edit.
+import { common, StartupTask } from '@kit.AbilityKit';
+import { setupGlobal } from '${REGISTRY_PACKAGE_NAME}';
+
+@Sendable
+export default class ${STARTUP_TASK_NAME} extends StartupTask {
+  constructor() {
+    super();
+  }
+
+  async init(_context: common.AbilityStageContext): Promise<void> {
+    setupGlobal();
+  }
+}
+`
+  );
+
+  let startup =
+    existingStartup === undefined
+      ? {
+          startupTasks: [],
+          configEntry,
+        }
+      : { ...existingStartup, startupTasks: [...existingStartup.startupTasks] };
+  const duplicateTask = startup.startupTasks.find(
+    (task) => task?.name === STARTUP_TASK_NAME
+  );
+  if (duplicateTask !== undefined) {
+    throw new Error(
+      `AppStartup task name ${STARTUP_TASK_NAME} is reserved by Lynx Autolink`
+    );
+  }
+  startup.startupTasks.push({
+    name: STARTUP_TASK_NAME,
+    srcEntry: taskEntry,
+    runOnThread: 'mainThread',
+    waitOnMainThread: true,
+  });
+
+  if (existingStartup === undefined) {
+    fs.writeFileSync(
+      path.join(etsDir, 'LynxAutolinkStartupConfig.ets'),
+      `// Generated by @lynx/lynx-library-plugin. Do not edit.
+import { StartupConfig, StartupConfigEntry } from '@kit.AbilityKit';
+
+export default class LynxAutolinkStartupConfig extends StartupConfigEntry {
+  onConfig(): StartupConfig {
+    return { timeoutMs: 10000 };
+  }
+}
+`
+    );
+  }
+
+  writeJson(path.join(profileDir, `${STARTUP_PROFILE_NAME}.json`), startup);
+}
+
+function addGeneratedResourceDirectory(modulePath, buildProfile, sourceRoot) {
+  const resourcesValue = toModuleRelativePath(
+    modulePath,
+    path.join(sourceRoot, 'resources')
+  );
+  const targets =
+    buildProfile?.targets?.length > 0
+      ? buildProfile.targets
+      : [{ name: 'default' }];
+
+  return {
+    ...buildProfile,
+    targets: targets.map((target) => ({
+      ...target,
+      resource: {
+        ...(target.resource ?? {}),
+        directories: appendUnique(
+          target.resource?.directories ?? ['./src/main/resources'],
+          resourcesValue
+        ),
+      },
+    })),
+  };
+}
+
+function setAppStartupProfile(moduleJson) {
+  if (!isObject(moduleJson?.module)) {
+    throw new Error('module.json5 must define a module object');
+  }
+  return {
+    ...moduleJson,
+    module: {
+      ...moduleJson.module,
+      appStartup: `$profile:${STARTUP_PROFILE_NAME}`,
+    },
+  };
+}
+
+function appendUnique(values = [], value) {
+  return values.includes(value) ? [...values] : [...values, value];
+}
+
+function toModuleRelativePath(modulePath, target) {
+  const relative = toPosixPath(path.relative(modulePath, target));
+  return relative === '..' || relative.startsWith('../')
+    ? relative
+    : `./${relative}`;
+}
+
+function resolveComparablePath(...parts) {
+  const resolved = path.resolve(...parts);
+  return fs.existsSync(resolved) ? fs.realpathSync(resolved) : resolved;
+}
+
+function toFileDependency(fromDir, targetDir) {
+  return `file:${toModuleRelativePath(fromDir, targetDir)}`;
+}
+
+function rebaseFileDependency(fromDir, targetDir, dependency) {
+  if (!dependency.startsWith('file:')) {
+    return dependency;
+  }
+  const dependencyPath = dependency.slice('file:'.length);
+  if (dependencyPath.length === 0) {
+    throw new Error('Harmony file dependency must include a path');
+  }
+  return toFileDependency(targetDir, path.resolve(fromDir, dependencyPath));
+}
+
+function toStartupEntry(modulePath, target) {
+  const entry = toModuleRelativePath(
+    path.join(modulePath, 'src', 'main'),
+    target
+  );
+  if (entry.length > 127) {
+    throw new Error(
+      `Generated AppStartup entry exceeds 127 characters: ${entry}`
+    );
+  }
+  return entry;
+}
+
+function assertPathInside(root, target, label) {
+  const relative = path.relative(path.resolve(root), path.resolve(target));
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`${label} escapes ${root}: ${target}`);
+  }
+}
+
+function assertRealPathInside(root, target, label) {
+  assertPathInside(fs.realpathSync(root), fs.realpathSync(target), label);
+}
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (error) {
+    throw new Error(`${filePath}: ${error.message}`);
+  }
+}
+
+function createJson5FileReader(parseJsonFile) {
+  if (typeof parseJsonFile !== 'function') {
+    throw new Error(
+      'Harmony Lynx Autolink requires @ohos/hvigor.parseJsonFile'
+    );
+  }
+  return (filePath) => {
+    try {
+      return parseJsonFile(filePath);
+    } catch (error) {
+      throw new Error(`${filePath}: ${error.message}`);
+    }
+  };
+}
+
+function requireJson5FileReader(readJson5File) {
+  if (typeof readJson5File !== 'function') {
+    throw new Error('Harmony Lynx Autolink requires a JSON5 file reader');
+  }
+}
+
+function requireNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value;
+}
+
+function isObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+module.exports = {
+  REGISTRY_PACKAGE_NAME,
+  STARTUP_PROFILE_NAME,
+  STARTUP_TASK_NAME,
+  configureHarmonyAutolinkHap,
+  discoverHarmonyLibraries,
+  generateRegistryHar,
+  generateRegistrySource,
+  prepareHarmonyAutolink,
+  setupHarmonyAutolink,
+};

--- a/platform/harmony/lynx_library_plugin/src/index.d.ts
+++ b/platform/harmony/lynx_library_plugin/src/index.d.ts
@@ -1,0 +1,17 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export interface HarmonyLynxAutolinkOptions {
+  /** Selects the entry or feature HAP module. Inferred when exactly one module depends on @lynx/lynx. */
+  moduleName?: string;
+  /** Overrides the directory from which ancestor node_modules folders are scanned. */
+  projectRoot?: string;
+}
+
+export declare function enableHarmonyLynxAutolink(
+  hvigorApi: typeof import('@ohos/hvigor'),
+  options?: HarmonyLynxAutolinkOptions
+): void;
+
+export default enableHarmonyLynxAutolink;

--- a/platform/harmony/lynx_library_plugin/src/index.js
+++ b/platform/harmony/lynx_library_plugin/src/index.js
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const { setupHarmonyAutolink } = require('./core.js');
+
+/**
+ * Enables global Lynx library Autolink for one entry or feature HAP module.
+ */
+function enableHarmonyLynxAutolink(hvigorApi, options = {}) {
+  if (hvigorApi === undefined || hvigorApi === null) {
+    throw new Error('Harmony Lynx Autolink requires the @ohos/hvigor API');
+  }
+  if (typeof hvigorApi.parseJsonFile !== 'function') {
+    throw new Error(
+      'Harmony Lynx Autolink requires @ohos/hvigor.parseJsonFile'
+    );
+  }
+  setupHarmonyAutolink(
+    hvigorApi.hvigorConfig,
+    hvigorApi.hvigor,
+    options,
+    hvigorApi.parseJsonFile
+  );
+}
+
+module.exports = enableHarmonyLynxAutolink;
+module.exports.enableHarmonyLynxAutolink = enableHarmonyLynxAutolink;
+module.exports.default = enableHarmonyLynxAutolink;

--- a/platform/harmony/lynx_library_plugin/test/core.test.js
+++ b/platform/harmony/lynx_library_plugin/test/core.test.js
@@ -1,0 +1,654 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const JSON5 = require('json5');
+
+const {
+  REGISTRY_PACKAGE_NAME,
+  discoverHarmonyLibraries,
+  generateRegistrySource,
+  setupHarmonyAutolink,
+} = require('../src/core.js');
+
+const tempDirs = [];
+
+test.afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+test('loads the public plugin entry through CommonJS', async () => {
+  const plugin = require('..');
+
+  assert.equal(typeof plugin, 'function');
+  assert.equal(typeof plugin.enableHarmonyLynxAutolink, 'function');
+  assert.equal(plugin.default, plugin.enableHarmonyLynxAutolink);
+
+  const importedPlugin = await import('../src/index.js');
+  assert.equal(importedPlugin.default, plugin);
+  assert.equal(importedPlugin.enableHarmonyLynxAutolink, plugin);
+});
+
+test('requires the public Hvigor JSON5 parser API', () => {
+  const plugin = require('..');
+
+  assert.throws(() => plugin({}), /requires @ohos\/hvigor\.parseJsonFile/);
+});
+
+test('discovers scoped libraries and parses JSON5 Harmony metadata', () => {
+  const project = createProject();
+  createLibrary(project, '@example/demo', '@example/demo_harmony', {
+    ohPackageSource: `{
+      name: '@example/demo_harmony',
+      main: 'Index.ets',
+    }`,
+  });
+
+  const libraries = discoverHarmonyLibraries(
+    path.join(project, 'entry'),
+    parseJson5File
+  );
+
+  assert.equal(libraries.length, 1);
+  assert.equal(libraries[0].npmPackageName, '@example/demo');
+  assert.equal(libraries[0].ohPackageName, '@example/demo_harmony');
+});
+
+test('rejects Harmony package paths that escape the npm package', () => {
+  const project = createProject();
+  const packageRoot = createLibrary(
+    project,
+    '@example/escape',
+    '@example/escape_harmony'
+  );
+  writeJson(path.join(packageRoot, 'lynx.lib.json'), {
+    platforms: { harmony: { packageDir: '../outside' } },
+  });
+
+  assert.throws(
+    () => discoverHarmonyLibraries(path.join(project, 'entry'), parseJson5File),
+    /platforms\.harmony\.packageDir escapes/
+  );
+});
+
+test('rejects duplicate npm package names', () => {
+  const project = createProject();
+  createLibrary(project, '@example/one', '@example/one_harmony');
+  const secondRoot = createLibrary(
+    project,
+    '@example/two',
+    '@example/two_harmony'
+  );
+  writeJson(path.join(secondRoot, 'package.json'), {
+    name: '@example/one',
+    version: '1.0.0',
+  });
+
+  assert.throws(
+    () => discoverHarmonyLibraries(path.join(project, 'entry'), parseJson5File),
+    /Duplicate npm package name/
+  );
+});
+
+test('rejects duplicate OHPM package names', () => {
+  const project = createProject();
+  createLibrary(project, '@example/one', '@example/shared', {
+    moduleName: 'one_module',
+  });
+  createLibrary(project, '@example/two', '@example/shared', {
+    moduleName: 'two_module',
+  });
+
+  assert.throws(
+    () => discoverHarmonyLibraries(path.join(project, 'entry'), parseJson5File),
+    /Duplicate OHPM package name/
+  );
+});
+
+test('rejects duplicate Harmony module names', () => {
+  const project = createProject();
+  createLibrary(project, '@example/one', '@example/one_harmony', {
+    moduleName: 'shared_module',
+  });
+  createLibrary(project, '@example/two', '@example/two_harmony', {
+    moduleName: 'shared_module',
+  });
+
+  assert.throws(
+    () => discoverHarmonyLibraries(path.join(project, 'entry'), parseJson5File),
+    /Duplicate Harmony module name/
+  );
+});
+
+test('rejects the generated Registry Harmony module name', () => {
+  const project = createProject();
+  createLibrary(project, '@example/reserved', '@example/reserved_harmony', {
+    moduleName: 'lynx_autolink_registry',
+  });
+
+  assert.throws(
+    () => discoverHarmonyLibraries(path.join(project, 'entry'), parseJson5File),
+    /Harmony module name lynx_autolink_registry is reserved/
+  );
+});
+
+test('generates registry imports in stable npm package order', () => {
+  const source = generateRegistrySource([
+    libraryDescriptor('@example/z', '@example/z_harmony'),
+    libraryDescriptor('@example/a', '@example/a_harmony'),
+  ]);
+
+  assert.ok(
+    source.indexOf("from '@example/a_harmony'") <
+      source.indexOf("from '@example/z_harmony'")
+  );
+  assert.match(source, /LynxLibraryRegistry\.setupGlobal\(PROVIDERS\)/);
+});
+
+test('adds HAR nodes before configuring the HAP through model setters', () => {
+  const project = createProject();
+  createLibrary(project, '@example/demo', '@example/demo_harmony');
+  const originalModuleJson = {
+    module: { name: 'entry', type: 'entry' },
+  };
+  const state = {
+    dependencies: { '@lynx/lynx': '^3.5.0' },
+    buildProfile: { targets: [{ name: 'default' }] },
+    moduleJson: originalModuleJson,
+  };
+  const { descriptors, lifecycle, result } = configureAutolink(project, state);
+
+  assert.equal(result.libraries.length, 1);
+  assert.match(
+    state.dependencies[REGISTRY_PACKAGE_NAME],
+    /^file:\.\.\/\.hvigor\/lynx-autolink\/entry\/registry$/
+  );
+  assert.equal(
+    state.moduleJson.module.appStartup,
+    '$profile:lynx_autolink_startup'
+  );
+  assert.deepEqual(
+    descriptors.map((descriptor) => descriptor.name),
+    ['entry', 'lynx_autolink_registry', 'demo']
+  );
+  assert.equal(
+    descriptors[1].srcPath,
+    './.hvigor/lynx-autolink/entry/registry'
+  );
+  assert.equal(descriptors[2].srcPath, './node_modules/@example/demo/harmony');
+  assert.deepEqual(descriptors[1].extraOptions.targets, [
+    { name: 'default', applyToProducts: ['default'] },
+  ]);
+  assert.equal(state.buildProfile.targets[0].source, undefined);
+  assert.deepEqual(state.buildProfile.targets[0].resource.directories, [
+    './src/main/resources',
+    './build/generated/lynx-autolink/src/main/resources',
+  ]);
+  const registrySource = fs.readFileSync(
+    path.join(result.registryDir, 'Index.ets'),
+    'utf8'
+  );
+  assert.match(registrySource, /new Provider0\(\)/);
+  const startupTask = fs.readFileSync(
+    path.join(
+      result.generatedSourceRoot,
+      'ets',
+      'lynx_autolink',
+      'LynxAutolinkStartupTask.ets'
+    ),
+    'utf8'
+  );
+  assert.match(startupTask, /setupGlobal\(\);/);
+  assert.doesNotMatch(
+    startupTask,
+    /registerBehavior|registerModule|registerService/
+  );
+  const startupProfile = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        result.generatedSourceRoot,
+        'resources',
+        'base',
+        'profile',
+        'lynx_autolink_startup.json'
+      ),
+      'utf8'
+    )
+  );
+  assert.equal(
+    startupProfile.startupTasks[0].srcEntry,
+    '../../build/generated/lynx-autolink/src/main/ets/lynx_autolink/LynxAutolinkStartupTask.ets'
+  );
+  assert.deepEqual(originalModuleJson, {
+    module: { name: 'entry', type: 'entry' },
+  });
+
+  fs.rmSync(result.generatedSourceRoot, { recursive: true });
+  lifecycle.runTask('generateLynxAutolink');
+  assert.ok(
+    fs.existsSync(
+      path.join(
+        result.generatedSourceRoot,
+        'resources',
+        'base',
+        'profile',
+        'lynx_autolink_startup.json'
+      )
+    )
+  );
+  assert.deepEqual(lifecycle.tasks[0].postDependencies, ['default@PreBuild']);
+});
+
+test('preserves existing startup tasks and config entry', () => {
+  const project = createProject();
+  const modulePath = path.join(project, 'entry');
+  const profileDir = path.join(
+    modulePath,
+    'src',
+    'main',
+    'resources',
+    'base',
+    'profile'
+  );
+  fs.mkdirSync(profileDir, { recursive: true });
+  writeJson(path.join(profileDir, 'startup.json'), {
+    startupTasks: [
+      { name: 'ExistingTask', srcEntry: './ets/ExistingTask.ets' },
+    ],
+    configEntry: './ets/ExistingConfig.ets',
+  });
+  const state = {
+    dependencies: { '@lynx/lynx': '^3.5.0' },
+    buildProfile: { targets: [{ name: 'default' }] },
+    moduleJson: {
+      module: {
+        name: 'entry',
+        type: 'entry',
+        appStartup: '$profile:startup',
+      },
+    },
+  };
+
+  const { result } = configureAutolink(project, state);
+  const generatedProfile = JSON.parse(
+    fs.readFileSync(
+      path.join(
+        result.generatedSourceRoot,
+        'resources',
+        'base',
+        'profile',
+        'lynx_autolink_startup.json'
+      ),
+      'utf8'
+    )
+  );
+
+  assert.equal(generatedProfile.configEntry, './ets/ExistingConfig.ets');
+  assert.deepEqual(
+    generatedProfile.startupTasks.map((task) => task.name),
+    ['ExistingTask', 'LynxAutolinkStartupTask']
+  );
+});
+
+test('rebases a local Lynx SDK dependency for the generated Registry HAR', () => {
+  const project = createProject();
+  setLynxDependency(project, 'entry', 'file:../sdk');
+  const state = {
+    dependencies: { '@lynx/lynx': 'file:../sdk' },
+    buildProfile: { targets: [{ name: 'default' }] },
+    moduleJson: { module: { name: 'entry', type: 'entry' } },
+  };
+
+  const { result } = configureAutolink(project, state);
+  const registryPackage = JSON.parse(
+    fs.readFileSync(path.join(result.registryDir, 'oh-package.json5'), 'utf8')
+  );
+
+  assert.equal(
+    registryPackage.dependencies['@lynx/lynx'],
+    'file:../../../../sdk'
+  );
+});
+
+test('accepts an existing project module that resolves through a symlink', () => {
+  const project = createProject();
+  const packageRoot = createLibrary(
+    project,
+    '@example/demo',
+    '@example/demo_harmony'
+  );
+  const linkedHarmonyDir = path.join(project, 'linked-demo-harmony');
+  fs.symlinkSync(path.join(packageRoot, 'harmony'), linkedHarmonyDir, 'dir');
+  const state = {
+    dependencies: { '@lynx/lynx': '^3.5.0' },
+    buildProfile: { targets: [{ name: 'default' }] },
+    moduleJson: { module: { name: 'entry', type: 'entry' } },
+  };
+
+  const { descriptors } = configureAutolink(project, state, {
+    descriptors: [
+      { name: 'entry', srcPath: './entry' },
+      { name: 'demo', srcPath: './linked-demo-harmony' },
+    ],
+    options: { moduleName: 'entry' },
+  });
+
+  assert.equal(
+    descriptors.filter((descriptor) => descriptor.name === 'demo').length,
+    1
+  );
+});
+
+test('rejects a HAP module source path outside the project', () => {
+  const project = createProject();
+  const outsideProject = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lynx-harmony-outside-')
+  );
+  tempDirs.push(outsideProject);
+  createHapModule(outsideProject, 'entry', 'entry');
+
+  assert.throws(
+    () =>
+      setupHarmonyAutolink(
+        createHvigorConfig(project, [
+          {
+            name: 'entry',
+            srcPath: path.relative(project, path.join(outsideProject, 'entry')),
+          },
+        ]),
+        createLifecycle(),
+        { moduleName: 'entry' },
+        parseJson5File
+      ),
+    /Hvigor module entry source path escapes/
+  );
+});
+
+test('rejects a HAP module symlink that resolves outside the project', () => {
+  const project = createProject();
+  const outsideProject = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lynx-harmony-outside-')
+  );
+  tempDirs.push(outsideProject);
+  createHapModule(outsideProject, 'entry', 'entry');
+  fs.symlinkSync(
+    path.join(outsideProject, 'entry'),
+    path.join(project, 'linked-entry'),
+    'dir'
+  );
+
+  assert.throws(
+    () =>
+      setupHarmonyAutolink(
+        createHvigorConfig(project, [
+          { name: 'entry', srcPath: './linked-entry' },
+        ]),
+        createLifecycle(),
+        { moduleName: 'entry' },
+        parseJson5File
+      ),
+    /Hvigor module entry source path escapes/
+  );
+});
+
+test('rejects a dynamic HAR node that conflicts with an existing module', () => {
+  const project = createProject();
+  createLibrary(project, '@example/demo', '@example/demo_harmony');
+
+  assert.throws(
+    () =>
+      setupHarmonyAutolink(
+        createHvigorConfig(project, [
+          { name: 'entry', srcPath: './entry' },
+          { name: 'demo', srcPath: './another-demo' },
+        ]),
+        createLifecycle(),
+        { moduleName: 'entry' },
+        parseJson5File
+      ),
+    /Harmony module conflict for demo/
+  );
+});
+
+test('isolates generated output by HAP module in the Hvigor cache', () => {
+  const project = createProject();
+  const hvigorConfig = createHvigorConfig(project);
+  const lifecycle = createLifecycle();
+
+  const result = setupHarmonyAutolink(
+    hvigorConfig,
+    lifecycle,
+    { moduleName: 'entry' },
+    parseJson5File
+  );
+
+  assert.equal(
+    result.outputRoot,
+    path.join(fs.realpathSync(project), '.hvigor', 'lynx-autolink', 'entry')
+  );
+});
+
+test('infers the only HAP module that depends on Lynx', () => {
+  const project = createProject();
+  const state = createModuleState();
+
+  const { result } = configureAutolink(project, state, { options: {} });
+
+  assert.equal(result.moduleName, 'entry');
+});
+
+test('requires moduleName when multiple HAP modules depend on Lynx', () => {
+  const project = createProject();
+  createHapModule(project, 'feature', 'feature');
+  const hvigorConfig = createHvigorConfig(project, [
+    { name: 'entry', srcPath: './entry' },
+    { name: 'feature', srcPath: './feature' },
+  ]);
+
+  assert.throws(
+    () =>
+      setupHarmonyAutolink(hvigorConfig, createLifecycle(), {}, parseJson5File),
+    /found multiple Lynx HAP modules \(entry, feature\); set moduleName explicitly/
+  );
+});
+
+function createProject() {
+  const project = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'lynx-harmony-autolink-')
+  );
+  tempDirs.push(project);
+  writeJson(path.join(project, 'package.json'), { name: 'app', private: true });
+  writeJson(path.join(project, 'build-profile.json5'), {
+    app: { products: [{ name: 'default' }] },
+    modules: [{ name: 'entry', srcPath: './entry' }],
+  });
+  createHapModule(project, 'entry', 'entry');
+  return project;
+}
+
+function createHapModule(project, moduleName, moduleType) {
+  const modulePath = path.join(project, moduleName);
+  writeJson(path.join(modulePath, 'oh-package.json5'), {
+    name: moduleName,
+    version: '1.0.0',
+    dependencies: { '@lynx/lynx': '^3.5.0' },
+  });
+  writeJson(path.join(modulePath, 'build-profile.json5'), {
+    apiType: 'stageMode',
+    targets: [{ name: 'default' }],
+  });
+  writeJson(path.join(modulePath, 'src', 'main', 'module.json5'), {
+    module: { name: moduleName, type: moduleType },
+  });
+}
+
+function setLynxDependency(project, moduleName, dependency) {
+  writeJson(path.join(project, moduleName, 'oh-package.json5'), {
+    name: moduleName,
+    version: '1.0.0',
+    dependencies: { '@lynx/lynx': dependency },
+  });
+}
+
+function createLibrary(project, npmName, ohPackageName, options = {}) {
+  const parts = npmName.split('/');
+  const packageRoot = path.join(project, 'node_modules', ...parts);
+  const harmonyDir = path.join(packageRoot, 'harmony');
+  fs.mkdirSync(path.join(harmonyDir, 'src', 'main'), { recursive: true });
+  writeJson(path.join(packageRoot, 'package.json'), {
+    name: npmName,
+    version: '1.0.0',
+  });
+  writeJson(path.join(packageRoot, 'lynx.lib.json'), {
+    platforms: { harmony: { packageDir: 'harmony' } },
+  });
+  if (options.ohPackageSource !== undefined) {
+    fs.writeFileSync(
+      path.join(harmonyDir, 'oh-package.json5'),
+      options.ohPackageSource
+    );
+  } else {
+    writeJson(path.join(harmonyDir, 'oh-package.json5'), {
+      name: ohPackageName,
+      main: 'Index.ets',
+    });
+  }
+  fs.writeFileSync(
+    path.join(harmonyDir, 'Index.ets'),
+    'export class LynxLibraryProviderImpl {}\n'
+  );
+  writeJson(path.join(harmonyDir, 'src', 'main', 'module.json5'), {
+    module: {
+      name:
+        options.moduleName ?? npmName.split('/').at(-1).replaceAll('-', '_'),
+      type: 'har',
+    },
+  });
+  writeJson(path.join(harmonyDir, 'build-profile.json5'), {
+    apiType: 'stageMode',
+    targets: [{ name: 'default' }],
+  });
+  fs.writeFileSync(
+    path.join(harmonyDir, 'hvigorfile.ts'),
+    "import { harTasks } from '@ohos/hvigor-ohos-plugin';\n\n" +
+      'export default { system: harTasks, plugins: [] };\n'
+  );
+  return packageRoot;
+}
+
+function createContext(modulePath, state) {
+  return {
+    getModulePath: () => modulePath,
+    getModuleType: () => 'entry',
+    targets: (callback) => {
+      for (const targetName of state.targetNames ?? ['default']) {
+        callback({ getTargetName: () => targetName });
+      }
+    },
+    getDependenciesOpt: () => state.dependencies,
+    setDependenciesOpt: (value) => {
+      state.dependencies = value;
+    },
+    getBuildProfileOpt: () => state.buildProfile,
+    setBuildProfileOpt: (value) => {
+      state.buildProfile = value;
+    },
+    getModuleJsonOpt: () => state.moduleJson,
+    setModuleJsonOpt: (value) => {
+      state.moduleJson = value;
+    },
+  };
+}
+
+function createModuleState() {
+  return {
+    dependencies: { '@lynx/lynx': '^3.5.0' },
+    buildProfile: { targets: [{ name: 'default' }] },
+    moduleJson: { module: { name: 'entry', type: 'entry' } },
+  };
+}
+
+function createHvigorConfig(
+  projectPath,
+  initialDescriptors = [{ name: 'entry', srcPath: './entry' }]
+) {
+  const descriptors = initialDescriptors.map((descriptor) => ({
+    ...descriptor,
+    extraOptions: descriptor.extraOptions ?? {},
+  }));
+  return {
+    descriptors,
+    getRootNodeDescriptor: () => ({ name: 'app', srcPath: projectPath }),
+    getAllNodeDescriptor: () => descriptors,
+    getNodeDescriptorByName: (name) =>
+      descriptors.find((descriptor) => descriptor.name === name),
+    includeNode: (name, srcPath, extraOptions) => {
+      descriptors.push({ name, srcPath, extraOptions });
+    },
+  };
+}
+
+function createLifecycle() {
+  let afterNodeEvaluate;
+  let nodesEvaluated;
+  const tasks = [];
+  return {
+    tasks,
+    afterNodeEvaluate(callback) {
+      afterNodeEvaluate = callback;
+    },
+    nodesEvaluated(callback) {
+      nodesEvaluated = callback;
+    },
+    evaluate(moduleName, context) {
+      afterNodeEvaluate({
+        getNodeName: () => moduleName,
+        getContext: () => context,
+        registerTask: (task) => tasks.push(task),
+      });
+      nodesEvaluated();
+    },
+    runTask(name) {
+      const task = tasks.find((candidate) => candidate.name === name);
+      assert.ok(task, `Missing task ${name}`);
+      task.run();
+    },
+  };
+}
+
+function configureAutolink(project, state, config = {}) {
+  const hvigorConfig = createHvigorConfig(project, config.descriptors);
+  const lifecycle = createLifecycle();
+  const options = config.options ?? { moduleName: 'entry' };
+  const result = setupHarmonyAutolink(
+    hvigorConfig,
+    lifecycle,
+    options,
+    parseJson5File
+  );
+  lifecycle.evaluate(
+    result.moduleName,
+    createContext(path.join(project, result.moduleName), state)
+  );
+  return { descriptors: hvigorConfig.descriptors, lifecycle, result };
+}
+
+function libraryDescriptor(npmPackageName, ohPackageName) {
+  return { npmPackageName, ohPackageName };
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function parseJson5File(filePath) {
+  return JSON5.parse(fs.readFileSync(filePath, 'utf8'));
+}


### PR DESCRIPTION
## Summary

Adds HarmonyOS support for Lynx global library Autolink.

- Exposes `LynxLibraryProvider`, `LynxLibraryRegistry`, and provider entries from the Harmony SDK.
- Registers global Native Modules before runtime-specific modules so explicit application registrations keep precedence.
- Merges global Behaviors before per-view Behaviors without mutating the caller-provided map.
- Adds `@lynx/lynx-library-plugin` to discover Harmony-enabled libraries and generate a Registry HAR plus AppStartup task.
- Uses the root `hvigorconfig.ts` configuration phase to add library and Registry HAR nodes before Hvigor initializes the module graph.
- Uses Hvigor's public `parseJsonFile()` API and ships no runtime npm parser dependency.
- Exposes a CommonJS-compatible plugin entry for Hvigor while retaining named and default imports.
- Keeps the Registry HAR in the project `.hvigor` cache and regenerates HAP-local AppStartup sources after `clean` and before `PreBuild`.
- Enables the same flow in Harmony Explorer.
- Supports global registration only; no per-`LynxView` library API is introduced.

## Design

A library exports `LynxLibraryProviderImpl` from its source HAR. The application enables Autolink once from the project root `hvigorconfig.ts`, passing the official `@ohos/hvigor` API namespace. Before module nodes are created, Autolink scans visible `node_modules` packages for `lynx.lib.json`, validates each `platforms.harmony.packageDir`, parses HarmonyOS JSON5 metadata with `parseJsonFile()`, generates a deterministic Registry HAR, and calls `hvigorConfig.includeNode()` for every required HAR.

The Registry HAR is generated under `.hvigor/lynx-autolink/<moduleName>` so the HAP `clean` task does not delete the module before compilation. After the selected entry or feature HAP is evaluated, Autolink uses HAP model APIs to inject the Registry dependency, generated resource directory, and AppStartup profile. A generated Hvigor task recreates the HAP-local AppStartup sources before each active target's `PreBuild`. The startup task calls only the Registry HAR's idempotent `setupGlobal()` before Lynx runtimes are created.

Registration is staged and validated before commit. Duplicate package, Behavior, Native Module, Service, and Harmony module identities fail with actionable errors. Native Module registration is frozen after the first runtime is created.

## Related PRs

- Harmony codegen and library scaffolding: https://github.com/lynx-family/lynx-stack/pull/2990
- Harmony Autolink documentation: https://github.com/lynx-family/lynx-website/pull/1182

## Validation

- `npm test`: 17/17 plugin tests passed, including CommonJS/default/named entry loading, JSON5 parser API validation, and regeneration after `clean`.
- Packed-plugin smoke test passed with no runtime npm dependencies.
- API 20 Hvigor initialization passed with the same `6.0.0.868` command-line tools used by CI while the plugin's own `node_modules` directory was absent.
- Generated a temporary Element, Native Module, and Service library with `create-lynx-library`, ran codegen, and integrated its HAR into Explorer through Autolink.
- Verified the temporary library and Registry as independent Hvigor nodes, the generated Registry provider import, and an AppStartup task that only calls `setupGlobal()`.
- API 20 `assembleApp` completed ArkTS compilation, HAP packaging, and APP packaging successfully without changing checked-in project configuration.
- Temporary library links, generated registry files, and test-only resources were removed after verification.

## Checklist

- [x] Tests updated.
- [x] Documentation updated in the companion website change.

Fixes #8099 
