### PR TITLE
fix(ios/lynx_service): SSE response should use processStreamingData, …

### DIFF
--- a/platform/darwin/ios/lynx_service/http/LynxNSUrlSessionDelegate.m
+++ b/platform/darwin/ios/lynx_service/http/LynxNSUrlSessionDelegate.m
@@ -10,6 +10,7 @@
   LynxHttpCallback _callback;
   NSMutableData *_buffer;
   BOOL _useDeprecatedStreamingConfig;
+  BOOL _isSseResponse;  // 响应 content-type 是 text/event-stream
 }
 
 - (instancetype)initWithDelegate:(LynxHttpStreamingDelegate *)httpDelegate
@@ -21,6 +22,7 @@
     _callback = callback;
     _buffer = [[NSMutableData alloc] init];
     _useDeprecatedStreamingConfig = useDeprecatedStreamingConfig;
+    _isSseResponse = NO;
   }
   return self;
 }
@@ -36,6 +38,11 @@
   resp.statusText = @"OK";
   resp.httpHeaders = httpResponse.allHeaderFields;
   resp.statusCode = httpResponse.statusCode;
+  // 检测 SSE 响应：content-type 含 text/event-stream
+  NSString *contentType = [[httpResponse valueForHTTPHeaderField:@"Content-Type"] lowercaseString] ?: @"";
+  if ([contentType containsString:@"text/event-stream"]) {
+    _isSseResponse = YES;
+  }
   _callback(resp);
   completionHandler(NSURLSessionResponseAllow);
 }
@@ -43,7 +50,10 @@
 - (void)URLSession:(NSURLSession *)session
           dataTask:(NSURLSessionDataTask *)dataTask
     didReceiveData:(NSData *)data {
-  if (_useDeprecatedStreamingConfig) {
+  // SSE 响应或非 deprecated 配置：走 processStreamingData（直接 onData 传整块，JS 端按 SSE 解析）。
+  // 否则（deprecated chunked 配置且非 SSE）：走 processChunkedData（按 chunked 编码解析）。
+  // 修复：原逻辑 useStreaming 时一律走 chunked，对 SSE 数据解析失败丢弃。
+  if (_useDeprecatedStreamingConfig && !_isSseResponse) {
     [_httpDelegate processChunkedData:_buffer withData:data];
   } else {
     [_httpDelegate processStreamingData:data];


### PR DESCRIPTION

## 问题（Bug）

Lynx iOS 3.9.0 的 `useStreaming` 配置下，SSE（Server-Sent Events）响应数据被错误地按 HTTP `Transfer-Encoding: chunked` 编码解析，导致 SSE 数据解析失败、`onData` 永不触发，流式响应收不到任何数据帧。

## 复现

1. 用 `lynx.fetch` 发 SSE 请求（`Accept: text/event-stream`），init 带 `lynxExtension: { useStreaming: true }`
2. 服务端正常返回 SSE 流（`Content-Type: text/event-stream`，多条 `data: {...}\n\n` 帧）
3. `URLSession:didReceiveData:` 被正常调用（多次，每帧一次）
4. 但 `LynxHttpStreamingDelegate` 的 `onData:` **一次都不触发**，最终只 `onEnd`

## 根因

`Pods/LynxService/platform/darwin/ios/lynx_service/http/LynxNSUrlSessionDelegate.m` 的 `didReceiveData:`：

```objc
if (_useDeprecatedStreamingConfig) {
    [_httpDelegate processChunkedData:_buffer withData:data];   // ← SSE 走这里
} else {
    [_httpDelegate processStreamingData:data];
}
```

`_useDeprecatedStreamingConfig` 来自 `useStreaming` flag。SSE 响应被错误地走 `processChunkedData`（按 chunked 编码：`<十六进制长度>\r\n<data>\r\n`）。但 SSE 数据格式是 `data: {...}\n\n`，chunked 解析器读不到合法的十六进制长度，`chunkSize == -1` 直接 return，数据丢弃，`onData` 永不触发。

## 修复

在 `didReceiveResponse:` 检测响应 `Content-Type`，若是 `text/event-stream` 标记为 SSE；`didReceiveData:` 里 SSE 响应走 `processStreamingData`（整块直传 `onData`，JS 端按 SSE 帧边界 `\n\n` 自行解析），而非 `processChunkedData`。

```objc
// didReceiveResponse: 里
NSString *contentType = [[httpResponse valueForHTTPHeaderField:@"Content-Type"] lowercaseString] ?: @"";
if ([contentType containsString:@"text/event-stream"]) {
    _isSseResponse = YES;
}

// didReceiveData: 里
if (_useDeprecatedStreamingConfig && !_isSseResponse) {
    [_httpDelegate processChunkedData:_buffer withData:data];
} else {
    [_httpDelegate processStreamingData:data];   // SSE 走这里
}
```

## 影响

- 不影响 chunked 传输（非 SSE 仍走 processChunkedData）
- 不影响非 streaming 配置
- 仅修正 SSE 场景的数据分发路径

## 测试

- SSE 请求（chatWithRobot）：修复前 `onData` 不触发、reader 读到空；修复后 `onData` 每帧触发、reader 逐块读到数据、流式正常
- 普通 REST：行为不变
- chunked 响应（非 SSE）：行为不变


---

## English

### Bug

Under the `useStreaming` config (Lynx iOS 3.9.0), SSE (Server-Sent Events) response data is incorrectly parsed using HTTP `Transfer-Encoding: chunked` encoding, causing SSE data parsing to fail and `onData:` to never fire — the streaming response receives no data frames.

### Reproduce

1. Send an SSE request via `lynx.fetch` (`Accept: text/event-stream`), with `init.lynxExtension = { useStreaming: true }`
2. Server returns a normal SSE stream (`Content-Type: text/event-stream`, multiple `data: {...}\n\n` frames)
3. `URLSession:didReceiveData:` is called correctly (multiple times, once per frame)
4. But `LynxHttpStreamingDelegate`'s `onData:` **never fires** — only `onEnd` at the end

### Root cause

`platform/darwin/ios/lynx_service/http/LynxNSUrlSessionDelegate.m` `didReceiveData:`:

```objc
if (_useDeprecatedStreamingConfig) {
    [_httpDelegate processChunkedData:_buffer withData:data];   // ← SSE goes here
} else {
    [_httpDelegate processStreamingData:data];
}
```

`_useDeprecatedStreamingConfig` comes from the `useStreaming` flag. SSE responses are wrongly routed through `processChunkedData` (which parses HTTP chunked encoding: `<hex-length>\r\n<data>\r\n`). But SSE data format is `data: {...}\n\n`, so the chunked parser can't read a valid hex length, returns early (`chunkSize == -1`), and silently drops the data. `onData:` is never invoked.

### Fix

Detect `Content-Type: text/event-stream` in `didReceiveResponse:` and mark the response as SSE; in `didReceiveData:`, route SSE responses through `processStreamingData` (which passes the raw block straight to `onData:`, letting the JS side parse SSE frame boundaries `\n\n` itself), instead of `processChunkedData`.

```objc
// in didReceiveResponse:
NSString *contentType = [[httpResponse valueForHTTPHeaderField:@"Content-Type"] lowercaseString] ?: @"";
if ([contentType containsString:@"text/event-stream"]) {
    _isSseResponse = YES;
}

// in didReceiveData:
if (_useDeprecatedStreamingConfig && !_isSseResponse) {
    [_httpDelegate processChunkedData:_buffer withData:data];
} else {
    [_httpDelegate processStreamingData:data];   // SSE goes here
}
```

### Impact

- Does NOT affect chunked transfer (non-SSE still uses processChunkedData)
- Does NOT affect non-streaming config
- Only fixes the data routing path for the SSE case

### Testing

- SSE request (chatWithRobot): before fix `onData` never fired, reader got empty stream; after fix `onData` fires per frame, reader reads data block by block, streaming works correctly
- Normal REST: behavior unchanged
- Chunked response (non-SSE): behavior unchanged

Fixes #8024 
