### PR TITLE
[Infra] Upload Habitat statistics from GitHub CI

### DIFF
--- a/.github/actions/common-deps/action.yml
+++ b/.github/actions/common-deps/action.yml
@@ -99,11 +99,22 @@ runs:
       shell: bash
       working-directory: lynx
       run: |
+        mkdir -p "$(dirname "$HABITAT_STAT_FILE")"
         if [[ "${{ inputs.target }}" == "" ]]; then
-          tools/hab sync .
+          tools/hab --stat-output "$HABITAT_STAT_FILE" sync .
         else
-          tools/hab sync . --target ${{ inputs.target }}
+          tools/hab --stat-output "$HABITAT_STAT_FILE" sync . --target ${{ inputs.target }}
         fi
       env:
         HABITAT_CONCURRENCY: ${{ inputs.concurrency }}
+        HABITAT_STAT_FILE: ${{ runner.temp }}/habitat-stats/habitat_session.jsonl
         npm_config_store_dir: ~/.local/share/pnpm/store
+
+    - name: Upload Habitat statistics
+      if: ${{ always() }}
+      continue-on-error: true
+      uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+      with:
+        name: habitat-stats-${{ github.job }}-${{ strategy.job-index || 0 }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/habitat-stats/habitat_session.jsonl
+        if-no-files-found: warn

--- a/.github/actions/windows-common-deps/action.yml
+++ b/.github/actions/windows-common-deps/action.yml
@@ -112,12 +112,23 @@ runs:
       shell: pwsh
       working-directory: lynx
       run: |
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $env:HABITAT_STAT_FILE) | Out-Null
         if ([string]::IsNullOrEmpty("${{ inputs.target }}")) {
-            .\tools\hab.ps1 sync .
+            .\tools\hab.ps1 --stat-output $env:HABITAT_STAT_FILE sync .
         } else {
-            .\tools\hab.ps1 sync . --target ${{ inputs.target }}
+            .\tools\hab.ps1 --stat-output $env:HABITAT_STAT_FILE sync . --target ${{ inputs.target }}
         }
         if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
       env:
         HABITAT_CONCURRENCY: ${{ inputs.concurrency }}
+        HABITAT_STAT_FILE: ${{ runner.temp }}/habitat-stats/habitat_session.jsonl
         npm_config_store_dir: ${{ steps.npm-cache-dir.outputs.NPM_CACHE_DIR }}
+
+    - name: Upload Habitat statistics
+      if: ${{ always() }}
+      continue-on-error: true
+      uses: lynx-infra/upload-artifact@332ec52e99f7cbf1fbbdc9bcc09280d49147d092
+      with:
+        name: habitat-stats-${{ github.job }}-${{ strategy.job-index || 0 }}-${{ github.run_attempt }}
+        path: ${{ runner.temp }}/habitat-stats/habitat_session.jsonl
+        if-no-files-found: warn

--- a/.habitat
+++ b/.habitat
@@ -1,4 +1,4 @@
-habitat_version = "0.3.147"
+habitat_version = "0.3.148"
 solutions = [
     {
         'name': '.',

--- a/tools/hab
+++ b/tools/hab
@@ -11,7 +11,7 @@ set -e
 ##  habitat start up script for UN*X
 ##
 ##############################################################################
-__version__="0.3.147"
+__version__="0.3.148"
 
 if [[ "$HABITAT_DEBUG" = "true" ]]; then
   set -x

--- a/tools/hab.ps1
+++ b/tools/hab.ps1
@@ -1,6 +1,6 @@
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-$__version__ = "0.3.147"
+$__version__ = "0.3.148"
 
 if ($null -eq $env:HABITAT_VERSION) { 
     $HABITAT_VERSION = $__version__


### PR DESCRIPTION
## Summary

- Upgrade the pinned Habitat version to 0.3.148.
- Generate habitat_session.jsonl for shared Linux, macOS, and Windows dependency syncs.
- Upload statistics on both successful and failed syncs without masking the CI result.

## Test Plan

- [x] tools/hab sync . -f
- [x] git lynx check
- [x] Validate successful and failed Habitat invocations produce valid JSONL with habVersion 0.3.148.
- [x] Validate the shared action YAML and Unix wrapper syntax.
- [ ] Verify Linux, macOS, and Windows jobs upload habitat-stats artifacts in PR CI.

## AI Assistance

This change was substantially assisted by OpenAI Codex. I reviewed the implementation, behavior, and verification results before submission.