### PR TITLE
[Infra] Upgrade habitat version to 0.3.148

### DIFF
--- a/.habitat
+++ b/.habitat
@@ -1,4 +1,4 @@
-habitat_version = "0.3.147"
+habitat_version = "0.3.148"
 solutions = [
     {
         'name': '.',

--- a/tools/hab
+++ b/tools/hab
@@ -11,7 +11,7 @@ set -e
 ##  habitat start up script for UN*X
 ##
 ##############################################################################
-__version__="0.3.147"
+__version__="0.3.148"
 
 if [[ "$HABITAT_DEBUG" = "true" ]]; then
   set -x

--- a/tools/hab.ps1
+++ b/tools/hab.ps1
@@ -1,6 +1,6 @@
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
-$__version__ = "0.3.147"
+$__version__ = "0.3.148"
 
 if ($null -eq $env:HABITAT_VERSION) { 
     $HABITAT_VERSION = $__version__


### PR DESCRIPTION
## Summary

- Upgrade the project Habitat requirement to 0.3.148.
- Upgrade the Unix and Windows Habitat wrapper defaults to 0.3.148.

## Test Plan

- [x] `tools/hab -v`
- [x] `tools/hab sync . -f`
- [x] `git lynx check`

## AI Assistance

This change was substantially assisted by OpenAI Codex. I reviewed the implementation and verification results before submission.