### PR TITLE
[BugFix][Android] Publish Lynx library Gradle plugin markers

### DIFF
--- a/platform/android/lynx_library_plugin/build.gradle
+++ b/platform/android/lynx_library_plugin/build.gradle
@@ -16,11 +16,6 @@ dependencies {
 }
 
 gradlePlugin {
-    // Keep the release artifact owned by ../publish.gradle and avoid
-    // java-gradle-plugin's pluginMaven / *PluginMarkerMaven publications.
-    // This also means the plugin is not published with Gradle plugin markers
-    // for Maven-based `plugins { id(...) version ... }` resolution.
-    automatedPublishing = false
     plugins {
         lynxLibrarySettings {
             id = 'org.lynxsdk.library-settings'

--- a/platform/android/publish.gradle
+++ b/platform/android/publish.gradle
@@ -12,6 +12,13 @@ def aarPathList=""
 def baseVersion = findProperty("version")
 def devVersion = "${baseVersion}-dev"
 
+if (findProperty("ARTIFACT_GROUP") != null) {
+    project.group = ARTIFACT_GROUP
+}
+if (baseVersion != null) {
+    project.version = baseVersion
+}
+
 def getAARPath(buildPath, boolean isDev = false) {
     def filePattern
     if (isDev) {
@@ -55,6 +62,11 @@ boolean isAndroidModule() {
     return result
 }
 
+boolean isGradlePluginModule() {
+    boolean result = project.plugins.hasPlugin('java-gradle-plugin')
+    return result
+}
+
 boolean hasDevFlavor() {
     if (!isAndroidModule() || !project.android.productFlavors.any { it.name == "dev" }) {
         return false
@@ -64,6 +76,36 @@ boolean hasDevFlavor() {
         taskName.contains("dev")
     }
     return isDevTaskExecuted
+}
+
+Task createJavaSourceJar() {
+    Task existingTask = project.tasks.findByName("sourceJar")
+    if (existingTask != null) {
+        return existingTask
+    }
+    return project.tasks.create("sourceJar", Jar) {
+        if (project.gradle.gradleVersion >= '8.0') {
+            it.setArchiveClassifier('sources')
+        } else {
+            classifier = 'sources'
+        }
+        from sourceSets.main.allSource
+    }
+}
+
+Task createJavaJavadocJar() {
+    Task existingTask = project.tasks.findByName("javadocJar")
+    if (existingTask != null) {
+        return existingTask
+    }
+    return project.tasks.create("javadocJar", Jar) {
+        if (project.gradle.gradleVersion >= '8.0') {
+            it.setArchiveClassifier('javadoc')
+        } else {
+            classifier = 'javadoc'
+        }
+        from sourceSets.main.java
+    }
 }
 
 Task createSourceJar(String baseName) {
@@ -89,13 +131,40 @@ Task createSourceJar(String baseName) {
     }
 }
 
-def configureSigning(pom) {
+def configurePomMetadata(publication) {
+    publication.pom {
+        name = publication.artifactId
+        url = REPOSITORY_URL
+        description = DESCRIPTION
+        licenses {
+            license {
+                name = 'The Apache License, version 2.0'
+                url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+        }
+        developers {
+            developer {
+                name = DEVELOPER_NAME
+                email = DEVELOPER_EMAIL
+            }
+        }
+        scm {
+            url = REPOSITORY_URL
+            connection = "scm:git:git://$REPOSITORY_SSH_URL"
+            developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
+        }
+    }
+}
+
+def configureSigningForPublications() {
     def signingKeyId = findProperty("signing.keyId")
     def signingPassword = findProperty("signing.password")
     def signingSecretKey = findProperty("signing.secretKey")
     if (signingKeyId != null && signingKeyId != "") {
-        useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-        sign pom
+        signing {
+            useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
+            sign publishing.publications
+        }
     }
 }
 
@@ -131,61 +200,26 @@ afterEvaluate {
     if (runTasks.contains("publish")) {
         publishing {
             publications {
-                if (isJavaModule()) {
+                if (isGradlePluginModule()) {
+                    withType(MavenPublication).all { publication ->
+                        if (publication.name == "pluginMaven") {
+                            groupId ARTIFACT_GROUP
+                            artifactId ARTIFACT_NAME
+                            version findProperty("version")
+                            artifact(createJavaSourceJar())
+                            artifact(createJavaJavadocJar())
+                        } else if (publication.name.endsWith("PluginMarkerMaven")) {
+                            version findProperty("version")
+                        }
+                    }
+                } else if (isJavaModule()) {
                     "jar"(MavenPublication) {
                         groupId ARTIFACT_GROUP
                         artifactId ARTIFACT_NAME
                         version findProperty("version")
                         from components.java
-                        task sourceJar(type: Jar) {
-                            if (project.gradle.gradleVersion >= '8.0') {
-                                it.setArchiveClassifier('sources')
-                            } else {
-                                classifier = 'sources'
-                            }
-                            from sourceSets.main.allSource
-                        }
-                        task javadocJar(type: Jar) {
-                            if (project.gradle.gradleVersion >= '8.0') {
-                                it.setArchiveClassifier('javadoc')
-                            } else {
-                                classifier = 'javadoc'
-                            }
-                            from sourceSets.main.java
-                        }
-                        artifact(sourceJar)
-                        artifact(javadocJar)
-                        pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.jar
-                                }
-                            }
-                        }
+                        artifact(createJavaSourceJar())
+                        artifact(createJavaJavadocJar())
                     }
                 } else if (isAndroidModule()) {
                     release(MavenPublication) {
@@ -197,35 +231,6 @@ afterEvaluate {
                         Task sourceJar = createSourceJar("release-source")
                         artifact sourceJar
                         pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.release
-                                }
-                            }
                             withXml {
                                 addDependenciesToPom(asNode())
                             }
@@ -242,40 +247,14 @@ afterEvaluate {
                         Task sourceJarDev = createSourceJar("dev-sources")
                         artifact sourceJarDev
                         pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.devRelease
-                                }
-                            }
                             withXml {
                                 addDependenciesToPom(asNode())
                             }
                         }
                     }
+                }
+                withType(MavenPublication).all { publication ->
+                    configurePomMetadata(publication)
                 }
             }
             repositories {
@@ -292,6 +271,7 @@ afterEvaluate {
                 }
             }
         }
+        configureSigningForPublications()
     }
     tasks.withType(PublishToMavenRepository) { task ->
         task.doFirst {


### PR DESCRIPTION
## Summary

Fix Android Lynx library Gradle plugin publishing so the plugin IDs can be resolved through standard Gradle plugin marker artifacts.

## Root Cause

`LynxLibraryPlugin` disabled `java-gradle-plugin` automated publishing, so release artifacts only included `org.lynxsdk.lynx:lynx-library-plugin`. The Gradle plugin marker artifacts for `org.lynxsdk.library-settings` and `org.lynxsdk.library-build` were not published, which made `plugins { id(...) version ... }` fail to resolve from public Maven repositories.

## Changes

- Re-enable Gradle plugin marker publication for `LynxLibraryPlugin`.
- Keep the implementation artifact published as `org.lynxsdk.lynx:lynx-library-plugin`.
- Add shared POM metadata and signing configuration for all Maven publications, including generated plugin marker publications.
- Keep sources and javadoc artifacts attached to Java and Gradle plugin implementation publications.

## Validation

- Published `LynxLibraryPlugin` to a local Maven repository and verified both marker POMs are generated.
- Published with a temporary GPG key and verified marker POMs, implementation jar, module metadata, sources, and javadocs receive `.asc` signatures.
- Created a temporary Gradle consumer and verified both plugin IDs resolve through standard plugin marker lookup.
- Ran `lynx_library_plugin` unit tests in an isolated single-project Gradle invocation.

Note: a full multi-project `:LynxLibraryPlugin:test` run was blocked locally because `third_party/weak-node-api/node_modules/@lynx-js/weak-node-api` is missing in the workspace.
