### PR TITLE
[BugFix][Android] Publish Lynx library Gradle plugin markers

### DIFF
--- a/platform/android/lynx_library_plugin/build.gradle
+++ b/platform/android/lynx_library_plugin/build.gradle
@@ -16,18 +16,13 @@ dependencies {
 }
 
 gradlePlugin {
-    // Keep the release artifact owned by ../publish.gradle and avoid
-    // java-gradle-plugin's pluginMaven / *PluginMarkerMaven publications.
-    // This also means the plugin is not published with Gradle plugin markers
-    // for Maven-based `plugins { id(...) version ... }` resolution.
-    automatedPublishing = false
     plugins {
         lynxLibrarySettings {
-            id = 'org.lynxsdk.library-settings'
+            id = 'org.lynxsdk.lynx.library-settings'
             implementationClass = 'org.lynxsdk.library.LynxLibrarySettingsPlugin'
         }
         lynxLibraryBuild {
-            id = 'org.lynxsdk.library-build'
+            id = 'org.lynxsdk.lynx.library-build'
             implementationClass = 'org.lynxsdk.library.LynxLibraryBuildPlugin'
         }
     }

--- a/platform/android/publish.gradle
+++ b/platform/android/publish.gradle
@@ -7,10 +7,14 @@ apply plugin: 'signing'
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependency
 
-def aarPathList=""
-
 def baseVersion = findProperty("version")
-def devVersion = "${baseVersion}-dev"
+
+if (findProperty("ARTIFACT_GROUP") != null) {
+    project.group = ARTIFACT_GROUP
+}
+if (baseVersion != null) {
+    project.version = baseVersion
+}
 
 def getAARPath(buildPath, boolean isDev = false) {
     def filePattern
@@ -55,6 +59,11 @@ boolean isAndroidModule() {
     return result
 }
 
+boolean isGradlePluginModule() {
+    boolean result = project.plugins.hasPlugin('java-gradle-plugin')
+    return result
+}
+
 boolean hasDevFlavor() {
     if (!isAndroidModule() || !project.android.productFlavors.any { it.name == "dev" }) {
         return false
@@ -64,6 +73,36 @@ boolean hasDevFlavor() {
         taskName.contains("dev")
     }
     return isDevTaskExecuted
+}
+
+Task createJavaSourceJar() {
+    Task existingTask = project.tasks.findByName("sourceJar")
+    if (existingTask != null) {
+        return existingTask
+    }
+    return project.tasks.create("sourceJar", Jar) {
+        if (project.gradle.gradleVersion >= '8.0') {
+            it.setArchiveClassifier('sources')
+        } else {
+            classifier = 'sources'
+        }
+        from sourceSets.main.allSource
+    }
+}
+
+Task createJavaJavadocJar() {
+    Task existingTask = project.tasks.findByName("javadocJar")
+    if (existingTask != null) {
+        return existingTask
+    }
+    return project.tasks.create("javadocJar", Jar) {
+        if (project.gradle.gradleVersion >= '8.0') {
+            it.setArchiveClassifier('javadoc')
+        } else {
+            classifier = 'javadoc'
+        }
+        from sourceSets.main.java
+    }
 }
 
 Task createSourceJar(String baseName) {
@@ -89,13 +128,40 @@ Task createSourceJar(String baseName) {
     }
 }
 
-def configureSigning(pom) {
+def configurePomMetadata(publication) {
+    publication.pom {
+        name = publication.artifactId
+        url = REPOSITORY_URL
+        description = DESCRIPTION
+        licenses {
+            license {
+                name = 'The Apache License, version 2.0'
+                url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+            }
+        }
+        developers {
+            developer {
+                name = DEVELOPER_NAME
+                email = DEVELOPER_EMAIL
+            }
+        }
+        scm {
+            url = REPOSITORY_URL
+            connection = "scm:git:git://$REPOSITORY_SSH_URL"
+            developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
+        }
+    }
+}
+
+def configureSigningForPublications() {
     def signingKeyId = findProperty("signing.keyId")
     def signingPassword = findProperty("signing.password")
     def signingSecretKey = findProperty("signing.secretKey")
     if (signingKeyId != null && signingKeyId != "") {
-        useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-        sign pom
+        signing {
+            useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
+            sign publishing.publications
+        }
     }
 }
 
@@ -131,101 +197,37 @@ afterEvaluate {
     if (runTasks.contains("publish")) {
         publishing {
             publications {
-                if (isJavaModule()) {
+                if (isGradlePluginModule()) {
+                    withType(MavenPublication).all { publication ->
+                        if (publication.name == "pluginMaven") {
+                            groupId ARTIFACT_GROUP
+                            artifactId ARTIFACT_NAME
+                            version baseVersion
+                            artifact(createJavaSourceJar())
+                            artifact(createJavaJavadocJar())
+                        } else if (publication.name.endsWith("PluginMarkerMaven")) {
+                            version baseVersion
+                        }
+                    }
+                } else if (isJavaModule()) {
                     "jar"(MavenPublication) {
                         groupId ARTIFACT_GROUP
                         artifactId ARTIFACT_NAME
-                        version findProperty("version")
+                        version baseVersion
                         from components.java
-                        task sourceJar(type: Jar) {
-                            if (project.gradle.gradleVersion >= '8.0') {
-                                it.setArchiveClassifier('sources')
-                            } else {
-                                classifier = 'sources'
-                            }
-                            from sourceSets.main.allSource
-                        }
-                        task javadocJar(type: Jar) {
-                            if (project.gradle.gradleVersion >= '8.0') {
-                                it.setArchiveClassifier('javadoc')
-                            } else {
-                                classifier = 'javadoc'
-                            }
-                            from sourceSets.main.java
-                        }
-                        artifact(sourceJar)
-                        artifact(javadocJar)
-                        pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.jar
-                                }
-                            }
-                        }
+                        artifact(createJavaSourceJar())
+                        artifact(createJavaJavadocJar())
                     }
                 } else if (isAndroidModule()) {
                     release(MavenPublication) {
                         groupId ARTIFACT_GROUP
                         artifactId ARTIFACT_NAME
-                        version findProperty("version")
+                        version baseVersion
                         artifact(getAARPath("$project.buildDir/outputs/aar"))
                         // collect source jar and add it into the component artifact.
                         Task sourceJar = createSourceJar("release-source")
                         artifact sourceJar
                         pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.release
-                                }
-                            }
                             withXml {
                                 addDependenciesToPom(asNode())
                             }
@@ -236,46 +238,20 @@ afterEvaluate {
                     devRelease(MavenPublication) {
                         groupId ARTIFACT_GROUP
                         artifactId ARTIFACT_NAME
-                        version findProperty("version")
+                        version baseVersion
                         artifact(getAARPath("$project.buildDir/outputs/aar", true))
                         // collect source jar and add it into the component artifact.
                         Task sourceJarDev = createSourceJar("dev-sources")
                         artifact sourceJarDev
                         pom {
-                            name = artifactId
-                            url = REPOSITORY_URL
-                            description = DESCRIPTION
-                            licenses {
-                                license {
-                                    name = 'The Apache License, version 2.0'
-                                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                                }
-                            }
-                            developers {
-                                developer {
-                                    name = DEVELOPER_NAME
-                                    email = DEVELOPER_EMAIL
-                                }
-                            }
-                            scm {
-                                url = REPOSITORY_URL
-                                connection = "scm:git:git://$REPOSITORY_SSH_URL"
-                                developerConnection = "scm:git:ssh://$REPOSITORY_SSH_URL"
-                            }
-                            signing {
-                                def signingKeyId = findProperty("signing.keyId")
-                                def signingPassword = findProperty("signing.password")
-                                def signingSecretKey = findProperty("signing.secretKey")
-                                if (signingKeyId != null && signingKeyId != "") {
-                                    useInMemoryPgpKeys(signingKeyId, signingSecretKey, signingPassword)
-                                    sign publishing.publications.devRelease
-                                }
-                            }
                             withXml {
                                 addDependenciesToPom(asNode())
                             }
                         }
                     }
+                }
+                withType(MavenPublication).all { publication ->
+                    configurePomMetadata(publication)
                 }
             }
             repositories {
@@ -292,6 +268,7 @@ afterEvaluate {
                 }
             }
         }
+        configureSigningForPublications()
     }
     tasks.withType(PublishToMavenRepository) { task ->
         task.doFirst {


### PR DESCRIPTION
## Summary

Fix Android Lynx library Gradle plugin publishing so the plugin IDs can be resolved through standard Gradle plugin marker artifacts.

## Root Cause

`LynxLibraryPlugin` disabled `java-gradle-plugin` automated publishing, so release artifacts only included `org.lynxsdk.lynx:lynx-library-plugin`. The Gradle plugin marker artifacts were not published, which made `plugins { id(...) version ... }` fail to resolve from public Maven repositories.

## Changes

- Re-enable Gradle plugin marker publication for `LynxLibraryPlugin`.
- Move the public plugin IDs under the already used Lynx Maven namespace:
  - `org.lynxsdk.lynx.library-settings`
  - `org.lynxsdk.lynx.library-build`
- Keep the implementation artifact published as `org.lynxsdk.lynx:lynx-library-plugin`.
- Add shared POM metadata and signing configuration for all Maven publications, including generated plugin marker publications.
- Keep sources and javadoc artifacts attached to Java and Gradle plugin implementation publications.

## Validation

- Published `LynxLibraryPlugin` to a local Maven repository and verified both marker POMs are generated under `org/lynxsdk/lynx/library-*`.
- Published with a temporary GPG key and verified marker POMs receive `.asc` signatures.
- Created a temporary Gradle consumer and verified both new plugin IDs resolve through standard plugin marker lookup.
- Ran `lynx_library_plugin` unit tests in an isolated single-project Gradle invocation.
- Verified the Android snapshot publish path with the new plugin marker namespace.
