### PR TITLE
[BugFix][DevTool] Register global domains after late enablement

### DIFF
--- a/devtool/lynx_devtool/lynx_devtool_ng.cc
+++ b/devtool/lynx_devtool/lynx_devtool_ng.cc
@@ -55,16 +55,16 @@ static constexpr char kTypeSetFetchDebugInfo[] = "SetFetchDebugInfo";
 
 LynxDevToolNG::LynxDevToolNG(bool debuggable)
     : devtool_mediator_(std::make_shared<LynxDevToolMediator>()) {
-  static std::once_flag flag;
-  std::call_once(flag, [] {
-    auto& global_dispatcher =
-        lynx::devtool::AbstractDevTool::GetGlobalMessageDispatcherInstance();
+  auto& global_dispatcher =
+      lynx::devtool::AbstractDevTool::GetGlobalMessageDispatcherInstance();
+  const bool enabled = lynx::tasm::LynxEnv::GetInstance().IsDevToolEnabled() ||
+                       lynx::tasm::LynxEnv::GetInstance().IsDebugModeEnabled();
+  static std::once_flag global_domain_agents_flag;
+  RegisterGlobalDomainAgentsIfEnabled(global_dispatcher,
+                                      global_domain_agents_flag, enabled);
 
-    if (lynx::tasm::LynxEnv::GetInstance().IsDevToolEnabled() ||
-        lynx::tasm::LynxEnv::GetInstance().IsDebugModeEnabled()) {
-      RegisterGlobalDomainAgents(global_dispatcher);
-    }
-
+  static std::once_flag common_handlers_and_proxies_flag;
+  std::call_once(common_handlers_and_proxies_flag, [&global_dispatcher] {
     global_dispatcher.RegisterMessageHandler(
         kTypeGetStopAtEntry, std::make_unique<StopAtEntryHandler>());
     global_dispatcher.RegisterMessageHandler(
@@ -85,8 +85,7 @@ LynxDevToolNG::LynxDevToolNG(bool debuggable)
 #endif
 #endif
   });
-  if (lynx::tasm::LynxEnv::GetInstance().IsDevToolEnabled() ||
-      lynx::tasm::LynxEnv::GetInstance().IsDebugModeEnabled()) {
+  if (enabled) {
     RegisterInstanceDomainAgents();
   } else if (debuggable) {
     std::unordered_set<std::string> activated_domains =
@@ -98,6 +97,17 @@ LynxDevToolNG::LynxDevToolNG(bool debuggable)
 }
 
 LynxDevToolNG::~LynxDevToolNG() { devtool_mediator_->Destroy(); }
+
+void LynxDevToolNG::RegisterGlobalDomainAgentsIfEnabled(
+    DevToolMessageDispatcher& global_dispatcher,
+    std::once_flag& registration_flag, bool enabled) {
+  if (!enabled) {
+    return;
+  }
+  std::call_once(registration_flag, [&global_dispatcher] {
+    RegisterGlobalDomainAgents(global_dispatcher);
+  });
+}
 
 int32_t LynxDevToolNG::Attach(const std::string& url) {
   int32_t session_id = AbstractDevTool::Attach(url);

--- a/devtool/lynx_devtool/lynx_devtool_ng.h
+++ b/devtool/lynx_devtool/lynx_devtool_ng.h
@@ -6,6 +6,7 @@
 #define DEVTOOL_LYNX_DEVTOOL_LYNX_DEVTOOL_NG_H_
 
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "core/inspector/console_message_postman.h"
@@ -49,6 +50,9 @@ class LynxDevToolNG : public lynx::devtool::AbstractDevTool,
   std::shared_ptr<LynxDevToolMediator> devtool_mediator_;
 
  private:
+  static void RegisterGlobalDomainAgentsIfEnabled(
+      DevToolMessageDispatcher& global_dispatcher,
+      std::once_flag& registration_flag, bool enabled);
   static void RegisterGlobalDomainAgents(
       DevToolMessageDispatcher& global_dispatcher);
   static void RegisterGlobalDomainAgents(

--- a/devtool/lynx_devtool/lynx_devtool_ng_unittest.cc
+++ b/devtool/lynx_devtool/lynx_devtool_ng_unittest.cc
@@ -21,6 +21,13 @@ namespace lynx {
 namespace devtool {
 namespace testing {
 
+class TestGlobalMessageDispatcher : public DevToolMessageDispatcher {
+ public:
+  std::shared_ptr<MessageSender> GetSender() const override { return nullptr; }
+
+  void RemoveAgent(const std::string& name) { agent_map_.erase(name); }
+};
+
 class LynxDevToolNGTest : public ::testing::Test {
  public:
   LynxDevToolNGTest() {}
@@ -60,6 +67,24 @@ TEST_F(LynxDevToolNGTest, GlobalMessageHandler) {
   EXPECT_EQ(it->second, get_fetch_debug_info_handler);
   it = global_dispatcher.handler_map_.find(kTypeSetFetchDebugInfo);
   EXPECT_EQ(it->second, set_fetch_debug_info_handler);
+}
+
+TEST_F(LynxDevToolNGTest, RegisterGlobalDomainAgentsAfterDevToolIsEnabled) {
+  TestGlobalMessageDispatcher dispatcher;
+  std::once_flag registration_flag;
+
+  LynxDevToolNG::RegisterGlobalDomainAgentsIfEnabled(dispatcher,
+                                                     registration_flag, false);
+  EXPECT_EQ(dispatcher.GetAgent("Memory"), nullptr);
+
+  LynxDevToolNG::RegisterGlobalDomainAgentsIfEnabled(dispatcher,
+                                                     registration_flag, true);
+  ASSERT_NE(dispatcher.GetAgent("Memory"), nullptr);
+  dispatcher.RemoveAgent("Memory");
+
+  LynxDevToolNG::RegisterGlobalDomainAgentsIfEnabled(dispatcher,
+                                                     registration_flag, true);
+  EXPECT_EQ(dispatcher.GetAgent("Memory"), nullptr);
 }
 
 TEST_F(LynxDevToolNGTest, AttachSetsMediatorAttached) {


### PR DESCRIPTION
## Summary

- separate the process-wide once flag for common handlers and proxies from the global-domain registration flag
- consume the global-domain flag only after Lynx DevTool is enabled
- add a deterministic `false -> true -> true` regression test that verifies registration happens exactly once

Fixes #8108.

## Testing

- `devtool_agent_unittest_exec --gtest_filter=LynxDevToolNGTest.*` (4 tests passed)
- clang-format dry run
- `git diff --check`

## Checklist

- [x] Tests updated.
- [x] Documentation is not required for this internal lifecycle correction.

## AI assistance

Codex assisted with analysis and implementation. I reviewed the final behavior, test coverage, licensing, and public-repository content.