### PR TITLE
[BugFix][DevTool] Report unavailable background JavaScript runtime

### DIFF
--- a/devtool/lynx_devtool/js_debug/java_script_debugger_ng_unittest.cc
+++ b/devtool/lynx_devtool/js_debug/java_script_debugger_ng_unittest.cc
@@ -8,6 +8,7 @@
 #include "devtool/lynx_devtool/js_debug/java_script_debugger_ng.h"
 
 #include "devtool/base_devtool/native/test/message_sender_mock.h"
+#include "devtool/lynx_devtool/js_debug/js/inspector_java_script_debugger_impl.h"
 #include "devtool/testing/mock/lynx_devtool_mediator_mock.h"
 #include "devtool/testing/mock/lynx_devtool_ng_mock.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
@@ -67,6 +68,46 @@ TEST_F(JavaScriptDebuggerNGTest, SendResponse) {
   sleep(1);
   EXPECT_EQ(MockReceiver::GetInstance().received_message_.first, "");
   EXPECT_EQ(MockReceiver::GetInstance().received_message_.second, "");
+}
+
+TEST_F(JavaScriptDebuggerNGTest,
+       ReportsUnavailableBackgroundRuntimeForRequests) {
+  auto debugger = std::make_shared<InspectorJavaScriptDebuggerImpl>(nullptr, 1);
+  const std::vector<std::string> requests = {
+      R"({"id":1,"method":"Runtime.evaluate","params":{"expression":"Runtime.enable"}})",
+      R"({"id":2,"method":"Debugger.enable"})",
+      R"({"id":3,"method":"Profiler.start"})",
+      R"({"id":4,"method":"HeapProfiler.takeHeapSnapshot"})",
+  };
+
+  for (size_t index = 0; index < requests.size(); ++index) {
+    debugger->DispatchMessage(requests[index]);
+    ASSERT_FALSE(debugger->message_buf_.empty());
+
+    Json::Value response;
+    Json::Reader reader;
+    ASSERT_TRUE(reader.parse(debugger->message_buf_.front(), response, false));
+    debugger->message_buf_.pop();
+    EXPECT_EQ(response["id"].asInt(), static_cast<int>(index + 1));
+    EXPECT_EQ(response["error"]["code"].asInt(), -32000);
+    EXPECT_EQ(response["error"]["message"].asString(),
+              "Background JavaScript runtime is unavailable.");
+    EXPECT_FALSE(debugger->runtime_enable_needed_);
+  }
+
+  EXPECT_TRUE(debugger->message_buf_.empty());
+}
+
+TEST_F(JavaScriptDebuggerNGTest, LatchesExactRuntimeEnableWithoutResponding) {
+  auto debugger = std::make_shared<InspectorJavaScriptDebuggerImpl>(nullptr, 1);
+
+  debugger->DispatchMessage(R"({"method":"Debugger.enable"})");
+  EXPECT_TRUE(debugger->message_buf_.empty());
+  EXPECT_FALSE(debugger->runtime_enable_needed_);
+
+  debugger->DispatchMessage(R"({"id":5,"method":"Runtime.enable"})");
+  EXPECT_TRUE(debugger->runtime_enable_needed_);
+  EXPECT_TRUE(debugger->message_buf_.empty());
 }
 
 }  // namespace testing

--- a/devtool/lynx_devtool/js_debug/js/inspector_java_script_debugger_impl.cc
+++ b/devtool/lynx_devtool/js_debug/js/inspector_java_script_debugger_impl.cc
@@ -140,9 +140,26 @@ void InspectorJavaScriptDebuggerImpl::DispatchMessage(
   if (delegate_ != nullptr) {
     delegate_->DispatchMessageAsync(message, view_id_);
   } else {
+    Json::Value request;
+    Json::Reader reader;
+    if (!reader.parse(message, request, false) || !request.isObject() ||
+        !request["method"].isString()) {
+      return;
+    }
+
     // TODO(lqy): Delete after e2e can send Page.getResourceTree message.
-    if (message.find(kMethodRuntimeEnable) != std::string::npos) {
+    if (request["method"].asString() == kMethodRuntimeEnable) {
       SetRuntimeEnableNeeded(true);
+      return;
+    }
+
+    if (request.isMember("id")) {
+      Json::Value response(Json::objectValue);
+      response["id"] = request["id"];
+      response["error"]["code"] = kServerError;
+      response["error"]["message"] =
+          "Background JavaScript runtime is unavailable.";
+      SendResponse(response.toStyledString());
     }
   }
 }


### PR DESCRIPTION
## Summary

- parse the incoming CDP request before handling the no-delegate fallback
- preserve the exact `Runtime.enable` delayed-enable latch
- return a `-32000` error with the original request ID for other requests when the background JavaScript runtime is unavailable
- keep notifications response-free

Fixes #8110.

## Testing

- new tests fail against the previous implementation because `Runtime.evaluate` params containing `Runtime.enable` are mistaken for the enable method
- `js_debug_unittest_exec --gtest_filter=JavaScriptDebuggerNGTest.*` (3 tests passed)
- full `js_debug_unittest_exec` (35 tests passed)
- clang-format dry run
- `git diff --check`

## Checklist

- [x] Tests updated.
- [x] Documentation is not required for this protocol error correction.

## AI assistance

Codex assisted with analysis and implementation. I reviewed the final protocol behavior, compatibility, test coverage, licensing, and public-repository content.