### PR TITLE
[BugFix][DevTool] Report disabled UITree requests

### DIFF
--- a/devtool/lynx_devtool/agent/inspector_ui_executor.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.cc
@@ -27,6 +27,7 @@ InspectorUIExecutor::InspectorUIExecutor(
     const std::shared_ptr<LynxDevToolMediator>& devtool_mediator)
     : shell_(nullptr),
       devtool_mediator_wp_(devtool_mediator),
+      uitree_enabled_(false),
       uitree_use_compression_(false),
       uitree_compression_threshold_(10240) {}
 
@@ -292,10 +293,24 @@ void InspectorUIExecutor::UITree_Disable(
   sender->SendMessage("CDP", response);
 }
 
+bool InspectorUIExecutor::EnsureUITreeEnabled(
+    const std::shared_ptr<MessageSender>& sender,
+    const Json::Value& message) const {
+  if (uitree_enabled_) {
+    return true;
+  }
+  if (message.isMember("id")) {
+    sender->SendErrorResponse(message["id"].asInt64(), "UITree is not enabled");
+  }
+  return false;
+}
+
 void InspectorUIExecutor::GetLynxUITree(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {
-  if (!uitree_enabled_) return;
+  if (!EnsureUITreeEnabled(sender, message)) {
+    return;
+  }
   Json::Value response(Json::ValueType::objectValue);
   Json::Value content = Json::Value(Json::ValueType::objectValue);
   CHECK_NULL_AND_LOG_RETURN(devtool_platform_facade_,
@@ -333,7 +348,9 @@ void InspectorUIExecutor::GetLynxUITree(
 void InspectorUIExecutor::GetUIInfoForNode(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {
-  if (!uitree_enabled_) return;
+  if (!EnsureUITreeEnabled(sender, message)) {
+    return;
+  }
   Json::Value response(Json::ValueType::objectValue);
   Json::Value content = Json::Value(Json::ValueType::objectValue);
   Json::Value params = message["params"];
@@ -356,7 +373,9 @@ void InspectorUIExecutor::GetUIInfoForNode(
 void InspectorUIExecutor::SetUIStyle(
     const std::shared_ptr<lynx::devtool::MessageSender>& sender,
     const Json::Value& message) {
-  if (!uitree_enabled_) return;
+  if (!EnsureUITreeEnabled(sender, message)) {
+    return;
+  }
   Json::Value response(Json::ValueType::objectValue);
   Json::Value content(Json::ValueType::objectValue);
   Json::Value params = message["params"];

--- a/devtool/lynx_devtool/agent/inspector_ui_executor.h
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor.h
@@ -104,6 +104,9 @@ class InspectorUIExecutor
   std::weak_ptr<LynxDevToolMediator> devtool_mediator_wp_;
 
  private:
+  bool EnsureUITreeEnabled(const std::shared_ptr<MessageSender>& sender,
+                           const Json::Value& message) const;
+
   bool uitree_enabled_;
   bool uitree_use_compression_;
   int uitree_compression_threshold_;

--- a/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
+++ b/devtool/lynx_devtool/agent/inspector_ui_executor_unittest.cc
@@ -60,6 +60,36 @@ class InspectorUIExecutorTest : public ::testing::Test {
     devtool_mediator_->ui_task_runner_ = ui_thread_->GetTaskRunner();
   }
 
+  using UITreeMethod = void (devtool::InspectorUIExecutor::*)(
+      const std::shared_ptr<devtool::MessageSender>&, const Json::Value&);
+
+  void ExpectDisabledUITreeError(UITreeMethod method, int64_t id) {
+    devtool::MockReceiver::GetInstance().ResetAll();
+    Json::Value message;
+    message["id"] = id;
+
+    (ui_executor_.get()->*method)(message_sender_, message);
+
+    Json::Value response;
+    Json::Reader reader;
+    ASSERT_TRUE(reader.parse(
+        devtool::MockReceiver::GetInstance().received_message_.second, response,
+        false));
+    EXPECT_EQ(response["id"].asInt64(), id);
+    EXPECT_EQ(response["error"]["code"].asInt(), devtool::kInspectorErrorCode);
+    EXPECT_EQ(response["error"]["message"].asString(), "UITree is not enabled");
+  }
+
+  void ExpectDisabledUITreeNotificationIgnored(UITreeMethod method) {
+    devtool::MockReceiver::GetInstance().ResetAll();
+    Json::Value message;
+
+    (ui_executor_.get()->*method)(message_sender_, message);
+
+    EXPECT_TRUE(
+        devtool::MockReceiver::GetInstance().received_message_.second.empty());
+  }
+
  private:
   std::shared_ptr<devtool::InspectorUIExecutor> ui_executor_;
   std::shared_ptr<devtool::LynxDevToolMediator> devtool_mediator_;
@@ -67,6 +97,21 @@ class InspectorUIExecutorTest : public ::testing::Test {
   std::shared_ptr<testing::LynxDevToolNGMock> devtools_ng_;
   std::unique_ptr<fml::Thread> ui_thread_;
 };
+
+TEST_F(InspectorUIExecutorTest, DisabledUITreeMethodsReplyOnlyToRequests) {
+  ASSERT_FALSE(ui_executor_->uitree_enabled_);
+  const std::vector<UITreeMethod> methods = {
+      &devtool::InspectorUIExecutor::GetLynxUITree,
+      &devtool::InspectorUIExecutor::GetUIInfoForNode,
+      &devtool::InspectorUIExecutor::SetUIStyle,
+  };
+
+  int64_t id = 101;
+  for (auto method : methods) {
+    ExpectDisabledUITreeError(method, id++);
+    ExpectDisabledUITreeNotificationIgnored(method);
+  }
+}
 
 TEST_F(InspectorUIExecutorTest, PageReloadTest) {
   LOGI("InspectorUIExecutorTest PageReloadTest start");


### PR DESCRIPTION
## Summary

- initialize the UITree domain state explicitly as disabled
- return an immediate CDP error with the original request ID when UITree commands arrive before `UITree.enable`
- keep notifications response-free and preserve enabled-domain behavior
- cover `UITree.getLynxUITree`, `UITree.getUIInfoForNode`, and `UITree.setUIStyle` with a local regression test

Fixes #8164.

## Testing

- `devtool_agent_unittest_exec` (107/107)
- `git lynx check --changed --checkers=coding-style,cpplint,file-type,api-check`
- `git lynx check --checkers=commit-message`
- `git diff --check`

## Checklist

- [x] Tests updated.
- [x] No public API or documentation change is required.

## AI assistance

Codex assisted with analysis and implementation. I reviewed the final behavior, test coverage, licensing, and public-repository content.