### PR TITLE
[BugFix] Preserve replacement QuickJS inspector sessions

### DIFF
--- a/devtool/js_inspect/quickjs/quickjs_inspector_client_impl.cc
+++ b/devtool/js_inspect/quickjs/quickjs_inspector_client_impl.cc
@@ -34,8 +34,11 @@ int GenerateGroupId() {
 QJSChannelImplNG::QJSChannelImplNG(
     const std::unique_ptr<quickjs_inspector::QJSInspector> &inspector,
     const std::shared_ptr<QJSInspectorClientImpl> &client,
-    const std::string &group_id, int instance_id)
-    : client_wp_(client), instance_id_(instance_id), group_id_(group_id) {
+    const std::string &group_id, int instance_id, int64_t owner_runtime_id)
+    : client_wp_(client),
+      instance_id_(instance_id),
+      group_id_(group_id),
+      owner_runtime_id_(owner_runtime_id) {
   session_ = inspector->Connect(this, group_id_, instance_id_);
 }
 
@@ -163,24 +166,36 @@ std::string QJSInspectorClientImpl::InitInspector(LEPUSContext *context,
 }
 
 void QJSInspectorClientImpl::ConnectSession(int instance_id,
-                                            const std::string &group_id) {
-  if (channels_.find(instance_id) == channels_.end()) {
-    auto it = inspectors_.find(group_id);
-    if (it != inspectors_.end()) {
-      channels_.emplace(instance_id,
-                        std::make_shared<QJSChannelImplNG>(
-                            it->second,
-                            std::static_pointer_cast<QJSInspectorClientImpl>(
-                                shared_from_this()),
-                            group_id, instance_id));
-    }
+                                            const std::string &group_id,
+                                            int64_t owner_runtime_id) {
+  auto inspector = inspectors_.find(group_id);
+  if (inspector == inspectors_.end()) {
+    return;
   }
+
+  auto channel = channels_.find(instance_id);
+  if (channel != channels_.end()) {
+    if (channel->second->OwnerRuntimeId() == owner_runtime_id &&
+        channel->second->GroupId() == group_id) {
+      return;
+    }
+    channels_.erase(channel);
+  }
+
+  channels_.emplace(
+      instance_id,
+      std::make_shared<QJSChannelImplNG>(
+          inspector->second,
+          std::static_pointer_cast<QJSInspectorClientImpl>(shared_from_this()),
+          group_id, instance_id, owner_runtime_id));
 }
 
-void QJSInspectorClientImpl::DisconnectSession(int instance_id) {
+void QJSInspectorClientImpl::DisconnectSession(int instance_id,
+                                               int64_t owner_runtime_id) {
   auto it = channels_.find(instance_id);
-  if (it != channels_.end()) {
-    auto &group_id = it->second->GroupId();
+  if (it != channels_.end() &&
+      it->second->OwnerRuntimeId() == owner_runtime_id) {
+    std::string group_id = it->second->GroupId();
     channels_.erase(it);
     auto sp = delegate_wp_.lock();
     if (sp != nullptr) {

--- a/devtool/js_inspect/quickjs/quickjs_inspector_client_impl.h
+++ b/devtool/js_inspect/quickjs/quickjs_inspector_client_impl.h
@@ -5,6 +5,7 @@
 #ifndef DEVTOOL_JS_INSPECT_QUICKJS_QUICKJS_INSPECTOR_CLIENT_IMPL_H_
 #define DEVTOOL_JS_INSPECT_QUICKJS_QUICKJS_INSPECTOR_CLIENT_IMPL_H_
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -23,10 +24,11 @@ class QJSChannelImplNG : public quickjs_inspector::QJSInspector::QJSChannel {
   QJSChannelImplNG(
       const std::unique_ptr<quickjs_inspector::QJSInspector>& inspector,
       const std::shared_ptr<QJSInspectorClientImpl>& client,
-      const std::string& group_id, int instance_id);
+      const std::string& group_id, int instance_id, int64_t owner_runtime_id);
   ~QJSChannelImplNG() override = default;
 
   const std::string& GroupId() { return group_id_; }
+  int64_t OwnerRuntimeId() const { return owner_runtime_id_; }
 
   void SendResponse(int call_id, const std::string& message) override;
   void SendNotification(const std::string& message) override;
@@ -46,6 +48,7 @@ class QJSChannelImplNG : public quickjs_inspector::QJSInspector::QJSChannel {
 
   int instance_id_;
   std::string group_id_;
+  int64_t owner_runtime_id_;
 };
 
 class QJSInspectorClientImpl : public quickjs_inspector::QJSInspectorClient,
@@ -70,8 +73,9 @@ class QJSInspectorClientImpl : public quickjs_inspector::QJSInspectorClient,
 
   std::string InitInspector(LEPUSContext* context, const std::string& group_id,
                             const std::string& name = "");
-  void ConnectSession(int instance_id, const std::string& group_id);
-  void DisconnectSession(int instance_id);
+  void ConnectSession(int instance_id, const std::string& group_id,
+                      int64_t owner_runtime_id);
+  void DisconnectSession(int instance_id, int64_t owner_runtime_id);
   // Only be called when preparing to destroy LEPUSContext. The param is the
   // group_id after mapping.
   void DestroyInspector(const std::string& group_id);

--- a/devtool/js_inspect/quickjs/quickjs_inspector_client_impl_unittest.cc
+++ b/devtool/js_inspect/quickjs/quickjs_inspector_client_impl_unittest.cc
@@ -1,0 +1,89 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#define private public
+#include "devtool/js_inspect/quickjs/quickjs_inspector_client_impl.h"
+#undef private
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace lynx {
+namespace devtool {
+namespace testing {
+namespace {
+
+class RecordingSession final : public quickjs_inspector::QJSInspectorSession {
+ public:
+  explicit RecordingSession(std::vector<std::string>* messages)
+      : messages_(messages) {}
+
+  void DispatchProtocolMessage(const std::string& message) override {
+    messages_->push_back(message);
+  }
+  void SchedulePauseOnNextStatement(const std::string& reason) override {}
+  void CancelPauseOnNextStatement() override {}
+  void SetEnableConsoleInspect(bool enable) override {}
+
+ private:
+  std::vector<std::string>* messages_;
+};
+
+class RecordingInspector final : public quickjs_inspector::QJSInspector {
+ public:
+  explicit RecordingInspector(
+      std::vector<std::vector<std::string>*> session_messages)
+      : session_messages_(std::move(session_messages)) {}
+
+  std::unique_ptr<quickjs_inspector::QJSInspectorSession> Connect(
+      QJSChannel* channel, const std::string& group_id,
+      int32_t session_id) override {
+    return std::make_unique<RecordingSession>(
+        session_messages_.at(connection_count_++));
+  }
+
+  size_t ConnectionCount() const { return connection_count_; }
+
+ private:
+  std::vector<std::vector<std::string>*> session_messages_;
+  size_t connection_count_{0};
+};
+
+TEST(QJSInspectorClientImplTest,
+     StaleRuntimeCannotDisconnectReplacementSharedGroupSession) {
+  constexpr int kViewId = 7;
+  constexpr int64_t kOldRuntimeId = 101;
+  constexpr int64_t kNewRuntimeId = 102;
+  constexpr char kSharedGroupId[] = "shared-group";
+  constexpr char kMessage[] = R"({"id":1,"method":"Runtime.evaluate"})";
+
+  std::vector<std::string> old_messages;
+  std::vector<std::string> new_messages;
+  auto inspector = std::make_unique<RecordingInspector>(
+      std::vector{&old_messages, &new_messages});
+  auto* inspector_ptr = inspector.get();
+  auto client = std::make_shared<QJSInspectorClientImpl>();
+  client->inspectors_.emplace(kSharedGroupId, std::move(inspector));
+
+  client->ConnectSession(kViewId, kSharedGroupId, kOldRuntimeId);
+  client->ConnectSession(kViewId, kSharedGroupId, kNewRuntimeId);
+  client->ConnectSession(kViewId, kSharedGroupId, kNewRuntimeId);
+  client->DisconnectSession(kViewId, kOldRuntimeId);
+  client->DispatchMessage(kMessage, kViewId);
+
+  EXPECT_EQ(inspector_ptr->ConnectionCount(), 2u);
+  EXPECT_TRUE(old_messages.empty());
+  EXPECT_EQ(new_messages, std::vector<std::string>{kMessage});
+
+  client->DisconnectSession(kViewId, kNewRuntimeId);
+}
+
+}  // namespace
+}  // namespace testing
+}  // namespace devtool
+}  // namespace lynx

--- a/devtool/lynx_devtool/js_debug/BUILD.gn
+++ b/devtool/lynx_devtool/js_debug/BUILD.gn
@@ -208,6 +208,7 @@ unittest_set("js_debug_testset") {
     "../:devtool_common_config",
   ]
   sources = [
+    "../../js_inspect/quickjs/quickjs_inspector_client_impl_unittest.cc",
     "helper/js_debug_helper_unittest.cc",
     "inspector_client_delegate_impl_unittest.cc",
     "java_script_debugger_ng_unittest.cc",

--- a/devtool/lynx_devtool/js_debug/js/quickjs/manager/quickjs_inspector_manager_impl.cc
+++ b/devtool/lynx_devtool/js_debug/js/quickjs/manager/quickjs_inspector_manager_impl.cc
@@ -34,7 +34,8 @@ void QuickjsInspectorManagerImpl::InitInspector(
   inspector_group_id_ = inspector_client_->InitInspector(
       quickjs_runtime->getJSContext(), group_id_,
       devtool::kTargetJSPrefix + group_id_);
-  inspector_client_->ConnectSession(instance_id_, inspector_group_id_);
+  inspector_client_->ConnectSession(instance_id_, inspector_group_id_,
+                                    runtime_id_);
 
   static thread_local std::once_flag set_release_ctx_callback;
   if (group_id_ != devtool::kSingleGroupStr) {
@@ -62,7 +63,7 @@ void QuickjsInspectorManagerImpl::DestroyInspector() {
     sp->OnRuntimeDestroyed(runtime_id_);
   }
   if (inspector_client_ != nullptr) {
-    inspector_client_->DisconnectSession(instance_id_);
+    inspector_client_->DisconnectSession(instance_id_, runtime_id_);
     // Only call DestroyInspector() when using single group, because the
     // LEPUSContext will be destroyed.
     if (group_id_ == devtool::kSingleGroupStr) {


### PR DESCRIPTION
## Summary

- associate each QuickJS inspector channel with its owning runtime ID
- replace the old channel before connecting a new runtime for the same Lynx DevTool view
- ignore stale disconnects from a runtime that no longer owns the channel
- add a deterministic shared-group replacement regression test

Fixes #8172.

## Testing

- focused QuickJS inspector regression test
- full `js_debug_unittest_exec` suite (34 tests)
- `clang-format --dry-run --Werror`
- `gn format --dry-run`
- `git diff --check`
