### PR TITLE
[BugFix][Harmony] Add OHPM author contact metadata

### DIFF
--- a/base/platform/harmony/oh-package.json5
+++ b/base/platform/harmony/oh-package.json5
@@ -9,6 +9,6 @@
     "liblynxbase.so": "file:./src/cpp/types/liblynxbase",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "description": "Lynx Base"
 }

--- a/platform/harmony/lynx_devtool/oh-package.json5
+++ b/platform/harmony/lynx_devtool/oh-package.json5
@@ -3,7 +3,7 @@
   "version": "@param:dependencies.lynx_version",
   "description": "Lynx DevTool",
   "main": "src/main/ets/Index.ets",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "license": "Apache-2.0",
   "dependencies": {
     "@lynx/lynx": "@param:dependencies.lynx_version",

--- a/platform/harmony/lynx_harmony/oh-package.json5
+++ b/platform/harmony/lynx_harmony/oh-package.json5
@@ -10,6 +10,6 @@
     "@lynx/lynx_base": "@param:dependencies.lynx_version",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "description": "A Powerful Cross-Platform Framework that builds native Apps with Web technologies"
 }

--- a/platform/harmony/lynx_services/lynx_devtool_service/oh-package.json5
+++ b/platform/harmony/lynx_services/lynx_devtool_service/oh-package.json5
@@ -8,5 +8,5 @@
     "@lynx/lynx": "@param:dependencies.lynx_version",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx"
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)"
 }

--- a/platform/harmony/lynx_services/lynx_http_service/oh-package.json5
+++ b/platform/harmony/lynx_services/lynx_http_service/oh-package.json5
@@ -8,5 +8,5 @@
     "@lynx/lynx": "@param:dependencies.lynx_version",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx"
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)"
 }

--- a/platform/harmony/lynx_services/lynx_image_service/oh-package.json5
+++ b/platform/harmony/lynx_services/lynx_image_service/oh-package.json5
@@ -9,5 +9,5 @@
     "@ohos/imageknifepro": "1.0.9",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx"
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)"
 }

--- a/platform/harmony/lynx_services/lynx_log_service/oh-package.json5
+++ b/platform/harmony/lynx_services/lynx_log_service/oh-package.json5
@@ -8,5 +8,5 @@
     "@lynx/lynx_base": "@param:dependencies.lynx_version",
   },
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx"
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)"
 }

--- a/platform/harmony/lynx_xelement/markdown/oh-package.json5
+++ b/platform/harmony/lynx_xelement/markdown/oh-package.json5
@@ -5,7 +5,7 @@
   "main": "Index.ets",
   "license": "Apache-2.0",
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "dependencies": {
     "@lynx/lynx": "@param:dependencies.lynx_version",
     "liblynx_xelement_markdown.so": "file:./src/main/cpp/types/liblynx_xelement_markdown",

--- a/platform/harmony/lynx_xelement/svg/oh-package.json5
+++ b/platform/harmony/lynx_xelement/svg/oh-package.json5
@@ -5,7 +5,7 @@
   "main": "Index.ets",
   "license": "Apache-2.0",
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "dependencies": {
     "@lynx/lynx_base": "@param:dependencies.lynx_version",
     "@lynx/lynx": "@param:dependencies.lynx_version",

--- a/platform/harmony/lynx_xelement/webview/oh-package.json5
+++ b/platform/harmony/lynx_xelement/webview/oh-package.json5
@@ -5,7 +5,7 @@
   "main": "Index.ets",
   "license": "Apache-2.0",
   "repository": "https://github.com/lynx-family/lynx",
-  "author": "lynx",
+  "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "dependencies": {
     "@lynx/lynx_base": "@param:dependencies.lynx_version",
     "@lynx/lynx": "@param:dependencies.lynx_version",


### PR DESCRIPTION
## Summary

- add an email address and repository URL to the author metadata of all Harmony HAR packages published by the release workflow
- keep workspace and application-only package manifests unchanged

## Motivation

The OHPM registry rejects the Harmony SDK publish request with HTTP 400 because the package author metadata does not include an author URL or email address.

## Testing

- parsed `explorer/harmony/build-profile.json5` and all 10 published HAR package manifests with the repository JSON5 environment
- `git diff --check`