### PR TITLE
[BugFix][Harmony] Add OHPM repository metadata for Lynx DevTool

### DIFF
--- a/platform/harmony/lynx_devtool/oh-package.json5
+++ b/platform/harmony/lynx_devtool/oh-package.json5
@@ -5,6 +5,7 @@
   "main": "src/main/ets/Index.ets",
   "author": "Lynx Authors <lynx.authors@gmail.com> (https://github.com/lynx-family/lynx)",
   "license": "Apache-2.0",
+  "repository": "https://github.com/lynx-family/lynx",
   "dependencies": {
     "@lynx/lynx": "@param:dependencies.lynx_version",
     "@lynx/lynx_base": "@param:dependencies.lynx_version",


### PR DESCRIPTION
## Summary

- Add the required `repository` metadata to the `@lynx/lynx_devtool` OHPM package.
- Align Lynx DevTool with the other Harmony OHPM packages so publishing passes repository URL validation.
- Fix the `Publish Harmony SDK` failure in https://github.com/lynx-family/lynx/actions/runs/31338637513/job/93308557953.

## Testing

- Parsed `platform/harmony/lynx_devtool/oh-package.json5` and validated the repository URL scheme with Node.js.
- Ran `git diff --check`.

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).