### PR TITLE
[Infra] Expose type package availability in config docs

### DIFF
--- a/core/template_bundle/template_codec/binary_decoder/lynx_config.yml
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_config.yml
@@ -858,6 +858,7 @@ enableEventThrough:
   valueType: bool
   author: rAY-ooo
   since: '1.4'
+  typePackageSince: '4.1.0'
   supportPlatform:
     - Android
     - HarmonyOS

--- a/js_libraries/type-config/types/config.d.ts
+++ b/js_libraries/type-config/types/config.d.ts
@@ -124,6 +124,8 @@ export interface Config {
    * @Harmony
    * @iOS
    *
+   * Type package availability: `@lynx-js/type-config` 4.1.0 or later
+   *
    * Since: LynxSDK 3.2
    *
    * @defaultValue false

--- a/tools/config/config_def.py
+++ b/tools/config/config_def.py
@@ -36,6 +36,7 @@ class Config:
         bind_member_to: str,
         read_settings: bool,
         read_native: bool,
+        type_package_since: str,
         export: bool,
     ):
         self.name = name
@@ -127,6 +128,7 @@ class Config:
         self.codeGen = code_gen if code_gen is not None else ["ALL"]
         self.read_settings = read_settings
         self.read_native = read_native
+        self.type_package_since = type_package_since
         self.export = export
 
     def is_invalid(self):

--- a/tools/config/config_def_test.py
+++ b/tools/config/config_def_test.py
@@ -27,6 +27,7 @@ class ConfigPlatformTagsTest(unittest.TestCase):
             bind_member_to="",
             read_settings=False,
             read_native=False,
+            type_package_since="",
             export=True,
         )
 

--- a/tools/config/gen_config.py
+++ b/tools/config/gen_config.py
@@ -47,6 +47,7 @@ def _construct_config_object(key: str, value: dict) -> Config:
         bind_member_to=value.get("bindMemberTo", ""),
         read_settings=value.get("readSettings", False),
         read_native=value.get("readNative", False),
+        type_package_since=value.get("typePackageSince", ""),
         export=export_to_open_source,
     )
 

--- a/tools/config/templates/config_types.tmpl
+++ b/tools/config/templates/config_types.tmpl
@@ -21,6 +21,10 @@ export interface Config {
    * {{ tag }}
    {% endfor %}
    {% endif %}
+   {% if export and config.type_package_since %}
+   *
+   * Type package availability: `@lynx-js/type-config` {{ config.type_package_since }} or later
+   {% endif %}
    {% if config.since %}
    *
    * Since: LynxSDK {{ config.since }}


### PR DESCRIPTION
## Summary

- add `typePackageSince` metadata to exported Lynx config definitions
- render the package-version floor in generated `@lynx-js/type-config` TSDoc
- mark `enableEventThrough` as available from `@lynx-js/type-config` 4.1.0

## Why

The generated website API reference needs to expose the npm type-package floor independently of the LynxSDK runtime floor. Keeping this in `lynx_config.yml` and the config generator prevents the generated reference from drifting.

## Validation

- `python3 tools/config/check_and_run.py --all`
- `python3 -m unittest discover -s tools/config -p "*_test.py"`
- `@lynx-js/type-config` tests: 3 files and 7 tests passed with no type errors in the synchronized internal checkout
- `git lynx check` passed for the identical synchronized patch