### PR TITLE
[BugFix][Android] Align input layout with locale line height

### DIFF
--- a/platform/android/lynx_xelement/lynx_xelement_input/src/main/java/com/lynx/xelement/input/LynxInputUtils.kt
+++ b/platform/android/lynx_xelement/lynx_xelement_input/src/main/java/com/lynx/xelement/input/LynxInputUtils.kt
@@ -3,6 +3,7 @@
 // LICENSE file in the root directory of this source tree.
 package com.lynx.xelement.input
 
+import android.graphics.Paint
 import android.os.Build
 import android.text.Layout
 import android.text.StaticLayout
@@ -14,8 +15,57 @@ import android.view.View
 import android.widget.EditText
 import com.lynx.tasm.behavior.shadow.text.StaticLayoutCompat
 import com.lynx.tasm.behavior.shadow.text.TextAttributes
+import java.lang.reflect.Method
 
 class LynxInputUtils() {
+    private data class LocaleLineHeightMethods(
+        val isLocalePreferredLineHeightForMinimumUsed: Method,
+        val getFontMetricsForLocale: Method,
+        val setMinimumFontMetrics: Method
+    )
+
+    companion object {
+        private const val API_LEVEL_35 = 35
+
+        // Resolve these public API 35 methods lazily to keep compileSdkVersion at 33.
+        private val localeLineHeightMethods by lazy {
+            if (Build.VERSION.SDK_INT < API_LEVEL_35) {
+                null
+            } else {
+                runCatching {
+                    LocaleLineHeightMethods(
+                        EditText::class.java.getMethod(
+                            "isLocalePreferredLineHeightForMinimumUsed"
+                        ),
+                        Paint::class.java.getMethod(
+                            "getFontMetricsForLocale",
+                            Paint.FontMetrics::class.java
+                        ),
+                        StaticLayout.Builder::class.java.getMethod(
+                            "setMinimumFontMetrics",
+                            Paint.FontMetrics::class.java
+                        )
+                    )
+                }.getOrNull()
+            }
+        }
+    }
+
+    private fun setLocalePreferredMinimumFontMetrics(
+        builder: StaticLayout.Builder,
+        editText: EditText
+    ) {
+        val methods = localeLineHeightMethods ?: return
+        runCatching {
+            if (methods.isLocalePreferredLineHeightForMinimumUsed.invoke(editText) != true) {
+                return@runCatching
+            }
+            val minimumFontMetrics = Paint.FontMetrics()
+            methods.getFontMetricsForLocale.invoke(editText.paint, minimumFontMetrics)
+            methods.setMinimumFontMetrics.invoke(builder, minimumFontMetrics)
+        }
+    }
+
     fun getLayoutInEditText(charSequence: CharSequence,
                             editText: EditText,
                             measuredWidth: Int,
@@ -47,6 +97,9 @@ class LynxInputUtils() {
                 .setIncludePad(editText.includeFontPadding)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                 builder.setUseLineSpacingFromFallbacks(true)
+            }
+            if (Build.VERSION.SDK_INT >= API_LEVEL_35) {
+                setLocalePreferredMinimumFontMetrics(builder, editText)
             }
             return builder.build()
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {


### PR DESCRIPTION
## Summary
- Mirror `EditText` locale-preferred minimum font metrics in Lynx's `StaticLayout` measurement on API 35+.
- Resolve the public API 35 methods lazily through cached reflection, keeping both Android roots on `compileSdkVersion 33`.
- Leave textarea scroll behavior unchanged.

## Root cause
For apps targeting SDK 35+ in a CJK locale, Android enables locale-preferred minimum font metrics for `TextView`/`EditText`. Lynx's separate `StaticLayout` used for auto-height measurement did not receive the same minimum metrics, so the measured height was smaller than the native editor content and the first line became clipped after repeated Enter presses.

## Compatibility
- `compileSdkVersion` remains 33.
- API levels below 35 do not perform reflection.
- API 35+ resolves and caches the public framework methods; if a method is unavailable, measurement safely retains the previous behavior.
- No scroll changes are included.

Fixes #8485

## Validation
- `./gradlew :LynxXElement:Input:compileDebugKotlin --no-daemon` with compileSdk 33 and the repository's default Android tooling.
- `./gradlew :LynxExplorer:assembleWithoutSparklingNoasanDebug --no-daemon` with compileSdk 33 and the default AAPT2 (533 tasks, successful).
- APK metadata: `compileSdkVersion=33`, `targetSdkVersion=36`, `arm64-v8a`.
- Pixel 10 Pro, Android 16, app locale `ko-KR`: followed the issue video's exact input sequence (`gg`, seven Enter + `mm`, final Enter). The 9-line textarea grew from 62 px to 550 px and all lines remained visible.