### PR TITLE
[grid-lanes M0] Add differential conformance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,15 @@ jobs:
       - name: Run Linux Node Lynx Tests
         run: |
           tools/env.sh pnpm --filter @lynx-js/node-lynx run test
+      - name: Install Grid Lanes Browser Oracles
+        run: |
+          tools/env.sh pnpm --filter @lynx-js/grid-lanes-conformance run install:browsers
+      - name: Run Grid Lanes Conformance
+        run: |
+          tools/env.sh pnpm --filter @lynx-js/grid-lanes-conformance run build
+          tools/env.sh pnpm --filter @lynx-js/grid-lanes-conformance run test:unit
+          tools/env.sh pnpm --filter @lynx-js/grid-lanes-conformance run test:calibration
+          tools/env.sh pnpm --filter @lynx-js/grid-lanes-conformance run test
 
   linux-sdk-amd64-build:
     runs-on: lynx-ubuntu-22.04-large

--- a/.rtf/native-ut-lynx.template
+++ b/.rtf/native-ut-lynx.template
@@ -28,6 +28,20 @@ builder({
         "output": "out/Default_test_enable_trace",
         "type": "gn",
     },
+
+    "builder_for_starlight_geometry" :{
+        "args": [
+            "enable_lepusng_worklet=true",
+            "enable_unittests=true",
+            "enable_inspector=true",
+            "enable_napi_binding=true",
+            "enable_coverage=true",
+            "use_flutter_cxx=false",
+            "is_debug=false",
+        ],
+        "output": "out/Default",
+        "type": "gn",
+    },
 })
 
 coverage({
@@ -237,6 +251,13 @@ targets({
         "owners":["ZhaoSongGOO"],
         "coverage": True,
         "enable_parallel":True,
+    },
+    "starlight_geometry_unittest_exec":{
+        "cwd": ".",
+        "owners":["ZhaoSongGOO"],
+        "coverage": True,
+        "enable_parallel":True,
+        "builder":'builder_for_starlight_geometry',
     },
     "runtime_common_unittests_exec":{
         "cwd": ".",

--- a/core/renderer/starlight/BUILD.gn
+++ b/core/renderer/starlight/BUILD.gn
@@ -158,7 +158,25 @@ unittest_set("starlight_testset") {
   ]
 }
 
+unittest_set("starlight_geometry_testset") {
+  public_configs = [ "../../:lynx_public_config" ]
+  sources = [
+    "../../services/replay/layout_tree_testbench.cc",
+    "layout/grid_geometry_unittest.cc",
+  ]
+  public_deps = [
+    ":starlight",
+    "../../../third_party/rapidjson:rapidjson",
+    "../dom:dom",
+  ]
+}
+
 unittest_exec("starlight_unittest_exec") {
   sources = []
   deps = [ ":starlight_testset" ]
+}
+
+unittest_exec("starlight_geometry_unittest_exec") {
+  sources = []
+  deps = [ ":starlight_geometry_testset" ]
 }

--- a/core/renderer/starlight/layout/grid_geometry_unittest.cc
+++ b/core/renderer/starlight/layout/grid_geometry_unittest.cc
@@ -1,0 +1,146 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "core/renderer/css/computed_css_style.h"
+#include "core/renderer/starlight/layout/layout_object.h"
+#include "core/services/replay/layout_tree_testbench.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace lynx {
+namespace starlight {
+namespace {
+
+struct MeasureContext {
+  FloatSize size;
+  int count = 0;
+};
+
+FloatSize CountingMeasure(void* context, const Constraints&, bool) {
+  auto* measure_context = static_cast<MeasureContext*>(context);
+  ++measure_context->count;
+  return measure_context->size;
+}
+
+class GridGeometryTest : public ::testing::Test {
+ protected:
+  void SetUp() override { configs_.SetQuirksMode(base::Version(3, 1)); }
+
+  ComputedCSSStyle* CreateStyle() {
+    styles_.push_back(std::make_unique<ComputedCSSStyle>(1.f, 1.f));
+    return styles_.back().get();
+  }
+
+  LayoutObject* CreateNode(ComputedCSSStyle* style) {
+    nodes_.push_back(std::make_unique<LayoutObject>(
+        configs_, style->GetLayoutComputedStyle()));
+    return nodes_.back().get();
+  }
+
+  LayoutObject* CreateMeasuredItem(float width, float height,
+                                   MeasureContext* context) {
+    auto* style = CreateStyle();
+    style->GetLayoutComputedStyle()->SetWidth(NLength::MakeUnitNLength(width));
+    style->GetLayoutComputedStyle()->SetHeight(
+        NLength::MakeUnitNLength(height));
+    auto* node = CreateNode(style);
+    context->size = FloatSize(width, height);
+    node->SetContext(context);
+    node->SetSLMeasureFunc(CountingMeasure);
+    return node;
+  }
+
+  LayoutObject* CreateGrid(float width, float height,
+                           const std::vector<float>& columns,
+                           const std::vector<float>& rows, float column_gap = 0,
+                           float row_gap = 0) {
+    auto* style = CreateStyle();
+    auto* layout_style = style->GetLayoutComputedStyle();
+    layout_style->SetDisplay(DisplayType::kGrid);
+    layout_style->SetWidth(NLength::MakeUnitNLength(width));
+    layout_style->SetHeight(NLength::MakeUnitNLength(height));
+    layout_style->SetColumnGap(NLength::MakeUnitNLength(column_gap));
+    layout_style->SetRowGap(NLength::MakeUnitNLength(row_gap));
+    for (float column : columns) {
+      layout_style->grid_data_.Access()
+          ->grid_template_columns_min_track_sizing_function_.push_back(
+              NLength::MakeUnitNLength(column));
+      layout_style->grid_data_.Access()
+          ->grid_template_columns_max_track_sizing_function_.push_back(
+              NLength::MakeUnitNLength(column));
+    }
+    for (float row : rows) {
+      layout_style->grid_data_.Access()
+          ->grid_template_rows_min_track_sizing_function_.push_back(
+              NLength::MakeUnitNLength(row));
+      layout_style->grid_data_.Access()
+          ->grid_template_rows_max_track_sizing_function_.push_back(
+              NLength::MakeUnitNLength(row));
+    }
+    return CreateNode(style);
+  }
+
+  std::string Layout(LayoutObject* root) {
+    root->ReLayout();
+    return tasm::replay::LayoutTreeTestBench::GetLayoutTree(root);
+  }
+
+ private:
+  LayoutConfigs configs_;
+  std::vector<std::unique_ptr<ComputedCSSStyle>> styles_;
+  std::vector<std::unique_ptr<LayoutObject>> nodes_;
+};
+
+TEST_F(GridGeometryTest, FixedTracks) {
+  MeasureContext first;
+  MeasureContext second;
+  auto* root = CreateGrid(220, 80, {100, 100}, {80}, 20);
+  root->AppendChild(CreateMeasuredItem(60, 40, &first));
+  root->AppendChild(CreateMeasuredItem(80, 50, &second));
+
+  EXPECT_EQ(
+      R"({"width":220.0,"height":80.0,"offset_top":0.0,"offset_left":0.0,"content":[0.0,0.0,220.0,0.0,220.0,80.0,0.0,80.0],"padding":[0.0,0.0,220.0,0.0,220.0,80.0,0.0,80.0],"border":[0.0,0.0,220.0,0.0,220.0,80.0,0.0,80.0],"margin":[0.0,0.0,220.0,0.0,220.0,80.0,0.0,80.0],"children":[{"width":60.0,"height":40.0,"offset_top":0.0,"offset_left":0.0,"content":[0.0,0.0,60.0,0.0,60.0,40.0,0.0,40.0],"padding":[0.0,0.0,60.0,0.0,60.0,40.0,0.0,40.0],"border":[0.0,0.0,60.0,0.0,60.0,40.0,0.0,40.0],"margin":[0.0,0.0,60.0,0.0,60.0,40.0,0.0,40.0]},{"width":80.0,"height":50.0,"offset_top":0.0,"offset_left":120.0,"content":[120.0,0.0,200.0,0.0,200.0,50.0,120.0,50.0],"padding":[120.0,0.0,200.0,0.0,200.0,50.0,120.0,50.0],"border":[120.0,0.0,200.0,0.0,200.0,50.0,120.0,50.0],"margin":[120.0,0.0,200.0,0.0,200.0,50.0,120.0,50.0]}]})",
+      Layout(root));
+  EXPECT_EQ(1, first.count);
+  EXPECT_EQ(1, second.count);
+}
+
+TEST_F(GridGeometryTest, SpanningItem) {
+  MeasureContext wide;
+  MeasureContext last;
+  auto* root = CreateGrid(230, 100, {70, 70, 70}, {40, 50}, 10, 10);
+  auto* wide_item = CreateMeasuredItem(150, 40, &wide);
+  wide_item->GetCSSMutableStyle()->grid_data_.Access()->grid_column_span_ = 2;
+  root->AppendChild(wide_item);
+  root->AppendChild(CreateMeasuredItem(70, 50, &last));
+
+  EXPECT_EQ(
+      R"({"width":230.0,"height":100.0,"offset_top":0.0,"offset_left":0.0,"content":[0.0,0.0,230.0,0.0,230.0,100.0,0.0,100.0],"padding":[0.0,0.0,230.0,0.0,230.0,100.0,0.0,100.0],"border":[0.0,0.0,230.0,0.0,230.0,100.0,0.0,100.0],"margin":[0.0,0.0,230.0,0.0,230.0,100.0,0.0,100.0],"children":[{"width":150.0,"height":40.0,"offset_top":0.0,"offset_left":0.0,"content":[0.0,0.0,150.0,0.0,150.0,40.0,0.0,40.0],"padding":[0.0,0.0,150.0,0.0,150.0,40.0,0.0,40.0],"border":[0.0,0.0,150.0,0.0,150.0,40.0,0.0,40.0],"margin":[0.0,0.0,150.0,0.0,150.0,40.0,0.0,40.0]},{"width":70.0,"height":50.0,"offset_top":0.0,"offset_left":160.0,"content":[160.0,0.0,230.0,0.0,230.0,50.0,160.0,50.0],"padding":[160.0,0.0,230.0,0.0,230.0,50.0,160.0,50.0],"border":[160.0,0.0,230.0,0.0,230.0,50.0,160.0,50.0],"margin":[160.0,0.0,230.0,0.0,230.0,50.0,160.0,50.0]}]})",
+      Layout(root));
+  EXPECT_EQ(1, wide.count);
+  EXPECT_EQ(1, last.count);
+}
+
+TEST_F(GridGeometryTest, RtlPlacement) {
+  MeasureContext first;
+  MeasureContext second;
+  auto* root = CreateGrid(210, 60, {100, 100}, {60}, 10);
+  root->GetCSSMutableStyle()->SetDirection(DirectionType::kRtl);
+  root->AppendChild(CreateMeasuredItem(40, 30, &first));
+  root->AppendChild(CreateMeasuredItem(50, 30, &second));
+
+  EXPECT_EQ(
+      R"({"width":210.0,"height":60.0,"offset_top":0.0,"offset_left":0.0,"content":[0.0,0.0,210.0,0.0,210.0,60.0,0.0,60.0],"padding":[0.0,0.0,210.0,0.0,210.0,60.0,0.0,60.0],"border":[0.0,0.0,210.0,0.0,210.0,60.0,0.0,60.0],"margin":[0.0,0.0,210.0,0.0,210.0,60.0,0.0,60.0],"children":[{"width":40.0,"height":30.0,"offset_top":0.0,"offset_left":170.0,"content":[170.0,0.0,210.0,0.0,210.0,30.0,170.0,30.0],"padding":[170.0,0.0,210.0,0.0,210.0,30.0,170.0,30.0],"border":[170.0,0.0,210.0,0.0,210.0,30.0,170.0,30.0],"margin":[170.0,0.0,210.0,0.0,210.0,30.0,170.0,30.0]},{"width":50.0,"height":30.0,"offset_top":0.0,"offset_left":50.0,"content":[50.0,0.0,100.0,0.0,100.0,30.0,50.0,30.0],"padding":[50.0,0.0,100.0,0.0,100.0,30.0,50.0,30.0],"border":[50.0,0.0,100.0,0.0,100.0,30.0,50.0,30.0],"margin":[50.0,0.0,100.0,0.0,100.0,30.0,50.0,30.0]}]})",
+      Layout(root));
+  EXPECT_EQ(1, first.count);
+  EXPECT_EQ(1, second.count);
+}
+
+}  // namespace
+}  // namespace starlight
+}  // namespace lynx

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,27 @@ importers:
       typescript: 5.8.3
       vitest: 2.1.9
 
+  testing/grid_lanes_conformance:
+    specifiers:
+      '@lynx-js/node-lynx': workspace:*
+      '@lynx-js/qrcode-rsbuild-plugin': 0.3.6
+      '@lynx-js/react': 0.107.0
+      '@lynx-js/react-rsbuild-plugin': 0.9.8
+      '@lynx-js/rspeedy': 0.9.3
+      '@lynx-js/types': 3.3.0
+      '@types/react': 18.3.18
+      playwright: 1.59.1
+    dependencies:
+      '@lynx-js/node-lynx': link:../../oliver/node-lynx
+    devDependencies:
+      '@lynx-js/qrcode-rsbuild-plugin': 0.3.6
+      '@lynx-js/react': 0.107.0_smdqjdvvdjbjwyrr673xzocrfm
+      '@lynx-js/react-rsbuild-plugin': 0.9.8_@lynx-js+react@0.107.0
+      '@lynx-js/rspeedy': 0.9.3
+      '@lynx-js/types': 3.3.0
+      '@types/react': 18.3.18
+      playwright: 1.59.1
+
   testing/integration_test/test_script:
     specifiers:
       appium: 2.11.2
@@ -5484,6 +5505,14 @@ packages:
       universalify: 2.0.1
     dev: true
 
+  /fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /fsevents/2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7002,6 +7031,22 @@ packages:
     dependencies:
       find-up: 5.0.0
     dev: false
+
+  /playwright-core/1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dev: true
+
+  /playwright/1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
 
   /plist/3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'js_libraries/*'
   - 'oliver/node-lynx'
   - 'oliver/node-lynx/platform/*'
+  - 'testing/grid_lanes_conformance'
   - devtool/base_devtool/js_libraries/logbox-types
   - devtool/base_devtool/js_libraries/logbox
   - devtool/lynx_devtool/resources/devtool-switch

--- a/testing/grid_lanes_conformance/.gitignore
+++ b/testing/grid_lanes_conformance/.gitignore
@@ -1,0 +1,3 @@
+fixtures/*/dist
+node_modules
+quickjs_cache

--- a/testing/grid_lanes_conformance/README.md
+++ b/testing/grid_lanes_conformance/README.md
@@ -1,0 +1,49 @@
+# Grid Lanes Differential Conformance
+
+This Ring 1 harness renders hand-mirrored fixtures in native Lynx, Chromium,
+and WebKit, then compares their box-model geometry numerically.
+
+## Run
+
+```sh
+testing/grid_lanes_conformance/run.sh
+```
+
+This command builds the native subject, runs Ring 0, installs the browser
+oracles, builds all fixtures, gates on calibration, and scores the seed corpus.
+It writes `out/grid-lanes-conformance/results.json`, prints a human
+scoreboard, and appends the same table to `$GITHUB_STEP_SUMMARY` when set.
+Calibration cases are a hard gate and must pass both browser oracles.
+Grid-lanes cases are expected to remain red until the implementation
+milestones land, but each case must render successfully in every runtime.
+
+## Fixture format
+
+Each directory under `fixtures/` contains:
+
+- `fixture.json`: suite, viewport, expected status, and any oracle
+  disagreement annotation.
+- `subjectOmissions`: a temporary, explicit pre-M1 omission when the current
+  Lynx encoder rejects a new property before a bundle can run. The canonical
+  property remains in `oracle.html`.
+- `index.tsx` and `index.css`: the ReactLynx subject, compiled to
+  `dist/main.lynx.bundle`.
+- `oracle.html`: a hand-mirrored plain HTML/CSS oracle.
+
+Every compared element has a stable `data-test-tag` in HTML and
+`lynx-test-tag` in Lynx. Fixtures explicitly normalize the viewport, body
+margin, `box-sizing`, flex direction, and intrinsic minimum sizes to avoid
+known Lynx/web default-layout differences.
+
+## Result policy
+
+Geometry is rounded to two decimal places with negative zero normalized to
+zero, matching `LayoutTreeTestBench::RoundToLayoutAccuracy`. Quads are compared
+with a `0.01` epsilon. Chromium and WebKit are cross-checked before native Lynx
+is scored; a fixture must include `oracleDisagreement` metadata if the two
+browser results differ.
+
+Use `--suite calibration` or `--suite grid-lanes` for a focused run. The
+grid-lanes seed corpus adapts the core WPT masonry scenarios to the current
+CSS Grid Level 3 names: fixed lanes, auto-fill, spans, flow tolerance, gaps,
+alignment, and RTL.

--- a/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/fixture.json
@@ -1,0 +1,10 @@
+{
+  "name": "grid-alignment",
+  "suite": "calibration",
+  "expectation": "pass",
+  "viewport": {
+    "width": 380,
+    "height": 300,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/index.css
@@ -1,0 +1,36 @@
+* {
+  box-sizing: border-box;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  height: 300px;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  width: 340px;
+  height: 200px;
+  grid-template-columns: repeat(3, 80px);
+  grid-template-rows: 80px;
+  justify-content: center;
+  align-content: center;
+  justify-items: center;
+  align-items: center;
+  column-gap: 12px;
+}
+
+.item {
+  width: 44px;
+  height: 32px;
+  min-width: 0;
+  min-height: 0;
+}
+
+.second {
+  justify-self: start;
+  align-self: end;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/index.tsx
@@ -1,0 +1,17 @@
+import { root } from '@lynx-js/react';
+
+import './index.css';
+
+function App() {
+  return (
+    <view className="page" lynx-test-tag="page">
+      <view className="grid" lynx-test-tag="grid">
+        <view className="item first" lynx-test-tag="first" />
+        <view className="item second" lynx-test-tag="second" />
+        <view className="item third" lynx-test-tag="third" />
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-alignment-rtl/oracle.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 380px; height: 300px; }
+  * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 380px; height: 300px; padding: 20px; }
+  .grid { display: grid; width: 340px; height: 200px; grid-template-columns: repeat(3, 80px); grid-template-rows: 80px; justify-content: center; align-content: center; justify-items: center; align-items: center; column-gap: 12px; }
+  .item { width: 44px; height: 32px; min-width: 0; min-height: 0; }
+  .second { justify-self: start; align-self: end; }
+</style>
+<div class="page" data-test-tag="page">
+  <div class="grid" data-test-tag="grid">
+    <div class="item first" data-test-tag="first"></div>
+    <div class="item second" data-test-tag="second"></div>
+    <div class="item third" data-test-tag="third"></div>
+  </div>
+</div>

--- a/testing/grid_lanes_conformance/fixtures/grid-fixed/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-fixed/fixture.json
@@ -1,0 +1,10 @@
+{
+  "name": "grid-fixed",
+  "suite": "calibration",
+  "expectation": "pass",
+  "viewport": {
+    "width": 360,
+    "height": 300,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-fixed/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-fixed/index.css
@@ -1,0 +1,40 @@
+* {
+  box-sizing: border-box;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 300px;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  width: 320px;
+  height: 180px;
+  padding: 8px;
+  border: 2px solid #000000;
+  grid-template-columns: 100px 1fr;
+  grid-template-rows: 60px 80px;
+  column-gap: 12px;
+  row-gap: 10px;
+}
+
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+
+.a {
+  margin: 3px;
+}
+
+.b {
+  padding: 5px;
+}
+
+.c {
+  border: 4px solid #000000;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-fixed/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-fixed/index.tsx
@@ -1,0 +1,18 @@
+import { root } from '@lynx-js/react';
+
+import './index.css';
+
+function App() {
+  return (
+    <view className="page" lynx-test-tag="page">
+      <view className="grid" lynx-test-tag="grid">
+        <view className="item a" lynx-test-tag="a" />
+        <view className="item b" lynx-test-tag="b" />
+        <view className="item c" lynx-test-tag="c" />
+        <view className="item d" lynx-test-tag="d" />
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/testing/grid_lanes_conformance/fixtures/grid-fixed/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-fixed/oracle.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 360px; height: 300px; }
+  * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 360px; height: 300px; padding: 20px; }
+  .grid { display: grid; width: 320px; height: 180px; padding: 8px; border: 2px solid #000; grid-template-columns: 100px 1fr; grid-template-rows: 60px 80px; column-gap: 12px; row-gap: 10px; }
+  .item { min-width: 0; min-height: 0; }
+  .a { margin: 3px; }
+  .b { padding: 5px; }
+  .c { border: 4px solid #000; }
+</style>
+<div class="page" data-test-tag="page">
+  <div class="grid" data-test-tag="grid">
+    <div class="item a" data-test-tag="a"></div>
+    <div class="item b" data-test-tag="b"></div>
+    <div class="item c" data-test-tag="c"></div>
+    <div class="item d" data-test-tag="d"></div>
+  </div>
+</div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-alignment",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry grid-axis alignment",
+  "viewport": {
+    "width": 400,
+    "height": 440,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/index.css
@@ -1,0 +1,43 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 400px;
+  height: 440px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  width: 360px;
+  grid-template-columns: repeat(3, 80px);
+  justify-content: space-between;
+  justify-items: center;
+  row-gap: 12px;
+}
+.item {
+  width: 52px;
+  min-width: 0;
+  min-height: 0;
+}
+.item1 {
+  height: 60px;
+  justify-self: start;
+}
+.item2 {
+  height: 92px;
+}
+.item3 {
+  height: 48px;
+  justify-self: end;
+}
+.item4 {
+  height: 104px;
+}
+.item5 {
+  height: 70px;
+}
+.item6 {
+  height: 82px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-alignment/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 400px; height: 440px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 400px; height: 440px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 360px; grid-template-columns: repeat(3, 80px); justify-content: space-between; justify-items: center; row-gap: 12px; }
+  .item { width: 52px; min-width: 0; min-height: 0; }
+  .item1 { height: 60px; justify-self: start; } .item2 { height: 92px; } .item3 { height: 48px; justify-self: end; }
+  .item4 { height: 104px; } .item5 { height: 70px; } .item6 { height: 82px; }
+</style>
+<div class="page" data-test-tag="page"><div class="lanes" data-test-tag="lanes">
+  <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+  <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+</div></div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-auto-fill",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry auto-repeat sizing",
+  "viewport": {
+    "width": 420,
+    "height": 420,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/index.css
@@ -1,0 +1,38 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 420px;
+  height: 420px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  width: 380px;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 10px;
+}
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+.item1 {
+  height: 66px;
+}
+.item2 {
+  height: 104px;
+}
+.item3 {
+  height: 58px;
+}
+.item4 {
+  height: 94px;
+}
+.item5 {
+  height: 74px;
+}
+.item6 {
+  height: 122px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-auto-fill/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 420px; height: 420px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 420px; height: 420px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 380px; grid-template-columns: repeat(auto-fill, minmax(90px, 1fr)); gap: 10px; }
+  .item { min-width: 0; min-height: 0; }
+  .item1 { height: 66px; } .item2 { height: 104px; } .item3 { height: 58px; }
+  .item4 { height: 94px; } .item5 { height: 74px; } .item6 { height: 122px; }
+</style>
+<div class="page" data-test-tag="page"><div class="lanes" data-test-tag="lanes">
+  <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+  <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+</div></div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-fixed",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry fixed-track placement",
+  "viewport": {
+    "width": 360,
+    "height": 420,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/index.css
@@ -1,0 +1,42 @@
+* {
+  box-sizing: border-box;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 420px;
+  padding: 20px;
+}
+
+.lanes {
+  display: grid-lanes;
+  width: 320px;
+  grid-template-columns: repeat(3, 96px);
+  gap: 12px;
+}
+
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+
+.item1 {
+  height: 72px;
+}
+.item2 {
+  height: 120px;
+}
+.item3 {
+  height: 56px;
+}
+.item4 {
+  height: 90px;
+}
+.item5 {
+  height: 44px;
+}
+.item6 {
+  height: 110px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-fixed/oracle.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 360px; height: 420px; }
+  * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 360px; height: 420px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 320px; grid-template-columns: repeat(3, 96px); gap: 12px; }
+  .item { min-width: 0; min-height: 0; }
+  .item1 { height: 72px; } .item2 { height: 120px; } .item3 { height: 56px; }
+  .item4 { height: 90px; } .item5 { height: 44px; } .item6 { height: 110px; }
+</style>
+<div class="page" data-test-tag="page">
+  <div class="lanes" data-test-tag="lanes">
+    <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+    <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+  </div>
+</div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-fixture.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-fixture.tsx
@@ -1,0 +1,16 @@
+import { root } from '@lynx-js/react';
+
+export function renderGridLanesFixture() {
+  root.render(
+    <view className="page" lynx-test-tag="page">
+      <view className="lanes" lynx-test-tag="lanes">
+        <view className="item item1" lynx-test-tag="item1" />
+        <view className="item item2" lynx-test-tag="item2" />
+        <view className="item item3" lynx-test-tag="item3" />
+        <view className="item item4" lynx-test-tag="item4" />
+        <view className="item item5" lynx-test-tag="item5" />
+        <view className="item item6" lynx-test-tag="item6" />
+      </view>
+    </view>
+  );
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/fixture.json
@@ -1,0 +1,14 @@
+{
+  "name": "grid-lanes-flow-tolerance",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry item-tolerance ordering",
+  "subjectOmissions": [
+    "flow-tolerance is retained in oracle.html but omitted from index.css until M1 adds the property to the Lynx encoder"
+  ],
+  "viewport": {
+    "width": 360,
+    "height": 460,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/index.css
@@ -1,0 +1,34 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 460px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  width: 320px;
+  grid-template-columns: repeat(2, 150px);
+  column-gap: 20px;
+  row-gap: 8px;
+  margin-bottom: 24px;
+}
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+.a1,
+.b1 {
+  height: 80px;
+}
+.a2,
+.b2 {
+  height: 82px;
+}
+.a3,
+.b3 {
+  height: 48px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/index.tsx
@@ -1,0 +1,18 @@
+import { root } from '@lynx-js/react';
+
+import './index.css';
+
+root.render(
+  <view className="page" lynx-test-tag="page">
+    <view className="lanes zero" lynx-test-tag="zero">
+      <view className="item a1" lynx-test-tag="a1" />
+      <view className="item a2" lynx-test-tag="a2" />
+      <view className="item a3" lynx-test-tag="a3" />
+    </view>
+    <view className="lanes infinite" lynx-test-tag="infinite">
+      <view className="item b1" lynx-test-tag="b1" />
+      <view className="item b2" lynx-test-tag="b2" />
+      <view className="item b3" lynx-test-tag="b3" />
+    </view>
+  </view>
+);

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-flow-tolerance/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 360px; height: 460px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 360px; height: 460px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 320px; grid-template-columns: repeat(2, 150px); column-gap: 20px; row-gap: 8px; margin-bottom: 24px; }
+  .zero { flow-tolerance: 0; } .infinite { flow-tolerance: infinite; }
+  .item { min-width: 0; min-height: 0; }
+  .a1, .b1 { height: 80px; } .a2, .b2 { height: 82px; } .a3, .b3 { height: 48px; }
+</style>
+<div class="page" data-test-tag="page">
+  <div class="lanes zero" data-test-tag="zero"><div class="item a1" data-test-tag="a1"></div><div class="item a2" data-test-tag="a2"></div><div class="item a3" data-test-tag="a3"></div></div>
+  <div class="lanes infinite" data-test-tag="infinite"><div class="item b1" data-test-tag="b1"></div><div class="item b2" data-test-tag="b2"></div><div class="item b3" data-test-tag="b3"></div></div>
+</div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-gaps",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry row and column gap coverage",
+  "viewport": {
+    "width": 360,
+    "height": 420,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/index.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 420px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  width: 320px;
+  grid-template-columns: repeat(3, 90px);
+  column-gap: 25px;
+  row-gap: 18px;
+  padding: 7px;
+  border: 3px solid #000000;
+}
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+.item1 {
+  height: 54px;
+  margin: 4px;
+}
+.item2 {
+  height: 82px;
+}
+.item3 {
+  height: 64px;
+  padding: 5px;
+}
+.item4 {
+  height: 98px;
+}
+.item5 {
+  height: 46px;
+}
+.item6 {
+  height: 74px;
+  border: 2px solid #000000;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-gaps/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 360px; height: 420px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 360px; height: 420px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 320px; grid-template-columns: repeat(3, 90px); column-gap: 25px; row-gap: 18px; padding: 7px; border: 3px solid #000; }
+  .item { min-width: 0; min-height: 0; }
+  .item1 { height: 54px; margin: 4px; } .item2 { height: 82px; } .item3 { height: 64px; padding: 5px; }
+  .item4 { height: 98px; } .item5 { height: 46px; } .item6 { height: 74px; border: 2px solid #000; }
+</style>
+<div class="page" data-test-tag="page"><div class="lanes" data-test-tag="lanes">
+  <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+  <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+</div></div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-rtl",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry RTL placement",
+  "viewport": {
+    "width": 380,
+    "height": 440,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/index.css
@@ -1,0 +1,40 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  height: 440px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  direction: lynx-rtl;
+  width: 340px;
+  grid-template-columns: repeat(3, 100px);
+  gap: 20px;
+}
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+.item1 {
+  height: 74px;
+}
+.item2 {
+  height: 118px;
+}
+.item3 {
+  height: 52px;
+}
+.item4 {
+  height: 86px;
+  grid-column-start: 2;
+}
+.item5 {
+  height: 64px;
+}
+.item6 {
+  height: 100px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-rtl/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 380px; height: 440px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 380px; height: 440px; padding: 20px; }
+  .lanes { display: grid-lanes; direction: rtl; width: 340px; grid-template-columns: repeat(3, 100px); gap: 20px; }
+  .item { min-width: 0; min-height: 0; }
+  .item1 { height: 74px; } .item2 { height: 118px; } .item3 { height: 52px; }
+  .item4 { height: 86px; grid-column-start: 2; } .item5 { height: 64px; } .item6 { height: 100px; }
+</style>
+<div class="page" data-test-tag="page"><div class="lanes" data-test-tag="lanes">
+  <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+  <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+</div></div>

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/fixture.json
@@ -1,0 +1,11 @@
+{
+  "name": "grid-lanes-spans",
+  "suite": "grid-lanes",
+  "expectation": "fail",
+  "source": "Adapted from WPT css/css-grid/masonry spanning-item placement",
+  "viewport": {
+    "width": 380,
+    "height": 440,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/index.css
@@ -1,0 +1,40 @@
+* {
+  box-sizing: border-box;
+}
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 380px;
+  height: 440px;
+  padding: 20px;
+}
+.lanes {
+  display: grid-lanes;
+  width: 340px;
+  grid-template-columns: repeat(3, 100px);
+  gap: 20px;
+}
+.item {
+  min-width: 0;
+  min-height: 0;
+}
+.item1 {
+  height: 72px;
+  grid-column-span: 2;
+}
+.item2 {
+  height: 110px;
+}
+.item3 {
+  height: 54px;
+}
+.item4 {
+  height: 88px;
+  grid-column-span: 2;
+}
+.item5 {
+  height: 64px;
+}
+.item6 {
+  height: 96px;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/index.tsx
@@ -1,0 +1,5 @@
+import { renderGridLanesFixture } from '../grid-lanes-fixture';
+
+import './index.css';
+
+renderGridLanesFixture();

--- a/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-lanes-spans/oracle.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 380px; height: 440px; } * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 380px; height: 440px; padding: 20px; }
+  .lanes { display: grid-lanes; width: 340px; grid-template-columns: repeat(3, 100px); gap: 20px; }
+  .item { min-width: 0; min-height: 0; }
+  .item1 { height: 72px; grid-column: span 2; } .item2 { height: 110px; } .item3 { height: 54px; }
+  .item4 { height: 88px; grid-column: span 2; } .item5 { height: 64px; } .item6 { height: 96px; }
+</style>
+<div class="page" data-test-tag="page"><div class="lanes" data-test-tag="lanes">
+  <div class="item item1" data-test-tag="item1"></div><div class="item item2" data-test-tag="item2"></div><div class="item item3" data-test-tag="item3"></div>
+  <div class="item item4" data-test-tag="item4"></div><div class="item item5" data-test-tag="item5"></div><div class="item item6" data-test-tag="item6"></div>
+</div></div>

--- a/testing/grid_lanes_conformance/fixtures/grid-spans/fixture.json
+++ b/testing/grid_lanes_conformance/fixtures/grid-spans/fixture.json
@@ -1,0 +1,10 @@
+{
+  "name": "grid-spans",
+  "suite": "calibration",
+  "expectation": "pass",
+  "viewport": {
+    "width": 360,
+    "height": 320,
+    "devicePixelRatio": 1
+  }
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-spans/index.css
+++ b/testing/grid_lanes_conformance/fixtures/grid-spans/index.css
@@ -1,0 +1,39 @@
+* {
+  box-sizing: border-box;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  width: 360px;
+  height: 320px;
+  padding: 18px;
+}
+
+.grid {
+  display: grid;
+  width: 324px;
+  height: 240px;
+  grid-template-columns: repeat(3, 100px);
+  grid-template-rows: repeat(3, 70px);
+  gap: 10px;
+}
+
+.grid > view {
+  min-width: 0;
+  min-height: 0;
+}
+
+.wide {
+  grid-column-start: 1;
+  grid-column-span: 2;
+}
+
+.tall {
+  grid-row-span: 2;
+}
+
+.last {
+  grid-column-start: 2;
+  grid-column-end: 4;
+}

--- a/testing/grid_lanes_conformance/fixtures/grid-spans/index.tsx
+++ b/testing/grid_lanes_conformance/fixtures/grid-spans/index.tsx
@@ -1,0 +1,18 @@
+import { root } from '@lynx-js/react';
+
+import './index.css';
+
+function App() {
+  return (
+    <view className="page" lynx-test-tag="page">
+      <view className="grid" lynx-test-tag="grid">
+        <view className="wide" lynx-test-tag="wide" />
+        <view className="tall" lynx-test-tag="tall" />
+        <view className="small" lynx-test-tag="small" />
+        <view className="last" lynx-test-tag="last" />
+      </view>
+    </view>
+  );
+}
+
+root.render(<App />);

--- a/testing/grid_lanes_conformance/fixtures/grid-spans/oracle.html
+++ b/testing/grid_lanes_conformance/fixtures/grid-spans/oracle.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<meta charset="utf-8">
+<style>
+  html, body { margin: 0; width: 360px; height: 320px; }
+  * { box-sizing: border-box; }
+  .page { display: flex; flex-direction: column; width: 360px; height: 320px; padding: 18px; }
+  .grid { display: grid; width: 324px; height: 240px; grid-template-columns: repeat(3, 100px); grid-template-rows: repeat(3, 70px); gap: 10px; }
+  .grid > div { min-width: 0; min-height: 0; }
+  .wide { grid-column: 1 / span 2; }
+  .tall { grid-row: span 2; }
+  .last { grid-column: 2 / 4; }
+</style>
+<div class="page" data-test-tag="page">
+  <div class="grid" data-test-tag="grid">
+    <div class="wide" data-test-tag="wide"></div>
+    <div class="tall" data-test-tag="tall"></div>
+    <div class="small" data-test-tag="small"></div>
+    <div class="last" data-test-tag="last"></div>
+  </div>
+</div>

--- a/testing/grid_lanes_conformance/lynx.config.mjs
+++ b/testing/grid_lanes_conformance/lynx.config.mjs
@@ -1,0 +1,17 @@
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginReactLynx } from '@lynx-js/react-rsbuild-plugin';
+
+const entry = process.env.GRID_LANES_FIXTURE_ENTRY;
+if (!entry) {
+  throw new Error('GRID_LANES_FIXTURE_ENTRY is required');
+}
+
+export default defineConfig({
+  source: {
+    entry,
+  },
+  output: {
+    filename: 'main.lynx.bundle',
+  },
+  plugins: [pluginReactLynx()],
+});

--- a/testing/grid_lanes_conformance/package.json
+++ b/testing/grid_lanes_conformance/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@lynx-js/grid-lanes-conformance",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "scripts": {
+    "build": "node scripts/build-fixtures.js",
+    "install:browsers": "node scripts/install-browsers.js",
+    "test": "node scripts/run-conformance.js",
+    "test:calibration": "node scripts/run-conformance.js --suite calibration",
+    "test:seed": "node scripts/run-conformance.js --suite grid-lanes",
+    "test:unit": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "@lynx-js/node-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "0.3.6",
+    "@lynx-js/react": "0.107.0",
+    "@lynx-js/react-rsbuild-plugin": "0.9.8",
+    "@lynx-js/rspeedy": "0.9.3",
+    "@lynx-js/types": "3.3.0",
+    "@types/react": "18.3.18",
+    "playwright": "1.59.1"
+  }
+}

--- a/testing/grid_lanes_conformance/run.sh
+++ b/testing/grid_lanes_conformance/run.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Lynx Authors. All rights reserved.
+# Licensed under the Apache License Version 2.0 that can be found in the
+# LICENSE file in the root directory of this source tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+RTF_PATH="${PATH}"
+if ! command -v sysctl >/dev/null 2>&1; then
+  RTF_TOOLS="$(mktemp -d)"
+  trap 'rm -rf "${RTF_TOOLS}"' EXIT
+  printf '#!/usr/bin/env sh\nexit 0\n' > "${RTF_TOOLS}/sysctl"
+  chmod +x "${RTF_TOOLS}/sysctl"
+  RTF_PATH="${RTF_TOOLS}:${RTF_PATH}"
+fi
+
+"${ROOT_DIR}/tools/env.sh" pnpm --filter @lynx-js/node-lynx run build
+cp \
+  "${ROOT_DIR}/oliver/node-lynx/build/linux/Release/node_lynx.node" \
+  "${ROOT_DIR}/oliver/node-lynx/platform/linux-x64/"
+PATH="${RTF_PATH}" "${ROOT_DIR}/tools/env.sh" tools/rtf/rtf native-ut run \
+  --names lynx \
+  --target starlight_geometry_unittest_exec \
+  --disable-flutter-cxx
+"${ROOT_DIR}/tools/env.sh" pnpm \
+  --filter @lynx-js/grid-lanes-conformance run install:browsers
+"${ROOT_DIR}/tools/env.sh" pnpm --filter @lynx-js/grid-lanes-conformance run build
+"${ROOT_DIR}/tools/env.sh" pnpm --filter @lynx-js/grid-lanes-conformance run test:unit
+"${ROOT_DIR}/tools/env.sh" pnpm --filter @lynx-js/grid-lanes-conformance run test:calibration
+"${ROOT_DIR}/tools/env.sh" pnpm --filter @lynx-js/grid-lanes-conformance run test

--- a/testing/grid_lanes_conformance/scripts/build-fixtures.js
+++ b/testing/grid_lanes_conformance/scripts/build-fixtures.js
@@ -1,0 +1,36 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const { PACKAGE_ROOT, readFixtures } = require('./fixtures');
+
+const configPath = path.join(PACKAGE_ROOT, 'lynx.config.mjs');
+const rspeedyPackagePath = require.resolve('@lynx-js/rspeedy/package.json');
+const rspeedyPath = path.join(
+  path.dirname(rspeedyPackagePath),
+  'bin',
+  'rspeedy.js'
+);
+for (const fixture of readFixtures()) {
+  const result = spawnSync(
+    process.execPath,
+    [rspeedyPath, 'build', '--config', configPath],
+    {
+      cwd: fixture.directory,
+      env: {
+        ...process.env,
+        GRID_LANES_FIXTURE_ENTRY: path.join(fixture.directory, 'index.tsx'),
+      },
+      encoding: 'utf8',
+    }
+  );
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout || '');
+    process.stderr.write(result.stderr || '');
+    process.exit(result.status || 1);
+  }
+  if (!fs.existsSync(fixture.bundlePath)) {
+    throw new Error(`fixture did not produce ${fixture.bundlePath}`);
+  }
+  console.log(`built ${fixture.name}`);
+}

--- a/testing/grid_lanes_conformance/scripts/fixtures.js
+++ b/testing/grid_lanes_conformance/scripts/fixtures.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const FIXTURES_ROOT = path.join(PACKAGE_ROOT, 'fixtures');
+
+function fixtureDirectories() {
+  return fs
+    .readdirSync(FIXTURES_ROOT, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(FIXTURES_ROOT, entry.name))
+    .sort();
+}
+
+function readFixtures(suite = 'all') {
+  const fixtures = fixtureDirectories().map((directory) => {
+    const metadataPath = path.join(directory, 'fixture.json');
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    for (const field of ['name', 'suite', 'expectation', 'viewport']) {
+      if (metadata[field] === undefined) {
+        throw new Error(`${metadataPath} is missing ${field}`);
+      }
+    }
+    if (!['calibration', 'grid-lanes'].includes(metadata.suite)) {
+      throw new Error(`${metadataPath} has invalid suite ${metadata.suite}`);
+    }
+    if (!['pass', 'fail'].includes(metadata.expectation)) {
+      throw new Error(
+        `${metadataPath} has invalid expectation ${metadata.expectation}`
+      );
+    }
+    return {
+      ...metadata,
+      directory,
+      bundlePath: path.join(directory, 'dist', 'main.lynx.bundle'),
+      oraclePath: path.join(directory, 'oracle.html'),
+    };
+  });
+  fixtures.sort((left, right) => {
+    const suiteOrder = { calibration: 0, 'grid-lanes': 1 };
+    return (
+      suiteOrder[left.suite] - suiteOrder[right.suite] ||
+      left.name.localeCompare(right.name)
+    );
+  });
+  return suite === 'all'
+    ? fixtures
+    : fixtures.filter((fixture) => fixture.suite === suite);
+}
+
+module.exports = {
+  FIXTURES_ROOT,
+  PACKAGE_ROOT,
+  readFixtures,
+};

--- a/testing/grid_lanes_conformance/scripts/geometry.js
+++ b/testing/grid_lanes_conformance/scripts/geometry.js
@@ -1,0 +1,110 @@
+const BOX_FIELDS = ['content', 'padding', 'border', 'margin'];
+const EPSILON = 0.01;
+
+function roundToLayoutAccuracy(value) {
+  const rounded = Math.round((Number(value) + Number.EPSILON) * 100) / 100;
+  return Object.is(rounded, -0) || Math.abs(rounded) < Number.EPSILON
+    ? 0
+    : rounded;
+}
+
+function normalizeBoxModel(model) {
+  if (!model) {
+    return null;
+  }
+  if (!Array.isArray(model.content) || model.content.length !== 8) {
+    throw new Error('invalid content quad');
+  }
+  const contentWidth = Math.hypot(
+    model.content[2] - model.content[0],
+    model.content[3] - model.content[1]
+  );
+  const contentHeight = Math.hypot(
+    model.content[4] - model.content[2],
+    model.content[5] - model.content[3]
+  );
+  const normalized = {
+    width: roundToLayoutAccuracy(contentWidth),
+    height: roundToLayoutAccuracy(contentHeight),
+  };
+  for (const field of BOX_FIELDS) {
+    if (!Array.isArray(model[field]) || model[field].length !== 8) {
+      throw new Error(`invalid ${field} quad`);
+    }
+    normalized[field] = model[field].map(roundToLayoutAccuracy);
+  }
+  return normalized;
+}
+
+function compareGeometry(expected, actual, epsilon = EPSILON) {
+  const differences = [];
+  const expectedTags = Object.keys(expected).sort();
+  const actualTags = Object.keys(actual).sort();
+  for (const tag of expectedTags) {
+    if (!actual[tag]) {
+      differences.push({
+        tag,
+        field: 'node',
+        expected: 'present',
+        actual: 'missing',
+      });
+      continue;
+    }
+    for (const field of ['width', 'height']) {
+      compareValue(
+        differences,
+        tag,
+        field,
+        expected[tag][field],
+        actual[tag][field],
+        epsilon
+      );
+    }
+    for (const field of BOX_FIELDS) {
+      for (let index = 0; index < 8; index += 1) {
+        compareValue(
+          differences,
+          tag,
+          `${field}[${index}]`,
+          expected[tag][field][index],
+          actual[tag][field][index],
+          epsilon
+        );
+      }
+    }
+  }
+  for (const tag of actualTags) {
+    if (!expected[tag]) {
+      differences.push({
+        tag,
+        field: 'node',
+        expected: 'missing',
+        actual: 'present',
+      });
+    }
+  }
+  return differences;
+}
+
+function compareValue(differences, tag, field, expected, actual, epsilon) {
+  if (
+    !Number.isFinite(expected) ||
+    !Number.isFinite(actual) ||
+    Math.abs(expected - actual) > epsilon
+  ) {
+    differences.push({ tag, field, expected, actual });
+  }
+}
+
+function formatDifference(difference) {
+  return `node #${difference.tag}: ${difference.field} ${difference.actual} vs ${difference.expected}`;
+}
+
+module.exports = {
+  BOX_FIELDS,
+  EPSILON,
+  compareGeometry,
+  formatDifference,
+  normalizeBoxModel,
+  roundToLayoutAccuracy,
+};

--- a/testing/grid_lanes_conformance/scripts/host-platform.js
+++ b/testing/grid_lanes_conformance/scripts/host-platform.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+function aptHasPackage(packageName) {
+  const result = spawnSync('apt-cache', ['show', packageName], {
+    stdio: 'ignore',
+  });
+  return result.status === 0;
+}
+
+function configurePlaywrightHostPlatform(environment = process.env) {
+  if (
+    process.platform !== 'linux' ||
+    environment.PLAYWRIGHT_HOST_PLATFORM_OVERRIDE
+  ) {
+    return environment;
+  }
+  const osRelease = fs.existsSync('/etc/os-release')
+    ? fs.readFileSync('/etc/os-release', 'utf8')
+    : '';
+  const debianVersion = fs.existsSync('/etc/debian_version')
+    ? fs.readFileSync('/etc/debian_version', 'utf8').trim()
+    : '';
+  const isDebian12Compatible =
+    debianVersion.startsWith('12') ||
+    (aptHasPackage('libicu72') && !aptHasPackage('libicu74'));
+  if (!/^ID=debian$/m.test(osRelease) && isDebian12Compatible) {
+    environment.PLAYWRIGHT_HOST_PLATFORM_OVERRIDE =
+      process.arch === 'arm64' ? 'debian12-arm64' : 'debian12-x64';
+  }
+  return environment;
+}
+
+module.exports = { configurePlaywrightHostPlatform };

--- a/testing/grid_lanes_conformance/scripts/install-browsers.js
+++ b/testing/grid_lanes_conformance/scripts/install-browsers.js
@@ -1,0 +1,18 @@
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { configurePlaywrightHostPlatform } = require('./host-platform');
+
+const environment = configurePlaywrightHostPlatform({ ...process.env });
+
+const packagePath = require.resolve('playwright/package.json');
+const cliPath = path.join(path.dirname(packagePath), 'cli.js');
+const result = spawnSync(
+  process.execPath,
+  [cliPath, 'install', '--with-deps', 'chromium', 'webkit'],
+  {
+    env: environment,
+    stdio: 'inherit',
+  }
+);
+process.exit(result.status === null ? 1 : result.status);

--- a/testing/grid_lanes_conformance/scripts/native-runner.js
+++ b/testing/grid_lanes_conformance/scripts/native-runner.js
@@ -1,0 +1,77 @@
+const fs = require('fs/promises');
+const path = require('path');
+const zlib = require('zlib');
+
+const { HeadlessLynxView, LynxEnv } = require('@lynx-js/node-lynx');
+const {
+  attrsOf,
+  initTestLynxEnv,
+  invokeCDPFromSDK,
+  walk,
+} = require('../../../oliver/node-lynx/test/helpers/dom');
+const { normalizeBoxModel } = require('./geometry');
+
+let initialized = false;
+
+function ensureEnvironment() {
+  if (!initialized) {
+    initTestLynxEnv(LynxEnv);
+    initialized = true;
+  }
+}
+
+function decodeDocument(result) {
+  if (!result.compress) {
+    return result.root;
+  }
+  const compressed = Buffer.from(result.root, 'base64');
+  return JSON.parse(zlib.inflateSync(compressed).toString('utf8'));
+}
+
+async function renderNativeFixture(fixture) {
+  ensureEnvironment();
+  const { width, height, devicePixelRatio } = fixture.viewport;
+  const errors = [];
+  const view = new HeadlessLynxView({
+    width,
+    height,
+    devicePixelRatio,
+    timeoutMs: 30000,
+    onErrorOccurred(_level, code, message) {
+      errors.push(`${code}: ${message}`);
+    },
+  });
+
+  try {
+    const template = await fs.readFile(fixture.bundlePath);
+    await view.loadTemplate(template, {
+      url: new URL(`file://${path.resolve(fixture.bundlePath)}`).href,
+    });
+    await view.waitForFrame();
+    await invokeCDPFromSDK(view, 'DOM.enable', { useCompression: false });
+    const result = await invokeCDPFromSDK(view, 'DOM.getDocumentWithBoxModel');
+    const root = decodeDocument(result);
+    const geometry = {};
+    walk(root, (node) => {
+      const tag = attrsOf(node)['lynx-test-tag'];
+      if (!tag) {
+        return;
+      }
+      if (!node.box_model) {
+        throw new Error(`native node #${tag} has no box model`);
+      }
+      geometry[tag] = normalizeBoxModel(node.box_model);
+    });
+    if (Object.keys(geometry).length === 0) {
+      throw new Error('native document has no lynx-test-tag geometry');
+    }
+    if (errors.length > 0) {
+      throw new Error(`native render reported errors:\n${errors.join('\n')}`);
+    }
+    return { geometry, errors };
+  } finally {
+    view.destroy();
+  }
+}
+
+module.exports = { renderNativeFixture };

--- a/testing/grid_lanes_conformance/scripts/oracle-runner.js
+++ b/testing/grid_lanes_conformance/scripts/oracle-runner.js
@@ -1,0 +1,170 @@
+const { pathToFileURL } = require('url');
+
+require('./host-platform').configurePlaywrightHostPlatform();
+const { chromium, webkit } = require('playwright');
+const { normalizeBoxModel } = require('./geometry');
+
+const ORACLES = {
+  chromium: {
+    browserType: chromium,
+    launchOptions: {
+      args: ['--enable-blink-features=CSSGridLanesLayout'],
+    },
+  },
+  webkit: {
+    browserType: webkit,
+    launchOptions: {},
+  },
+};
+
+async function renderOracleFixture(oracleName, fixture) {
+  const oracle = ORACLES[oracleName];
+  const browser = await oracle.browserType.launch({
+    headless: true,
+    ...oracle.launchOptions,
+  });
+  try {
+    const page = await browser.newPage({
+      viewport: {
+        width: fixture.viewport.width,
+        height: fixture.viewport.height,
+      },
+      deviceScaleFactor: fixture.viewport.devicePixelRatio,
+    });
+    await page.goto(pathToFileURL(fixture.oraclePath).href);
+    await page.evaluate(() => document.fonts.ready);
+    const supportsGridLanes = await page.evaluate(() =>
+      CSS.supports('display', 'grid-lanes')
+    );
+    if (fixture.suite === 'grid-lanes' && !supportsGridLanes) {
+      throw new Error(
+        `${oracleName} ${browser.version()} does not support display: grid-lanes`
+      );
+    }
+
+    const geometry =
+      oracleName === 'chromium'
+        ? await collectChromiumGeometry(page)
+        : await collectWebKitGeometry(page);
+    if (Object.keys(geometry).length === 0) {
+      throw new Error(`${oracleName} document has no data-test-tag geometry`);
+    }
+    return {
+      browserVersion: browser.version(),
+      geometry,
+      supportsGridLanes,
+    };
+  } finally {
+    await browser.close();
+  }
+}
+
+async function collectChromiumGeometry(page) {
+  const client = await page.context().newCDPSession(page);
+  await client.send('DOM.enable');
+  const { root } = await client.send('DOM.getDocument', { depth: -1 });
+  const geometry = {};
+  await collectTaggedChromiumGeometry(client, root, geometry);
+  return geometry;
+}
+
+async function collectTaggedChromiumGeometry(client, node, geometry) {
+  const attributes = Array.isArray(node.attributes) ? node.attributes : [];
+  for (let index = 0; index + 1 < attributes.length; index += 2) {
+    if (attributes[index] === 'data-test-tag') {
+      const { model } = await client.send('DOM.getBoxModel', {
+        backendNodeId: node.backendNodeId,
+      });
+      geometry[attributes[index + 1]] = normalizeBoxModel(model);
+      break;
+    }
+  }
+  for (const child of node.children || []) {
+    await collectTaggedChromiumGeometry(client, child, geometry);
+  }
+}
+
+async function collectWebKitGeometry(page) {
+  const rawGeometry = await page.evaluate(() => {
+    const number = (value) => Number.parseFloat(value) || 0;
+    const quad = (left, top, right, bottom) => [
+      left,
+      top,
+      right,
+      top,
+      right,
+      bottom,
+      left,
+      bottom,
+    ];
+    return Object.fromEntries(
+      Array.from(document.querySelectorAll('[data-test-tag]')).map(
+        (element) => {
+          const rect = element.getBoundingClientRect();
+          const style = getComputedStyle(element);
+          const borderLeft = number(style.borderLeftWidth);
+          const borderTop = number(style.borderTopWidth);
+          const borderRight = number(style.borderRightWidth);
+          const borderBottom = number(style.borderBottomWidth);
+          const paddingLeft = number(style.paddingLeft);
+          const paddingTop = number(style.paddingTop);
+          const paddingRight = number(style.paddingRight);
+          const paddingBottom = number(style.paddingBottom);
+          const marginLeft = number(style.marginLeft);
+          const marginTop = number(style.marginTop);
+          const marginRight = number(style.marginRight);
+          const marginBottom = number(style.marginBottom);
+          const paddingBox = {
+            left: rect.left + borderLeft,
+            top: rect.top + borderTop,
+            right: rect.right - borderRight,
+            bottom: rect.bottom - borderBottom,
+          };
+          const contentBox = {
+            left: paddingBox.left + paddingLeft,
+            top: paddingBox.top + paddingTop,
+            right: paddingBox.right - paddingRight,
+            bottom: paddingBox.bottom - paddingBottom,
+          };
+          return [
+            element.getAttribute('data-test-tag'),
+            {
+              width: rect.width,
+              height: rect.height,
+              content: quad(
+                contentBox.left,
+                contentBox.top,
+                contentBox.right,
+                contentBox.bottom
+              ),
+              padding: quad(
+                paddingBox.left,
+                paddingBox.top,
+                paddingBox.right,
+                paddingBox.bottom
+              ),
+              border: quad(rect.left, rect.top, rect.right, rect.bottom),
+              margin: quad(
+                rect.left - marginLeft,
+                rect.top - marginTop,
+                rect.right + marginRight,
+                rect.bottom + marginBottom
+              ),
+            },
+          ];
+        }
+      )
+    );
+  });
+  return Object.fromEntries(
+    Object.entries(rawGeometry).map(([tag, model]) => [
+      tag,
+      normalizeBoxModel(model),
+    ])
+  );
+}
+
+module.exports = {
+  ORACLES: Object.keys(ORACLES),
+  renderOracleFixture,
+};

--- a/testing/grid_lanes_conformance/scripts/run-conformance.js
+++ b/testing/grid_lanes_conformance/scripts/run-conformance.js
@@ -1,0 +1,210 @@
+const fs = require('fs');
+const path = require('path');
+
+const { compareGeometry, formatDifference } = require('./geometry');
+const { PACKAGE_ROOT, readFixtures } = require('./fixtures');
+const { renderNativeFixture } = require('./native-runner');
+const { ORACLES, renderOracleFixture } = require('./oracle-runner');
+
+function parseSuite() {
+  const index = process.argv.indexOf('--suite');
+  if (index === -1) {
+    return 'all';
+  }
+  const suite = process.argv[index + 1];
+  if (!['all', 'calibration', 'grid-lanes'].includes(suite)) {
+    throw new Error(`invalid suite: ${suite}`);
+  }
+  return suite;
+}
+
+function percent(passed, total) {
+  return total === 0 ? 0 : Number(((passed / total) * 100).toFixed(2));
+}
+
+async function runFixture(fixture) {
+  const native = await renderNativeFixture(fixture);
+  const oracleResults = {};
+  for (const oracle of ORACLES) {
+    oracleResults[oracle] = await renderOracleFixture(oracle, fixture);
+  }
+
+  const oracleDifferences = compareGeometry(
+    oracleResults.chromium.geometry,
+    oracleResults.webkit.geometry
+  );
+  if (oracleDifferences.length > 0 && !fixture.oracleDisagreement) {
+    throw new Error(
+      `${fixture.name}: Chromium and WebKit disagree without an oracleDisagreement annotation\n` +
+        oracleDifferences.slice(0, 20).map(formatDifference).join('\n')
+    );
+  }
+  if (oracleDifferences.length === 0 && fixture.oracleDisagreement) {
+    throw new Error(
+      `${fixture.name}: stale oracleDisagreement annotation; browser oracles now agree`
+    );
+  }
+
+  const comparisons = {};
+  for (const oracle of ORACLES) {
+    const differences = compareGeometry(
+      oracleResults[oracle].geometry,
+      native.geometry
+    );
+    comparisons[oracle] = {
+      passed: differences.length === 0,
+      differences,
+    };
+  }
+  const passed = ORACLES.every((oracle) => comparisons[oracle].passed);
+  return {
+    name: fixture.name,
+    suite: fixture.suite,
+    expectation: fixture.expectation,
+    passed,
+    expectedOutcome: fixture.expectation === (passed ? 'pass' : 'fail'),
+    viewport: fixture.viewport,
+    oracleDisagreement: fixture.oracleDisagreement || null,
+    nativeErrors: native.errors,
+    oracles: Object.fromEntries(
+      ORACLES.map((oracle) => [
+        oracle,
+        {
+          browserVersion: oracleResults[oracle].browserVersion,
+          supportsGridLanes: oracleResults[oracle].supportsGridLanes,
+          passed: comparisons[oracle].passed,
+          differences: comparisons[oracle].differences,
+        },
+      ])
+    ),
+  };
+}
+
+function buildSummary(results) {
+  const suites = {};
+  for (const suite of ['calibration', 'grid-lanes', 'all']) {
+    const cases =
+      suite === 'all'
+        ? results
+        : results.filter((result) => result.suite === suite);
+    suites[suite] = {
+      total: cases.length,
+      passed: cases.filter((result) => result.passed).length,
+      conformancePercent: percent(
+        cases.filter((result) => result.passed).length,
+        cases.length
+      ),
+      expectedOutcomes: cases.filter((result) => result.expectedOutcome).length,
+    };
+  }
+  return suites;
+}
+
+function table(results, summary) {
+  const lines = [
+    '| Case | Suite | Chromium | WebKit | Expected |',
+    '| --- | --- | ---: | ---: | ---: |',
+  ];
+  for (const result of results) {
+    lines.push(
+      `| ${result.name} | ${result.suite} | ${
+        result.oracles.chromium.passed ? 'PASS' : 'FAIL'
+      } | ${result.oracles.webkit.passed ? 'PASS' : 'FAIL'} | ${
+        result.expectedOutcome ? 'YES' : 'NO'
+      } |`
+    );
+  }
+  lines.push('');
+  lines.push(
+    `Calibration: ${summary.calibration.passed}/${summary.calibration.total} ` +
+      `(${summary.calibration.conformancePercent}%)`
+  );
+  lines.push(
+    `Grid lanes: ${summary['grid-lanes'].passed}/${summary['grid-lanes'].total} ` +
+      `(${summary['grid-lanes'].conformancePercent}%)`
+  );
+  lines.push(
+    `Overall: ${summary.all.passed}/${summary.all.total} ` +
+      `(${summary.all.conformancePercent}%)`
+  );
+  return lines.join('\n');
+}
+
+function printDifferences(results) {
+  for (const result of results) {
+    for (const oracle of ORACLES) {
+      const differences = result.oracles[oracle].differences;
+      if (differences.length === 0) {
+        continue;
+      }
+      console.log(`\n${result.name} vs ${oracle}:`);
+      for (const difference of differences.slice(0, 20)) {
+        console.log(`  ${formatDifference(difference)}`);
+      }
+      if (differences.length > 20) {
+        console.log(`  ... ${differences.length - 20} more differences`);
+      }
+    }
+  }
+}
+
+async function main() {
+  const suite = parseSuite();
+  const fixtures = readFixtures(suite);
+  if (fixtures.length === 0) {
+    throw new Error(`no fixtures selected for ${suite}`);
+  }
+
+  const results = [];
+  for (const fixture of fixtures) {
+    process.stdout.write(`running ${fixture.name} ... `);
+    const result = await runFixture(fixture);
+    results.push(result);
+    console.log(result.expectedOutcome ? 'expected' : 'UNEXPECTED');
+    if (fixture.suite === 'calibration' && !result.passed) {
+      throw new Error(
+        `${fixture.name}: calibration failed; grid-lanes scoring was not run`
+      );
+    }
+  }
+
+  const summary = buildSummary(results);
+  const report = {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    epsilon: 0.01,
+    results,
+    summary,
+  };
+  const outputDirectory = path.resolve(
+    PACKAGE_ROOT,
+    '..',
+    '..',
+    'out',
+    'grid-lanes-conformance'
+  );
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  const outputPath = path.join(outputDirectory, 'results.json');
+  fs.writeFileSync(outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  const summaryTable = table(results, summary);
+  console.log(`\n${summaryTable}`);
+  printDifferences(results);
+  console.log(`\nJSON: ${outputPath}`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `## Grid Lanes Conformance\n\n${summaryTable}\n`
+    );
+  }
+
+  if (results.some((result) => !result.expectedOutcome)) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exit(1);
+});

--- a/testing/grid_lanes_conformance/test/geometry.test.js
+++ b/testing/grid_lanes_conformance/test/geometry.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const test = require('node:test');
+
+const {
+  compareGeometry,
+  normalizeBoxModel,
+  roundToLayoutAccuracy,
+} = require('../scripts/geometry');
+
+const quad = [0, 0, 10, 0, 10, 20, 0, 20];
+
+test('roundToLayoutAccuracy matches replay policy', () => {
+  assert.strictEqual(roundToLayoutAccuracy(4.44444), 4.44);
+  assert.strictEqual(roundToLayoutAccuracy(-0), 0);
+  assert.strictEqual(Object.is(roundToLayoutAccuracy(-0.001), -0), false);
+});
+
+test('normalizeBoxModel rounds every coordinate', () => {
+  const model = normalizeBoxModel({
+    width: 99,
+    height: 99,
+    content: [0, 0, 10.005, 0, 10.005, 20, 0, 20],
+    padding: quad,
+    border: quad,
+    margin: quad,
+  });
+  assert.strictEqual(model.width, 10.01);
+  assert.strictEqual(model.height, 20);
+  assert.deepStrictEqual(model.content, [0, 0, 10.01, 0, 10.01, 20, 0, 20]);
+});
+
+test('compareGeometry reports actionable tag and field', () => {
+  const expected = {
+    card3: normalizeBoxModel({
+      width: 10,
+      height: 20,
+      content: quad,
+      padding: quad,
+      border: quad,
+      margin: quad,
+    }),
+  };
+  const actual = JSON.parse(JSON.stringify(expected));
+  actual.card3.content[1] = 3.5;
+  assert.deepStrictEqual(compareGeometry(expected, actual), [
+    {
+      tag: 'card3',
+      field: 'content[1]',
+      expected: 0,
+      actual: 3.5,
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add node-lynx to Chromium/WebKit box-model differential harness
- add 100% green Grid calibration corpus and expected-red grid-lanes seed corpus
- add Starlight geometry snapshot fixture and Linux CI wiring

Closes #8616

## Validation
- Ring 0 geometry tests: 3/3
- harness unit tests: 3/3
- calibration: 3/3 (100%)
- grid-lanes seeds: 0/7, all expected red
