### PR TITLE
[Feature][CSS] Support prefers-reduced-motion media queries

### DIFF
--- a/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/best-practices.md
+++ b/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/best-practices.md
@@ -194,7 +194,7 @@ list-item {
   flex-direction: column;
 }
 
-/* Note: Lynx does not support @media. Adjust with JavaScript or viewport units. */
+/* Use @media with enableCSSRule, or use JavaScript or viewport units. */
 /* JavaScript: if (viewportWidth >= 768) { setLayout('row') } */
 ```
 
@@ -242,7 +242,9 @@ list-item {
 
 ### Grid Layout Patterns
 
-**Note:** Lynx does **not** support `@media` queries. See [Responsive Layout Patterns](patterns/responsive.md) for responsive layout strategies.
+**Note:** Lynx supports `@media` queries when `enableCSSRule` is enabled. See
+[Responsive Layout Patterns](patterns/responsive.md) for responsive layout
+strategies.
 
 ## Style Organization
 
@@ -362,7 +364,8 @@ page {
 
 #### 20. Scale Typography
 
-⚠️ **Note:** Lynx does **not** support `@media`. Use one of the following alternatives:
+Use `@media` with `enableCSSRule`, or use one of the following fluid-layout
+alternatives:
 
 **Option 1: Use `rem` (recommended)**
 

--- a/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/layout/grid-layout.md
+++ b/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/layout/grid-layout.md
@@ -389,7 +389,7 @@ If the Web layout's essential behavior depends on Table Layout itself, such as t
 ## Responsive Grids
 
 ```css
-/* Note: Lynx does not support @media. Use viewport units or update the layout dynamically with JavaScript. */
+/* Use @media with enableCSSRule, or use viewport units or JavaScript. */
 
 /* Mobile/default: one column */
 .grid {

--- a/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/lynx-vs-web/unsupported-features.md
+++ b/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/lynx-vs-web/unsupported-features.md
@@ -137,54 +137,41 @@ The CSS parser recognizes the following selectors without reporting an error, bu
 
 #### Media Queries: `@media` ⚠️
 
-**Important**: Lynx does **not support** the CSS `@media` rule.
+Lynx supports CSS media queries when the standard CSS rule path is enabled.
+Supported media features include viewport dimensions, orientation, resolution,
+aspect ratio, color, device pixel ratio, `prefers-color-scheme`, and
+`prefers-reduced-motion`. Conditions can use `and`, `or`, and `not`.
 
-- ❌ **Completely unsupported**: `@media (min-width: ...)` and `@media (max-width: ...)` have no effect at runtime
-- ❌ **Unsupported**: `@media print`
-- ❌ **Unsupported**: Other media types such as `@media speech` and `@media tty`
+`prefers-reduced-motion` accepts the standard `reduce` and `no-preference`
+values. It defaults to `no-preference` when no platform value is available.
+Android reads the system animator and transition animation scales; iOS reads
+the Reduce Motion accessibility setting. On Harmony API 23 and later, Lynx
+reads the system animation-reduction accessibility setting; earlier Harmony
+versions use the `no-preference` default. Changes are observed while a page is
+alive and cause affected media queries to be evaluated again.
 
-**Alternatives**:
-
-1. Use **`rem` with `vw`** for responsive adaptation; this is **recommended**.
-2. Use **viewport units**, `vw` and `vh`, for fluid layouts.
-3. Adjust styles dynamically with **JavaScript**.
-
-```css
-/* Recommended: use rem with vw instead of media queries. */
-page {
-  font-size: calc(100vw / 23.4375); /* 1rem = 16px at a width of 375px */
-}
-
-.container {
-  width: 100vw;
-  padding: 4vw; /* Adjusts automatically to the viewport width. */
-}
-
-.title {
-  font-size: 2.25rem; /* Approximately 36px at 375px; scales with screen width. */
-}
-
-/* Alternative: use vw directly. */
-.subtitle {
-  font-size: 4.8vw; /* Approximately 18px at a width of 375px */
-}
-```
-
-```javascript
-// Adjust styles dynamically with JavaScript.
-const viewportWidth = /* Obtain the viewport width. */;
-if (viewportWidth >= 768) {
-  // Apply styles for a large screen.
-}
-```
+To verify live updates, keep a page using the query open while changing the
+system setting. On Android, set the animator or transition animation scale to
+zero in Developer options. On iOS, toggle **Settings > Accessibility > Motion >
+Reduce Motion**. On Harmony API 23 and later, toggle the system animation
+reduction accessibility setting. The matched styles should update without
+reloading the page.
 
 ```css
-/* Use viewport units instead of media queries. */
-.container {
-  width: 100vw;
-  padding: 4vw; /* Adjusts automatically to the viewport width. */
+.hero {
+  transition: transform 500ms, opacity 500ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero {
+    transition: none;
+  }
 }
 ```
+
+Unsupported media types such as `print`, `speech`, and `tty` do not match.
+Viewport units remain useful for continuously fluid layouts that do not need
+discrete media-query breakpoints.
 
 #### Other At-rules
 

--- a/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/patterns/responsive.md
+++ b/ai/skills/lynx-api-docs/skills/using-lynx-api-docs/patterns/responsive.md
@@ -35,7 +35,8 @@ page {
 
 ## Use Viewport Units (`vw` and `vh`)
 
-> **Note:** Lynx does **not** support CSS `@media` queries. Use viewport units to create fluid layouts.
+> **Note:** Use viewport units for continuously fluid layouts. Standard CSS
+> media queries are also available when `enableCSSRule` is enabled.
 
 ```css
 /* Use vw instead of @media */
@@ -164,10 +165,10 @@ Combine this with conditional rendering:
 
 ## Common Pitfalls
 
-### Do Not Use `@media`
+### Use `@media` Only with `enableCSSRule`
 
 ```css
-/* ❌ Unsupported: this rule has no effect */
+/* Requires enableCSSRule. */
 @media (min-width: 768px) {
   .container {
     flex-direction: row;

--- a/core/renderer/css/dynamic_css_styles_manager.h
+++ b/core/renderer/css/dynamic_css_styles_manager.h
@@ -68,7 +68,8 @@ class DynamicCSSStylesManager {
     kFontScaleType = 4,
     kViewportType = 5,
     kColorSchemeType = 6,
-    kDynamicTypeCount = 7
+    kReducedMotionType = 7,
+    kDynamicTypeCount = 8
   };
 
  public:
@@ -82,11 +83,13 @@ class DynamicCSSStylesManager {
     kUpdateFontScale = 1 << kFontScaleType,
     kUpdateViewport = 1 << kViewportType,
     kUpdateColorScheme = 1 << kColorSchemeType,
+    kUpdateReducedMotion = 1 << kReducedMotionType,
   };
 
   static constexpr uint32_t kAllStyleUpdate =
       kUpdateEm | kUpdateRem | kUpdateScreenMetrics | kUpdateDirectionStyle |
-      kUpdateFontScale | kUpdateViewport | kUpdateColorScheme;
+      kUpdateFontScale | kUpdateViewport | kUpdateColorScheme |
+      kUpdateReducedMotion;
 
   static constexpr uint32_t kNoUpdate = 0;
 

--- a/core/renderer/css/ng/media_query/media_feature.cc
+++ b/core/renderer/css/ng/media_query/media_feature.cc
@@ -95,6 +95,7 @@ MediaFeatureId FeatureIdFromU32(uint32_t raw) {
     case MediaFeatureId::kDevicePixelRatio:
     case MediaFeatureId::kMinDevicePixelRatio:
     case MediaFeatureId::kMaxDevicePixelRatio:
+    case MediaFeatureId::kPrefersReducedMotion:
       return static_cast<MediaFeatureId>(raw);
   }
   return MediaFeatureId::kUnknown;
@@ -137,6 +138,7 @@ MediaFeatureId ResolveMediaFeatureId(const std::string& name) {
       {"device-pixel-ratio", MediaFeatureId::kDevicePixelRatio},
       {"min-device-pixel-ratio", MediaFeatureId::kMinDevicePixelRatio},
       {"max-device-pixel-ratio", MediaFeatureId::kMaxDevicePixelRatio},
+      {"prefers-reduced-motion", MediaFeatureId::kPrefersReducedMotion},
   };
   auto it = kMap.find(name);
   return it != kMap.end() ? it->second : MediaFeatureId::kUnknown;
@@ -194,6 +196,9 @@ MediaFeature MediaFeature::FromLepus(const lepus_value& value) {
   if (arr->size() < 5) return feature;
   feature.id_ = FeatureIdFromU32(arr->get(0).UInt32());
   feature.name_ = arr->get(1).StdString();
+  if (feature.id_ == MediaFeatureId::kUnknown && !feature.name_.empty()) {
+    feature.id_ = ResolveMediaFeatureId(feature.name_);
+  }
   feature.left_op_ = OperatorFromU32(arr->get(2).UInt32());
   feature.left_value_ = MediaFeatureValue::FromLepus(arr->get(3));
   const bool has_right = arr->get(4).Bool();

--- a/core/renderer/css/ng/media_query/media_feature.h
+++ b/core/renderer/css/ng/media_query/media_feature.h
@@ -128,6 +128,8 @@ enum class MediaFeatureId : uint8_t {
   kDevicePixelRatio = 29,
   kMinDevicePixelRatio = 30,
   kMaxDevicePixelRatio = 31,
+
+  kPrefersReducedMotion = 32,
 };
 
 // Map a lowercased feature name to its enum id. Returns kUnknown for

--- a/core/renderer/css/ng/media_query/media_query_evaluator.cc
+++ b/core/renderer/css/ng/media_query/media_query_evaluator.cc
@@ -305,6 +305,8 @@ bool MediaQueryEvaluator::EvalFeature(const MediaFeature& feature) const {
     case MediaFeatureId::kMaxDevicePixelRatio:
       return EvalNumericFeature(values_.DevicePixelRatio(), feature,
                                 MediaFeatureOperator::kLe, &ToNumber);
+    case MediaFeatureId::kPrefersReducedMotion:
+      return EvalReducedMotionFeature(feature);
     case MediaFeatureId::kUnknown:
       return EvalCustomFeature(feature);
   }
@@ -399,6 +401,24 @@ bool MediaQueryEvaluator::EvalColorSchemeFeature(
   const auto want = values_.PreferredColorScheme();
   if (v.Text() == "light") return want == MediaPreferredColorScheme::kLight;
   if (v.Text() == "dark") return want == MediaPreferredColorScheme::kDark;
+  return false;
+}
+
+bool MediaQueryEvaluator::EvalReducedMotionFeature(
+    const MediaFeature& feature) const {
+  if (feature.IsBoolean()) {
+    return values_.PreferredReducedMotion() ==
+           MediaPreferredReducedMotion::kReduce;
+  }
+  const auto& v = feature.LeftValue();
+  if (!v.IsIdent()) return false;
+  const auto want = values_.PreferredReducedMotion();
+  if (v.Text() == "reduce") {
+    return want == MediaPreferredReducedMotion::kReduce;
+  }
+  if (v.Text() == "no-preference") {
+    return want == MediaPreferredReducedMotion::kNoPreference;
+  }
   return false;
 }
 

--- a/core/renderer/css/ng/media_query/media_query_evaluator.h
+++ b/core/renderer/css/ng/media_query/media_query_evaluator.h
@@ -65,6 +65,7 @@ class LYNX_EXPORT_FOR_DEVTOOL MediaQueryEvaluator {
   bool EvalHoverFeature(const MediaFeature& feature) const;
   bool EvalPointerFeature(const MediaFeature& feature) const;
   bool EvalColorSchemeFeature(const MediaFeature& feature) const;
+  bool EvalReducedMotionFeature(const MediaFeature& feature) const;
   bool EvalCustomFeature(const MediaFeature& feature) const;
 
   MediaValues values_;

--- a/core/renderer/css/ng/media_query/media_query_evaluator_test.cc
+++ b/core/renderer/css/ng/media_query/media_query_evaluator_test.cc
@@ -44,6 +44,8 @@ TEST(MediaValuesTest, DefaultValues) {
   EXPECT_EQ(v.Hover(), MediaTristate::kUnknown);
   EXPECT_EQ(v.Pointer(), MediaTristate::kUnknown);
   EXPECT_EQ(v.PreferredColorScheme(), MediaPreferredColorScheme::kLight);
+  EXPECT_EQ(v.PreferredReducedMotion(),
+            MediaPreferredReducedMotion::kNoPreference);
 }
 
 TEST(MediaValuesTest, WithViewportFactory) {
@@ -685,6 +687,52 @@ TEST_F(MediaQueryEvaluatorTest, PrefersColorSchemeBoolean) {
   auto f = MakeFeature("prefers-color-scheme", MediaFeatureOperator::kNone,
                        MediaFeatureValue::Boolean());
   EXPECT_TRUE(evaluator_.EvalFeature(f));
+}
+
+// ---- prefers-reduced-motion -----------------------------------------------
+
+TEST_F(MediaQueryEvaluatorTest, PrefersReducedMotionDefaultsToNoPreference) {
+  MediaQueryEvaluator evaluator;
+  auto reduce =
+      MakeFeature("prefers-reduced-motion", MediaFeatureOperator::kNone,
+                  MediaFeatureValue::Ident("reduce"));
+  auto no_preference =
+      MakeFeature("prefers-reduced-motion", MediaFeatureOperator::kNone,
+                  MediaFeatureValue::Ident("no-preference"));
+  EXPECT_FALSE(evaluator.EvalFeature(reduce));
+  EXPECT_TRUE(evaluator.EvalFeature(no_preference));
+}
+
+TEST_F(MediaQueryEvaluatorTest, PrefersReducedMotionReduce) {
+  values_.SetPreferredReducedMotion(MediaPreferredReducedMotion::kReduce);
+  evaluator_.SetValues(values_);
+  auto f = MakeFeature("prefers-reduced-motion", MediaFeatureOperator::kNone,
+                       MediaFeatureValue::Ident("reduce"));
+  EXPECT_TRUE(evaluator_.EvalFeature(f));
+}
+
+TEST_F(MediaQueryEvaluatorTest, PrefersReducedMotionInvalidValueFailsClosed) {
+  values_.SetPreferredReducedMotion(MediaPreferredReducedMotion::kReduce);
+  evaluator_.SetValues(values_);
+  auto f = MakeFeature("prefers-reduced-motion", MediaFeatureOperator::kNone,
+                       MediaFeatureValue::Ident("less"));
+  EXPECT_FALSE(evaluator_.EvalFeature(f));
+}
+
+TEST_F(MediaQueryEvaluatorTest, PrefersReducedMotionComposesWithAnd) {
+  values_.SetPreferredReducedMotion(MediaPreferredReducedMotion::kReduce);
+  evaluator_.SetValues(values_);
+  auto set = MediaQueryParser::ParseMediaQuerySet(
+      "(prefers-reduced-motion: reduce) and (min-width: 300px)");
+  ASSERT_NE(set, nullptr);
+  EXPECT_TRUE(evaluator_.Eval(*set));
+}
+
+TEST_F(MediaQueryEvaluatorTest, PrefersReducedMotionComposesWithNot) {
+  auto set = MediaQueryParser::ParseMediaQuerySet(
+      "not (prefers-reduced-motion: reduce)");
+  ASSERT_NE(set, nullptr);
+  EXPECT_TRUE(evaluator_.Eval(*set));
 }
 
 // ---- color ----------------------------------------------------------------

--- a/core/renderer/css/ng/media_query/media_query_test.cc
+++ b/core/renderer/css/ng/media_query/media_query_test.cc
@@ -167,6 +167,30 @@ TEST(MediaFeatureTest, ToFromLepusRoundtripSimple) {
   EXPECT_FALSE(restored.HasRightBound());
 }
 
+TEST(MediaFeatureTest, PrefersReducedMotionIdRoundtrip) {
+  auto original =
+      MakeFeature("prefers-reduced-motion", MediaFeatureOperator::kNone,
+                  MediaFeatureValue::Ident("reduce"));
+  auto restored = MediaFeature::FromLepus(original.ToLepus());
+  EXPECT_EQ(restored.Id(), MediaFeatureId::kPrefersReducedMotion);
+  EXPECT_EQ(restored.Name(), "prefers-reduced-motion");
+  EXPECT_EQ(restored.LeftValue().Text(), "reduce");
+}
+
+TEST(MediaFeatureTest, PrefersReducedMotionRestoresUnknownIdFromName) {
+  auto arr = lepus::CArray::Create();
+  arr->emplace_back(static_cast<uint32_t>(MediaFeatureId::kUnknown));
+  arr->emplace_back(std::string("prefers-reduced-motion"));
+  arr->emplace_back(static_cast<uint32_t>(MediaFeatureOperator::kNone));
+  arr->emplace_back(MediaFeatureValue::Ident("reduce").ToLepus());
+  arr->emplace_back(false);
+
+  auto restored = MediaFeature::FromLepus(lepus_value(std::move(arr)));
+  EXPECT_EQ(restored.Id(), MediaFeatureId::kPrefersReducedMotion);
+  EXPECT_EQ(restored.Name(), "prefers-reduced-motion");
+  EXPECT_EQ(restored.LeftValue().Text(), "reduce");
+}
+
 TEST(MediaFeatureTest, ToFromLepusRoundtripRange) {
   auto original = MakeFeature(
       "width", MediaFeatureOperator::kGt,

--- a/core/renderer/css/ng/media_query/media_values.h
+++ b/core/renderer/css/ng/media_query/media_values.h
@@ -34,6 +34,13 @@ enum class MediaPreferredColorScheme {
   kDark,
 };
 
+// Maps to the `prefers-reduced-motion` media feature. The web-compatible
+// default is `no-preference` when the platform does not provide a value.
+enum class MediaPreferredReducedMotion {
+  kNoPreference,
+  kReduce,
+};
+
 class MediaValues {
  public:
   MediaValues() = default;
@@ -80,6 +87,12 @@ class MediaValues {
   void SetPreferredColorScheme(MediaPreferredColorScheme v) {
     preferred_color_scheme_ = v;
   }
+  MediaPreferredReducedMotion PreferredReducedMotion() const {
+    return preferred_reduced_motion_;
+  }
+  void SetPreferredReducedMotion(MediaPreferredReducedMotion v) {
+    preferred_reduced_motion_ = v;
+  }
 
   // ---- color -----------------------------------------------------------
   int ColorBitsPerComponent() const { return color_bits_per_component_; }
@@ -107,6 +120,8 @@ class MediaValues {
   MediaTristate pointer_ = MediaTristate::kUnknown;
   MediaPreferredColorScheme preferred_color_scheme_ =
       MediaPreferredColorScheme::kLight;
+  MediaPreferredReducedMotion preferred_reduced_motion_ =
+      MediaPreferredReducedMotion::kNoPreference;
   int color_bits_per_component_ = 8;
 };
 

--- a/core/renderer/css/ng/parser/media_query_parser_test.cc
+++ b/core/renderer/css/ng/parser/media_query_parser_test.cc
@@ -164,6 +164,21 @@ TEST(MediaQueryParserTest, FeatureWithIdentValue) {
   EXPECT_EQ(feature.LeftValue().Text(), "landscape");
 }
 
+TEST(MediaQueryParserTest, PrefersReducedMotionValues) {
+  for (const std::string& value : {"reduce", "no-preference"}) {
+    auto set = MediaQueryParser::ParseMediaQuerySet(
+        "(prefers-reduced-motion: " + value + ")");
+    ASSERT_NE(set, nullptr);
+    ASSERT_EQ(set->Queries().size(), 1u);
+    const auto& feature = static_cast<const MediaQueryFeatureExpNode&>(
+                              *set->Queries()[0]->Condition())
+                              .Feature();
+    EXPECT_EQ(feature.Id(), MediaFeatureId::kPrefersReducedMotion);
+    EXPECT_EQ(feature.LeftValue().Type(), MediaFeatureType::kIdent);
+    EXPECT_EQ(feature.LeftValue().Text(), value);
+  }
+}
+
 TEST(MediaQueryParserTest, FeatureWithNumberValue) {
   auto set = MediaQueryParser::ParseMediaQuerySet("(color: 8)");
   ASSERT_NE(set, nullptr);

--- a/core/renderer/dom/element_manager.cc
+++ b/core/renderer/dom/element_manager.cc
@@ -804,6 +804,23 @@ void ElementManager::UpdateColorScheme(int scheme) {
   OnCSSMediaQueryResultChangedForInspector();
 }
 
+void ElementManager::UpdateReducedMotion(bool reduced_motion) {
+  auto value = reduced_motion ? css::MediaPreferredReducedMotion::kReduce
+                              : css::MediaPreferredReducedMotion::kNoPreference;
+  if (value == GetLynxEnvConfig().PreferredReducedMotion()) {
+    return;
+  }
+  GetLynxEnvConfig().SetPreferredReducedMotion(value);
+  if (root()) {
+    root()->UpdateDynamicElementStyle(
+        DynamicCSSStylesManager::kUpdateReducedMotion, false);
+    auto options = std::make_shared<PipelineOptions>();
+    RequestResolve(options);
+  }
+
+  OnCSSMediaQueryResultChangedForInspector();
+}
+
 void ElementManager::SetInspectorElementObserver(
     const std::shared_ptr<InspectorElementObserver>
         &inspector_element_observer) {

--- a/core/renderer/dom/element_manager.h
+++ b/core/renderer/dom/element_manager.h
@@ -298,6 +298,7 @@ class ElementManager : public LayoutScheduler::LayoutSchedulerImpl {
   void UpdateScreenMetrics(float width, float height);
   void UpdateFontScale(float font_scale);
   void UpdateColorScheme(int scheme);
+  void UpdateReducedMotion(bool reduced_motion);
   void UpdateViewport(float width, SLMeasureMode width_mode_, float height,
                       SLMeasureMode height_mode, bool need_layout);
 

--- a/core/renderer/dom/fiber/fiber_element.cc
+++ b/core/renderer/dom/fiber/fiber_element.cc
@@ -5139,7 +5139,8 @@ void Element::UpdateDynamicElementStyleForNewPipeline(
       DynamicCSSStylesManager::kUpdateViewport |
       DynamicCSSStylesManager::kUpdateScreenMetrics |
       DynamicCSSStylesManager::kUpdateRem | DynamicCSSStylesManager::kUpdateEm |
-      DynamicCSSStylesManager::kUpdateColorScheme;
+      DynamicCSSStylesManager::kUpdateColorScheme |
+      DynamicCSSStylesManager::kUpdateReducedMotion;
   bool media_query_env_changed = false;
   if (is_component() &&
       ((style & kMediaQueryEnvMask) != 0 || (dirty_ & kDirtyFontSize))) {
@@ -5247,7 +5248,8 @@ void Element::UpdateDynamicElementStyleRecursively(uint32_t style,
       DynamicCSSStylesManager::kUpdateViewport |
       DynamicCSSStylesManager::kUpdateScreenMetrics |
       DynamicCSSStylesManager::kUpdateRem | DynamicCSSStylesManager::kUpdateEm |
-      DynamicCSSStylesManager::kUpdateColorScheme;
+      DynamicCSSStylesManager::kUpdateColorScheme |
+      DynamicCSSStylesManager::kUpdateReducedMotion;
   if (is_component() &&
       ((style & kMediaQueryEnvMask) != 0 || (dirty_ & kDirtyFontSize))) {
     auto *fragment = GetRelatedCSSFragment();

--- a/core/renderer/dom/fiber/fiber_element_unittest.cc
+++ b/core/renderer/dom/fiber/fiber_element_unittest.cc
@@ -11194,9 +11194,12 @@ TEST_P(FiberElementTest,
       static_cast<int>(css::MediaPreferredColorScheme::kDark));
   EXPECT_EQ(observer->media_query_result_changed_count, 3);
 
+  manager->UpdateReducedMotion(true);
+  EXPECT_EQ(observer->media_query_result_changed_count, 4);
+
   manager->dom_tree_enabled_ = false;
   manager->UpdateScreenMetrics(200.0f, 400.0f);
-  EXPECT_EQ(observer->media_query_result_changed_count, 3);
+  EXPECT_EQ(observer->media_query_result_changed_count, 4);
 }
 
 TEST_P(FiberElementTest, InsertTypedPageTemplateChildBeforeAutomaticFlush) {
@@ -22212,6 +22215,78 @@ TEST_P(FiberElementTest, NewStylingMediaQueryReResolveOnColorSchemeChange) {
                                   false);
 
   // Now the media query should match and width should be 200px
+  EXPECT_TRUE(StyleMapHasValue(child->computed_css_style()->GetResolvedValues(),
+                               CSSPropertyID::kPropertyIDWidth,
+                               CSSValue(200, CSSValuePattern::PX)));
+}
+
+TEST_P(FiberElementTest, NewStylingMediaQueryReResolveOnReducedMotionChange) {
+  auto config = std::make_shared<PageConfig>();
+  config->SetEnableFiberArch(true);
+  config->SetEnableNewStylingPipeline(true);
+  config->SetEnableStandardCSSSelector(true);
+  manager->SetConfig(config);
+  manager->GetLynxEnvConfig().UpdateViewport(375, SLMeasureModeDefinite, 812,
+                                             SLMeasureModeDefinite);
+
+  CSSParserTokenMap token_map;
+  std::vector<int32_t> dependent_ids;
+  CSSKeyframesTokenMap keyframes;
+  CSSFontFaceRuleMap font_faces;
+  auto fragment = std::make_shared<SharedCSSFragment>(
+      1, dependent_ids, token_map, keyframes, font_faces);
+  fragment->SetEnableCSSSelector();
+
+  auto media_feature = css::MediaFeature(
+      css::MediaFeatureId::kPrefersReducedMotion, "prefers-reduced-motion",
+      css::MediaFeatureOperator::kNone,
+      css::MediaFeatureValue::Ident("reduce"));
+  auto feature_node =
+      fml::MakeRefCounted<css::MediaQueryFeatureExpNode>(media_feature);
+  auto media_query = fml::MakeRefCounted<css::MediaQuery>(
+      css::MediaQueryRestrictor::kNone, css::MediaQuery::kTypeAll,
+      feature_node);
+  std::vector<fml::RefPtr<const css::MediaQuery>> queries;
+  queries.push_back(std::move(media_query));
+  auto mq_set = fml::MakeRefCounted<css::MediaQuerySet>(std::move(queries));
+
+  auto condition_rule = fml::MakeRefCounted<css::ConditionRule>(fragment.get());
+  condition_rule->SetMediaQueries(std::move(mq_set));
+
+  auto selector_array = std::make_unique<css::LynxCSSSelector[]>(1);
+  selector_array[0].SetValue("foo");
+  selector_array[0].SetMatch(css::LynxCSSSelector::MatchType::kClass);
+  selector_array[0].SetLastInTagHistory(true);
+  selector_array[0].SetLastInSelectorList(true);
+  CSSParserConfigs configs;
+  auto parse_token = fml::MakeRefCounted<CSSParseToken>(configs);
+  parse_token->SetAttribute(kPropertyIDWidth,
+                            CSSValue(200, CSSValuePattern::PX));
+  parse_token->MarkParsed();
+  condition_rule->AddStyleRule(fml::MakeRefCounted<css::StyleRule>(
+      std::move(selector_array), std::move(parse_token)));
+  fragment->AddConditionRule(std::move(condition_rule));
+
+  auto page = manager->CreateFiberPage("page", 0);
+  manager->SetFiberPageElement(page);
+  page->style_sheet_ = std::make_unique<CSSFragmentDecorator>(fragment.get());
+  page->MarkAttached();
+
+  auto child = manager->CreateFiberNode("view");
+  child->parent_component_element_ = page.get();
+  child->SetClasses(ClassList{base::String("foo")});
+  page->InsertNode(child);
+  page->FlushActionsAsRoot();
+
+  EXPECT_FALSE(StyleMapHasValue(
+      child->computed_css_style()->GetResolvedValues(),
+      CSSPropertyID::kPropertyIDWidth, CSSValue(200, CSSValuePattern::PX)));
+
+  manager->GetLynxEnvConfig().SetPreferredReducedMotion(
+      css::MediaPreferredReducedMotion::kReduce);
+  page->UpdateDynamicElementStyle(DynamicCSSStylesManager::kUpdateReducedMotion,
+                                  false);
+
   EXPECT_TRUE(StyleMapHasValue(child->computed_css_style()->GetResolvedValues(),
                                CSSPropertyID::kPropertyIDWidth,
                                CSSValue(200, CSSValuePattern::PX)));

--- a/core/renderer/dom/style_resolver.cc
+++ b/core/renderer/dom/style_resolver.cc
@@ -887,6 +887,7 @@ StyleResolver::BuildMediaQueryEvaluator(ElementManager* element_manager,
     values = css::MediaValues::WithViewport(width, height,
                                             env_config.DevicePixelRatio());
     values.SetPreferredColorScheme(env_config.PreferredColorScheme());
+    values.SetPreferredReducedMotion(env_config.PreferredReducedMotion());
     if (Element* root = element_manager->root()) {
       values.SetRootFontSize(root->GetFontSize() / layout_unit);
     }

--- a/core/renderer/lynx_env_config.h
+++ b/core/renderer/lynx_env_config.h
@@ -61,6 +61,12 @@ class LynxEnvConfig {
   void SetPreferredColorScheme(css::MediaPreferredColorScheme scheme) {
     preferred_color_scheme_ = scheme;
   }
+  css::MediaPreferredReducedMotion PreferredReducedMotion() const {
+    return preferred_reduced_motion_;
+  }
+  void SetPreferredReducedMotion(css::MediaPreferredReducedMotion preference) {
+    preferred_reduced_motion_ = preference;
+  }
 
   float DevicePixelRatio() const {
     return layouts_unit_per_px_ * physical_pixels_per_layout_unit_;
@@ -96,6 +102,8 @@ class LynxEnvConfig {
   bool font_scale_sp_only_ = false;
   css::MediaPreferredColorScheme preferred_color_scheme_ =
       css::MediaPreferredColorScheme::kLight;
+  css::MediaPreferredReducedMotion preferred_reduced_motion_ =
+      css::MediaPreferredReducedMotion::kNoPreference;
   // Currently, layout unit is equal to default unit used by platform
   // On iOS one layout unit equals to one ios point
   // On Android one layout unit equals to one physical pixel

--- a/core/shell/android/lynx_template_render_android.cc
+++ b/core/shell/android/lynx_template_render_android.cc
@@ -1021,6 +1021,19 @@ void UpdateColorScheme(JNIEnv* env, jclass jcaller, jlong ptr, jlong lifecycle,
   AtomicLifecycle::TryFree(lifecycle_ptr);
 }
 
+void UpdateReducedMotion(JNIEnv* env, jclass jcaller, jlong ptr,
+                         jlong lifecycle, jboolean reduced_motion,
+                         jboolean use_act_lite) {
+  AtomicLifecycle* lifecycle_ptr =
+      reinterpret_cast<AtomicLifecycle*>(lifecycle);
+  if (!AtomicLifecycle::TryLock(lifecycle_ptr)) {
+    return;
+  }
+  reinterpret_cast<LynxShell*>(ptr)->UpdateReducedMotion(
+      static_cast<bool>(reduced_motion), static_cast<bool>(use_act_lite));
+  AtomicLifecycle::TryFree(lifecycle_ptr);
+}
+
 void SyncFetchLayoutResult(JNIEnv* env, jclass jcaller, jlong ptr,
                            jlong lifecycle) {
   AtomicLifecycle* lifecycle_ptr =

--- a/core/shell/lynx_engine.cc
+++ b/core/shell/lynx_engine.cc
@@ -203,6 +203,13 @@ void LynxEngine::UpdateColorScheme(int scheme) {
   }
 }
 
+void LynxEngine::UpdateReducedMotion(bool reduced_motion) {
+  auto& client = tasm_->page_proxy()->element_manager();
+  if (client != nullptr) {
+    client->UpdateReducedMotion(reduced_motion);
+  }
+}
+
 void LynxEngine::SetFontScale(float scale) {
   auto& client = tasm_->page_proxy()->element_manager();
   if (client != nullptr) {

--- a/core/shell/lynx_engine.h
+++ b/core/shell/lynx_engine.h
@@ -127,6 +127,8 @@ class LynxEngine {
 
   void UpdateColorScheme(int scheme);
 
+  void UpdateReducedMotion(bool reduced_motion);
+
   void UpdateScreenMetrics(float width, float height, float device_pixel_ratio);
 
   void UpdateViewport(float width, int32_t width_mode, float height,

--- a/core/shell/lynx_shell.cc
+++ b/core/shell/lynx_shell.cc
@@ -1161,6 +1161,17 @@ void LynxShell::UpdateColorScheme(int scheme, bool use_act_lite) {
   }
 }
 
+void LynxShell::UpdateReducedMotion(bool reduced_motion, bool use_act_lite) {
+  auto update_reduced_motion = [reduced_motion](auto& engine) {
+    engine->UpdateReducedMotion(reduced_motion);
+  };
+  if (use_act_lite) {
+    engine_actor_->ActLite(std::move(update_reduced_motion));
+  } else {
+    engine_actor_->Act(std::move(update_reduced_motion));
+  }
+}
+
 void LynxShell::SetFontScale(float scale) {
   engine_actor_->ActLite(
       [scale](auto& engine) { engine->SetFontScale(scale); });

--- a/core/shell/lynx_shell.h
+++ b/core/shell/lynx_shell.h
@@ -200,6 +200,8 @@ class LynxShell {
 
   void UpdateColorScheme(int scheme, bool use_act_lite = false);
 
+  void UpdateReducedMotion(bool reduced_motion, bool use_act_lite = false);
+
   void SetFontScale(float scale);
 
   void SetPlatformConfig(std::string platform_config_json_string);

--- a/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/LynxReducedMotionHelperTest.java
+++ b/platform/android/lynx_android/src/android_test/java/com/lynx/tasm/LynxReducedMotionHelperTest.java
@@ -1,0 +1,63 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import java.lang.reflect.Field;
+import java.util.WeakHashMap;
+import org.junit.Test;
+
+public class LynxReducedMotionHelperTest {
+  @Test
+  public void animationScaleMapping() {
+    assertFalse(LynxReducedMotionHelper.isReducedMotionEnabled(1.0f, 1.0f));
+    assertTrue(LynxReducedMotionHelper.isReducedMotionEnabled(0.0f, 1.0f));
+    assertTrue(LynxReducedMotionHelper.isReducedMotionEnabled(1.0f, 0.0f));
+    assertTrue(LynxReducedMotionHelper.isReducedMotionEnabled(0.0f, 0.0f));
+  }
+
+  @Test
+  public void sharesSystemObserversAcrossTemplateRenders() throws Exception {
+    Context context = ApplicationProvider.getApplicationContext();
+    LynxTemplateRender firstRender = mock(LynxTemplateRender.class);
+    LynxTemplateRender secondRender = mock(LynxTemplateRender.class);
+
+    LynxReducedMotionHelper helper =
+        LynxReducedMotionHelper.getInstance(context.getContentResolver());
+    assertSame(helper, LynxReducedMotionHelper.getInstance(context.getContentResolver()));
+    helper.start(firstRender);
+    helper.start(secondRender);
+
+    assertTrue(isStarted(helper));
+    assertEquals(2, listenerCount(helper));
+
+    helper.stop(firstRender);
+    assertTrue(isStarted(helper));
+    assertEquals(1, listenerCount(helper));
+
+    helper.stop(secondRender);
+    assertFalse(isStarted(helper));
+    assertEquals(0, listenerCount(helper));
+  }
+
+  private static boolean isStarted(LynxReducedMotionHelper helper) throws Exception {
+    Field field = LynxReducedMotionHelper.class.getDeclaredField("mStarted");
+    field.setAccessible(true);
+    return field.getBoolean(helper);
+  }
+
+  private static int listenerCount(LynxReducedMotionHelper helper) throws Exception {
+    Field field = LynxReducedMotionHelper.class.getDeclaredField("mTemplateRenders");
+    field.setAccessible(true);
+    return ((WeakHashMap<?, ?>) field.get(helper)).size();
+  }
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxReducedMotionHelper.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxReducedMotionHelper.java
@@ -1,0 +1,138 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package com.lynx.tasm;
+
+import android.content.ContentResolver;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.WeakHashMap;
+
+@RestrictTo(RestrictTo.Scope.LIBRARY)
+final class LynxReducedMotionHelper {
+  private static volatile LynxReducedMotionHelper sInstance;
+
+  private final ContentResolver mContentResolver;
+  private final ContentObserver mObserver;
+  private final WeakHashMap<LynxTemplateRender, Boolean> mTemplateRenders = new WeakHashMap<>();
+  private boolean mStarted;
+  private volatile boolean mReducedMotionEnabled;
+
+  static LynxReducedMotionHelper getInstance(@NonNull ContentResolver contentResolver) {
+    if (sInstance == null) {
+      synchronized (LynxReducedMotionHelper.class) {
+        if (sInstance == null) {
+          sInstance = new LynxReducedMotionHelper(contentResolver);
+        }
+      }
+    }
+    return sInstance;
+  }
+
+  LynxReducedMotionHelper(@NonNull ContentResolver contentResolver) {
+    mContentResolver = contentResolver;
+    mObserver = new ContentObserver(new Handler(Looper.getMainLooper())) {
+      @Override
+      public void onChange(boolean selfChange) {
+        notifyReducedMotionChanged();
+      }
+    };
+  }
+
+  synchronized void start(@NonNull LynxTemplateRender templateRender) {
+    mTemplateRenders.put(templateRender, true);
+    if (mStarted) {
+      return;
+    }
+    mReducedMotionEnabled = readReducedMotionEnabled();
+    try {
+      mContentResolver.registerContentObserver(getAnimatorDurationScaleUri(), false, mObserver);
+      mContentResolver.registerContentObserver(getTransitionAnimationScaleUri(), false, mObserver);
+      mStarted = true;
+    } catch (SecurityException ignored) {
+      try {
+        mContentResolver.unregisterContentObserver(mObserver);
+      } catch (IllegalArgumentException | SecurityException unregisterException) {
+      }
+      mStarted = false;
+    }
+  }
+
+  synchronized void stop(@NonNull LynxTemplateRender templateRender) {
+    mTemplateRenders.remove(templateRender);
+    if (!mStarted || !mTemplateRenders.isEmpty()) {
+      return;
+    }
+    try {
+      mContentResolver.unregisterContentObserver(mObserver);
+    } catch (IllegalArgumentException | SecurityException ignored) {
+    }
+    mStarted = false;
+  }
+
+  private void notifyReducedMotionChanged() {
+    List<LynxTemplateRender> templateRenders;
+    synchronized (this) {
+      templateRenders = new ArrayList<>(mTemplateRenders.keySet());
+    }
+    boolean reducedMotion = readReducedMotionEnabled();
+    mReducedMotionEnabled = reducedMotion;
+    for (LynxTemplateRender templateRender : templateRenders) {
+      if (templateRender != null) {
+        templateRender.updateReducedMotion(reducedMotion);
+      }
+    }
+  }
+
+  boolean isReducedMotionEnabled() {
+    return mReducedMotionEnabled;
+  }
+
+  private boolean readReducedMotionEnabled() {
+    try {
+      float animatorScale;
+      float transitionScale;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        animatorScale = Settings.Global.getFloat(
+            mContentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1.0f);
+        transitionScale = Settings.Global.getFloat(
+            mContentResolver, Settings.Global.TRANSITION_ANIMATION_SCALE, 1.0f);
+      } else {
+        animatorScale = Settings.System.getFloat(
+            mContentResolver, Settings.System.ANIMATOR_DURATION_SCALE, 1.0f);
+        transitionScale = Settings.System.getFloat(
+            mContentResolver, Settings.System.TRANSITION_ANIMATION_SCALE, 1.0f);
+      }
+      return isReducedMotionEnabled(animatorScale, transitionScale);
+    } catch (SecurityException ignored) {
+      return false;
+    }
+  }
+
+  static boolean isReducedMotionEnabled(float animatorScale, float transitionScale) {
+    return animatorScale == 0.0f || transitionScale == 0.0f;
+  }
+
+  private static Uri getAnimatorDurationScaleUri() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      return Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE);
+    }
+    return Settings.System.getUriFor(Settings.System.ANIMATOR_DURATION_SCALE);
+  }
+
+  private static Uri getTransitionAnimationScaleUri() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+      return Settings.Global.getUriFor(Settings.Global.TRANSITION_ANIMATION_SCALE);
+    }
+    return Settings.System.getUriFor(Settings.System.TRANSITION_ANIMATION_SCALE);
+  }
+}

--- a/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
+++ b/platform/android/lynx_android/src/main/java/com/lynx/tasm/LynxTemplateRender.java
@@ -218,6 +218,7 @@ public class LynxTemplateRender
 
   private Context mContext;
   @Keep private LynxDevtool mDevTool;
+  private LynxReducedMotionHelper mReducedMotionHelper;
 
   private long mInitStart;
   private long mInitEnd;
@@ -1149,6 +1150,7 @@ public class LynxTemplateRender
     if (colorScheme != LynxColorScheme.LIGHT) {
       nativeUpdateColorScheme(mNativePtr, mNativeLifecycle, colorScheme.id(), true);
     }
+    startReducedMotionObserver();
     nativeOnLynxEngineCreated(mNativePtr, lynxUIRenderer().getUIDelegatePtr());
 
     TraceEvent.endSection(TraceEventDef.TEMPLATE_RENDER_CREATE_TASM);
@@ -2562,6 +2564,40 @@ public class LynxTemplateRender
     nativeUpdateColorScheme(mNativePtr, mNativeLifecycle, scheme.id(), false);
   }
 
+  private void startReducedMotionObserver() {
+    Context applicationContext = LynxEnv.inst().getAppContext();
+    if (applicationContext == null && mContext != null) {
+      applicationContext = mContext.getApplicationContext();
+    }
+    if (applicationContext == null) {
+      return;
+    }
+    if (mReducedMotionHelper == null) {
+      mReducedMotionHelper =
+          LynxReducedMotionHelper.getInstance(applicationContext.getContentResolver());
+    }
+    mReducedMotionHelper.start(this);
+    updateReducedMotion(mReducedMotionHelper.isReducedMotionEnabled(), true);
+  }
+
+  private void stopReducedMotionObserver() {
+    if (mReducedMotionHelper != null) {
+      mReducedMotionHelper.stop(this);
+      mReducedMotionHelper = null;
+    }
+  }
+
+  void updateReducedMotion(boolean reducedMotion) {
+    updateReducedMotion(reducedMotion, false);
+  }
+
+  private void updateReducedMotion(boolean reducedMotion, boolean useActLite) {
+    if (!checkIfEnvPrepared() || mNativePtr == 0) {
+      return;
+    }
+    nativeUpdateReducedMotion(mNativePtr, mNativeLifecycle, reducedMotion, useActLite);
+  }
+
   public void destroy() {
     String eventName = "LynxTemplateRender.destroy";
     onTraceEventBegin(eventName);
@@ -3253,6 +3289,9 @@ public class LynxTemplateRender
       eventEmitter.registerEventFallback(this);
       mLynxContext.setEventEmitter(eventEmitter);
 
+      if (mReducedMotionHelper != null) {
+        updateReducedMotion(mReducedMotionHelper.isReducedMotionEnabled(), true);
+      }
       nativeOnLynxEngineCreated(mNativePtr, lynxUIRenderer().getUIDelegatePtr());
     } else {
       createLynxEngine(lastInstanceId);
@@ -4213,6 +4252,7 @@ public class LynxTemplateRender
     if (!mIsDestroyed.compareAndSet(false, true)) {
       return;
     }
+    stopReducedMotionObserver();
     boolean shouldCacheLynxEngine = shouldCacheLynxEngine();
     unregisterMemoryUsageFetcherIfNeeded();
 
@@ -4681,6 +4721,9 @@ public class LynxTemplateRender
 
   private static native void nativeUpdateColorScheme(
       long ptr, long lifecycle, int scheme, boolean useActLite);
+
+  private static native void nativeUpdateReducedMotion(
+      long ptr, long lifecycle, boolean reducedMotion, boolean useActLite);
 
   // layout
   private static native void nativeUpdateViewport(long ptr, long lifecycle, int width,

--- a/platform/darwin/ios/lynx/LynxTemplateRender.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRender.mm
@@ -33,6 +33,7 @@
 #import <Lynx/LynxTraceEvent.h>
 #import <Lynx/LynxUIRenderer.h>
 #import <Lynx/LynxView.h>
+#import <UIKit/UIAccessibility.h>
 #import "LynxAccessibilityModule.h"
 #import "LynxBaseConfigurator+Internal.h"
 #import "LynxCallStackUtil.h"
@@ -207,6 +208,11 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
 
     /// UIRender + LynxShell + Event
     [self setUpWithBuilder:builder screenSize:screenSize];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(reducedMotionStatusDidChange:)
+               name:UIAccessibilityReduceMotionStatusDidChangeNotification
+             object:nil];
 
     // Update info
     [self updateNativeTheme];
@@ -487,6 +493,10 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
 }
 
 - (void)dealloc {
+  [[NSNotificationCenter defaultCenter]
+      removeObserver:self
+                name:UIAccessibilityReduceMotionStatusDidChangeNotification
+              object:nil];
   [self destroyStaticPageHost];
   [self unregisterMemoryUsageFetcherIfNeeded];
   if (_lynxEngine == nil) {
@@ -1560,6 +1570,13 @@ LYNX_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder*)aDecoder)
     return;
   }
   shell_->UpdateColorScheme(static_cast<int>(scheme));
+}
+
+- (void)reducedMotionStatusDidChange:(NSNotification*)notification {
+  if (shell_->IsDestroyed()) {
+    return;
+  }
+  shell_->UpdateReducedMotion(UIAccessibilityIsReduceMotionEnabled());
 }
 
 - (void)pauseRootLayoutAnimation {

--- a/platform/darwin/ios/lynx/LynxTemplateRenderHelper.mm
+++ b/platform/darwin/ios/lynx/LynxTemplateRenderHelper.mm
@@ -36,6 +36,7 @@
 #import <Lynx/LynxUIRenderer.h>
 #import <Lynx/LynxViewBuilder+Internal.h>
 #import <Lynx/PaintingContextProxy.h>
+#import <UIKit/UIAccessibility.h>
 #import "LynxLogContext+Internal.h"
 #import "LynxTraceEventDef.h"
 
@@ -227,6 +228,9 @@ bool HasNativePaintingCtxPlatformRef(lynx::tasm::PaintingCtxPlatformImpl* painti
   shell_->SetFontScale(_fontScale);
   if (_colorScheme != LynxColorSchemeLight) {
     shell_->UpdateColorScheme(static_cast<int>(_colorScheme), true);
+  }
+  if (UIAccessibilityIsReduceMotionEnabled()) {
+    shell_->UpdateReducedMotion(true, true);
   }
 
   // Thread pool

--- a/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.cc
+++ b/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.cc
@@ -530,6 +530,10 @@ void LynxTemplateRenderer::UpdateColorScheme(int scheme) {
   shell_->UpdateColorScheme(scheme);
 }
 
+void LynxTemplateRenderer::UpdateReducedMotion(bool enabled) {
+  shell_->UpdateReducedMotion(enabled);
+}
+
 void LynxTemplateRenderer::SetEnableBytecode(bool enable,
                                              std::string source_url) {
   shell_->SetEnableBytecode(enable, std::move(source_url));
@@ -732,6 +736,7 @@ napi_value LynxTemplateRenderer::Init(napi_env env, napi_value exports) {
       DECLARE_NAPI_METHOD("getInstanceId", GetInstanceId),
       DECLARE_NAPI_METHOD("updateFontScale", UpdateFontScale),
       DECLARE_NAPI_METHOD("updateColorScheme", UpdateColorScheme),
+      DECLARE_NAPI_METHOD("updateReducedMotion", UpdateReducedMotion),
       DECLARE_NAPI_METHOD("nativeSetEnableBytecode", NativeSetEnableBytecode),
       DECLARE_NAPI_METHOD("getPageDataByKey", GetPageDataByKey),
       DECLARE_NAPI_METHOD("getPageDataByKeyAsync", GetPageDataByKeyAsync),
@@ -1893,6 +1898,26 @@ napi_value LynxTemplateRenderer::UpdateColorScheme(napi_env env,
     return nullptr;
   }
   obj->UpdateColorScheme(scheme);
+  return nullptr;
+}
+
+napi_value LynxTemplateRenderer::UpdateReducedMotion(napi_env env,
+                                                     napi_callback_info info) {
+  napi_value js_this;
+  size_t argc = 1;
+  napi_value args[1] = {nullptr};
+  napi_get_cb_info(env, info, &argc, args, &js_this, nullptr);
+
+  bool enabled = false;
+  napi_get_value_bool(env, args[0], &enabled);
+
+  LynxTemplateRenderer* obj = nullptr;
+  napi_status status =
+      napi_unwrap(env, js_this, reinterpret_cast<void**>(&obj));
+  if (!CheckNapiUnwrapObject(status, obj, "NativeUpdateReducedMotion failed")) {
+    return nullptr;
+  }
+  obj->UpdateReducedMotion(enabled);
   return nullptr;
 }
 

--- a/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.h
+++ b/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.h
@@ -93,6 +93,7 @@ class LynxTemplateRenderer : public devtool::LynxDevToolProxy {
   bool ShouldSendEventToMainThread() const;
   void UpdateFontScale(float font_scale);
   void UpdateColorScheme(int scheme);
+  void UpdateReducedMotion(bool enabled);
   void SetEnableBytecode(bool enable, std::string source_url);
   lepus::Value GetPageDataByKey(std::vector<std::string> keys);
 
@@ -224,6 +225,7 @@ class LynxTemplateRenderer : public devtool::LynxDevToolProxy {
                                                 napi_callback_info info);
   static napi_value UpdateFontScale(napi_env env, napi_callback_info info);
   static napi_value UpdateColorScheme(napi_env env, napi_callback_info info);
+  static napi_value UpdateReducedMotion(napi_env env, napi_callback_info info);
   static napi_value NativeSetEnableBytecode(napi_env env,
                                             napi_callback_info info);
   static napi_value GetPageDataByKey(napi_env env, napi_callback_info info);

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxView.ets
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/LynxView.ets
@@ -49,6 +49,13 @@ import { LynxDevTool } from '../devtool_wrapper/LynxDevTool';
 import { ILynxDevToolService } from './service/ILynxDevToolService';
 import { LynxImageConfig } from './image/LynxImageConfig';
 import { registerGlobalLynxModules } from '../library/LynxLibraryRegistry';
+import {
+  AnimationReduceStateChangeCallback,
+  isAnimationReduceAvailable,
+  isAnimationReduceEnabled,
+  offAnimationReduceStateChange,
+  onAnimationReduceStateChange,
+} from './ReducedMotionCompatibility';
 
 export enum MeasureMode {
   INDEFINITE = 0,
@@ -215,11 +222,13 @@ export struct LynxView {
   private keyboardHeightChangeCallback?: (height: number) => void;
   private keyboardWillShowCallback?: (keyboardInfo: window.KeyboardInfo) => void;
   private keyboardWillHideCallback?: (keyboardInfo: window.KeyboardInfo) => void;
+  private animationReduceStateChangeCallback?: AnimationReduceStateChangeCallback;
   private pendingKeyboardAnimationOption?: AnimateParam;
   private activeKeyboardAnimationOption?: AnimateParam;
   private loadingID: number = 0;
   private fontScale: number = 1.0;
   private colorScheme: ColorScheme = ColorScheme.LIGHT;
+  private reducedMotionEnabled: boolean = false;
   private enableMultiAsyncThread: boolean = true;
   onCreate: (context: LynxContext) => void = ((context: LynxContext) => {
   });
@@ -450,6 +459,9 @@ export struct LynxView {
     if (this.colorScheme != ColorScheme.LIGHT) {
       this.context.updateColorScheme(this.colorScheme);
     }
+    if (this.reducedMotionEnabled) {
+      this.templateRenderer.updateReducedMotion(true);
+    }
 
     this.nodeController?.updateNode(this.uiRenderer, this.fitContentHeight && !!this.experimentalFixFitContent);
     if (!this.enableAirStrictMode) {
@@ -486,6 +498,7 @@ export struct LynxView {
       this.uiRendererCreator ? this.uiRendererCreator.createNodeController() : new CAPINodeController()
     this.setupLogBox();
     this.context.setLynxView(this);
+    this.startReducedMotionObserver();
     if (this.hasLoadSource()) {
       this.reInitTemplateRenderer(true);
     }
@@ -545,6 +558,7 @@ export struct LynxView {
   aboutToDisappear() {
     LLog.d(TAG, 'aboutToDisappear.')
     this.hasAppeared = false;
+    this.stopReducedMotionObserver();
     this.perfController?.destroy();
     this.perfController = undefined;
     this.uiRenderer?.aboutToDisappear();
@@ -584,6 +598,36 @@ export struct LynxView {
       extensionService.onLynxViewDestroy(this.context);
     }
     this.context.aboutToDisappear();
+  }
+
+  private startReducedMotionObserver(): void {
+    if (this.animationReduceStateChangeCallback !== undefined ||
+      !isAnimationReduceAvailable()) {
+      return;
+    }
+    try {
+      this.reducedMotionEnabled = isAnimationReduceEnabled();
+      this.animationReduceStateChangeCallback = (enabled: boolean): void => {
+        this.reducedMotionEnabled = enabled;
+        this.templateRenderer?.updateReducedMotion(enabled);
+      };
+      onAnimationReduceStateChange(this.animationReduceStateChangeCallback);
+    } catch (e) {
+      this.animationReduceStateChangeCallback = undefined;
+      LLog.e(TAG, `Failed to observe animation reduce state. Code: ${e.code}, message: ${e.message}`);
+    }
+  }
+
+  private stopReducedMotionObserver(): void {
+    if (this.animationReduceStateChangeCallback === undefined) {
+      return;
+    }
+    try {
+      offAnimationReduceStateChange(this.animationReduceStateChangeCallback);
+    } catch (e) {
+      LLog.e(TAG, `Failed to stop observing animation reduce state. Code: ${e.code}, message: ${e.message}`);
+    }
+    this.animationReduceStateChangeCallback = undefined;
   }
 
   private getDefaultKeyboardAnimationOption(): AnimateParam {

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/ReducedMotionCompatibility.ts
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/ReducedMotionCompatibility.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import accessibility from '@ohos.accessibility';
+
+export type AnimationReduceStateChangeCallback = (enabled: boolean) => void;
+
+interface AccessibilityCompatibilityApi {
+  isAnimationReduceEnabledSync?: () => boolean;
+  onAnimationReduceStateChange?: (
+    callback: AnimationReduceStateChangeCallback
+  ) => void;
+  offAnimationReduceStateChange?: (
+    callback: AnimationReduceStateChangeCallback
+  ) => void;
+}
+
+function getAccessibilityApi(): AccessibilityCompatibilityApi {
+  return accessibility as AccessibilityCompatibilityApi;
+}
+
+export function isAnimationReduceAvailable(): boolean {
+  const api = getAccessibilityApi();
+  return (
+    typeof api.isAnimationReduceEnabledSync === 'function' &&
+    typeof api.onAnimationReduceStateChange === 'function'
+  );
+}
+
+export function isAnimationReduceEnabled(): boolean {
+  return getAccessibilityApi().isAnimationReduceEnabledSync?.() ?? false;
+}
+
+export function onAnimationReduceStateChange(
+  callback: AnimationReduceStateChangeCallback
+): void {
+  getAccessibilityApi().onAnimationReduceStateChange?.(callback);
+}
+
+export function offAnimationReduceStateChange(
+  callback: AnimationReduceStateChangeCallback
+): void {
+  getAccessibilityApi().offAnimationReduceStateChange?.(callback);
+}

--- a/platform/harmony/lynx_harmony/src/main/ets/tasm/types/liblynx/index.d.ts
+++ b/platform/harmony/lynx_harmony/src/main/ets/tasm/types/liblynx/index.d.ts
@@ -200,6 +200,8 @@ export class LynxTemplateRenderer {
 
   updateColorScheme(scheme: number): void;
 
+  updateReducedMotion(enabled: boolean): void;
+
   nativeSetEnableBytecode(enableBytecode: boolean, sourceUrl: string): void;
 
   getPageDataByKey(keys: string[]): Object;


### PR DESCRIPTION
## Summary

- Add support for the `prefers-reduced-motion` media feature with `reduce` and `no-preference` values.
- Propagate Android animation-scale and iOS Reduce Motion changes to active pages and re-evaluate affected media queries without reloading.
- Add parser, evaluator, serialization, invalidation, and Android helper coverage, and update media-query documentation.

Closes #8623.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Verification

- Focused CSS media-query tests passed.
- Android LynxExplorer built successfully from the changed native sources.
- Lynx Sandbox verified a reversible no-preference → reduce → no-preference live update in the same page and process without reload.
- Headless browser media-query baseline passed.
