### PR TITLE
[Feature] Deliver app-level callbacks as context-proxy message events

### DIFF
--- a/core/runtime/js/bindings/js_app.cc
+++ b/core/runtime/js/bindings/js_app.cc
@@ -2228,10 +2228,6 @@ void App::OnAppReload(tasm::TemplateData init_data) {
     Scope scope(*rt);
     auto js_app = js_app_.getObject(*rt);
 
-    auto on_app_reload = js_app.getPropertyAsFunction(*rt, "onAppReload");
-    if (!on_app_reload) {
-      return;
-    }
     auto js_init_data = valueFromLepus(*rt, init_data.GetValue(),
                                        jsi_object_wrapper_manager_.get());
     if (!js_init_data) {
@@ -2246,6 +2242,21 @@ void App::OnAppReload(tasm::TemplateData init_data) {
       return;
     }
 
+    // A framework subscribed to the message event receives it there; the
+    // property call below stays for frameworks that did not subscribe.
+    auto payload = Array::createWithLength(*rt, 2);
+    if (payload &&
+        payload->setValueAtIndex(*rt, 0, Value(*rt, *js_init_data)) &&
+        payload->setValueAtIndex(*rt, 1, Value(*rt, options)) &&
+        DispatchAppEventMessage(runtime::kMessageEventTypeOnAppReload, *rt,
+                                Value(*rt, *payload))) {
+      return;
+    }
+
+    auto on_app_reload = js_app.getPropertyAsFunction(*rt, "onAppReload");
+    if (!on_app_reload) {
+      return;
+    }
     size_t count = 2;
     const Value args[2] = {std::move(*js_init_data), std::move(options)};
     on_app_reload->callWithThis(*rt, js_app, args, count);
@@ -2567,6 +2578,21 @@ void App::EraseApiCallBack(ApiCallBack callback) {
   api_callback_manager_.EraseWithCallback(callback);
 }
 
+bool App::DispatchAppEventMessage(const char* type, Runtime& rt,
+                                  Value payload) {
+  auto* proxy =
+      GetOrCreateContextProxyImpl(runtime::ContextProxy::Type::kCoreContext);
+  if (proxy == nullptr || !proxy->HasEventListener(type)) {
+    return false;
+  }
+  auto event = fml::MakeRefCounted<runtime::MessageEvent>(
+      type, runtime::ContextProxy::Type::kCoreContext,
+      runtime::ContextProxy::Type::kJSContext,
+      std::make_unique<pub::ValueImplPiper>(rt, payload));
+  proxy->DispatchEvent(std::move(event));
+  return true;
+}
+
 void App::NotifyUpdatePageData(uint64_t trace_flow_id) {
   TRACE_EVENT(LYNX_TRACE_CATEGORY, APP_UPDATE_CARD_DATA,
               [trace_flow_id](lynx::perfetto::EventContext ctx) {
@@ -2586,10 +2612,6 @@ void App::NotifyUpdatePageData(uint64_t trace_flow_id) {
       LOGI("App::updateCardData" << this);
 
       Object js_app = js_app_.getObject(*rt);
-      auto publishEvent = js_app.getPropertyAsFunction(*rt, "updateCardData");
-      if (!publishEvent) {
-        continue;
-      }
       TRACE_EVENT_BEGIN(LYNX_TRACE_CATEGORY, LEPUS_VALUE_TO_JS_VALUE);
       auto jsValue = valueFromLepus(*rt, data.GetValue(),
                                     jsi_object_wrapper_manager_.get());
@@ -2617,6 +2639,21 @@ void App::NotifyUpdatePageData(uint64_t trace_flow_id) {
       }
 
       TRACE_EVENT_END(LYNX_TRACE_CATEGORY);
+
+      // A framework subscribed to the message event receives it there; the
+      // property call below stays for frameworks that did not subscribe.
+      auto payload = Array::createWithLength(*rt, 2);
+      if (payload && payload->setValueAtIndex(*rt, 0, Value(*rt, *jsValue)) &&
+          payload->setValueAtIndex(*rt, 1, Value(*rt, options)) &&
+          DispatchAppEventMessage(runtime::kMessageEventTypeUpdateCardData, *rt,
+                                  Value(*rt, *payload))) {
+        continue;
+      }
+
+      auto publishEvent = js_app.getPropertyAsFunction(*rt, "updateCardData");
+      if (!publishEvent) {
+        continue;
+      }
       const Value args[2] = {std::move(*jsValue), std::move(options)};
       size_t count = 2;
       const Object& thisObj = js_app;

--- a/core/runtime/js/bindings/js_app.h
+++ b/core/runtime/js/bindings/js_app.h
@@ -252,6 +252,12 @@ class App {
   void PauseGcSuppressionMode();
   void ResumeGcSuppressionMode();
 
+  // Delivers an app-level callback as a MessageEvent on the CoreContext
+  // proxy when the script side has registered a listener for it. Returns
+  // false when no listener is registered so callers can fall back to the
+  // legacy js_app property call.
+  bool DispatchAppEventMessage(const char* type, Runtime& rt, Value payload);
+
   void OnStandaloneScriptAdded(const std::string& url, JsContent script,
                                const std::shared_ptr<const JsBundle>& bundle);
   void OnSetPresetData(lepus::Value data);

--- a/core/runtime/js/runtime_constant.h
+++ b/core/runtime/js/runtime_constant.h
@@ -81,6 +81,8 @@ constexpr const char kMessageEventTypeUpdatePage[] = "__UpdatePage";
 constexpr const char kMessageEventTypeUpdateGlobalProps[] =
     "__UpdateGlobalProps";
 constexpr const char kMessageEventTypeRemoveComponents[] = "__RemoveComponents";
+constexpr const char kMessageEventTypeUpdateCardData[] = "__UpdateCardData";
+constexpr const char kMessageEventTypeOnAppReload[] = "__OnAppReload";
 
 constexpr char kRawRuntimeMemoryInfo[] = "raw_memory_info_json_str";
 constexpr char kRawRuntimePageRssMemoryInfo[] = "page_rss_usage";

--- a/js_libraries/lynx-core/src/app/app.ts
+++ b/js_libraries/lynx-core/src/app/app.ts
@@ -203,6 +203,10 @@ export abstract class BaseApp<
       );
 
       this.lynx = this.createLynx(lynx, promiseCtor);
+      this.lynx.__initData = {
+        ...(this.params?.initData as Record<string, unknown> | undefined),
+        ...(this.params?.updateData as Record<string, unknown> | undefined),
+      };
       this.setupJSModule();
       this.setupIntersectionApi();
       this.setupFetchAPI(promiseCtor);

--- a/js_libraries/lynx-core/src/lynx/lynx.ts
+++ b/js_libraries/lynx-core/src/lynx/lynx.ts
@@ -42,6 +42,24 @@ export class Lynx {
   static __registerSharedDataCounter: number = 0;
   __globalProps: GlobalProps;
   __presetData: Record<string, unknown>;
+  /**
+   * The card's initial data, merged from the load-time initData and
+   * updateData. Frameworks used to compute this by reading the injected
+   * app's private `_params`; the core now owns the merge so scripts can
+   * read it straight off `lynx`.
+   */
+  __initData?: Record<string, unknown>;
+  /**
+   * Marks a core that delivers every app-level callback a UI framework
+   * needs as a `MessageEvent` on the context proxies, so frameworks can
+   * subscribe with `lynx.getCoreContext().addEventListener(...)` instead
+   * of assigning methods onto the injected app object.
+   *
+   * Frameworks must feature-detect this: on an older core the callbacks
+   * still arrive as property lookups on the app object and the framework
+   * has to keep assigning them.
+   */
+  readonly __appEventsAsMessages: boolean = true;
   _switches: Record<string, boolean>;
   targetSdkVersion?: string;
 
@@ -59,6 +77,16 @@ export class Lynx {
     this.getNativeApp().setTimeout,
     'setTimeout Error'
   );
+
+  /**
+   * Runs the core's before-publish-event AOP hook. Frameworks used to
+   * reach this through the injected app object.
+   */
+  callBeforePublishEvent = (eventData?: unknown): void => {
+    ((this.getApp() as unknown) as {
+      callBeforePublishEvent?: (eventData?: unknown) => void;
+    }).callBeforePublishEvent?.(eventData);
+  };
 
   public rebind(getApp: () => BaseApp) {
     this.init(getApp);


### PR DESCRIPTION
## Summary

A UI framework used to receive the engine's app-level callbacks by assigning methods onto the JS app object, which the engine then found by property lookup. This PR lets frameworks subscribe on the context proxies instead — the same `MessageEvent` transport the main thread already uses to reach the background thread — and moves the card's init-data merge into lynx-core.

### Engine

- `updateCardData` and `onAppReload` gain `__UpdateCardData` and `__OnAppReload` message events on the CoreContext proxy. Both are dispatched **only while a listener is registered**, mirroring how `__DestroyLifetime` already works, so a framework that does not subscribe keeps the existing property-call path untouched.
- New helper `App::DispatchAppEventMessage` centralizes the listener check and dispatch.

The remaining app-level callbacks already have message events — `__OnLifecycleEvent`, `__SendPageEvent`, `__PublishComponentEvent`, `__NotifyGlobalPropsUpdated`, `__DestroyLifetime` — so no new plumbing is needed for them.

### lynx-core

- `lynx.__initData` now holds the load-time `initData` merged with `updateData`. Frameworks previously computed this by reading the app object's private `_params`.
- `lynx.callBeforePublishEvent(data)` exposes the before-publish-event hook, which frameworks also used to reach through the injected app object.
- `lynx.__appEventsAsMessages` marks a core that delivers every callback a framework needs as a message event. Frameworks feature-detect it and fall back to assigning onto the app object on older cores, so no compatibility break.

## Verification

Built the Android LynxExplorer from this branch and ran the `examples/react` app from the companion PR (lynx-family/lynx-stack#3553) on a physical Pixel 5, with the framework instrumented to report how it received each callback.

- `lynx.__appEventsAsMessages` was `true`, so the framework subscribed on the context proxies, and the app object's `publishEvent` stayed `undefined` — read from inside the framework, off the same object the engine looks up.
- `lynx.__initData` arrived as `{"mockData":"Hello Lynx Explorer"}`, so the core-side merge reached the framework.
- First screen, a tap, the post-hydration handler swap and card destruction all behaved the same as on an engine without these changes, with no errors.
- With the framework's probe forced off, the same build fell back to the property path on this engine: all eight callbacks landed on the app object and taps and destruction still worked, confirming the `HasEventListener` gates leave the old path intact.
