### PR TITLE
[grid-lanes M1] Add CSS plumbing and feature gate

### DIFF
--- a/core/renderer/css/build.gni
+++ b/core/renderer/css/build.gni
@@ -146,6 +146,8 @@ lynx_css_core_sources = [
   "parser/flex_flow_handler.h",
   "parser/flex_handler.cc",
   "parser/flex_handler.h",
+  "parser/flow_tolerance_handler.cc",
+  "parser/flow_tolerance_handler.h",
   "parser/font_feature_settings_handler.cc",
   "parser/font_feature_settings_handler.h",
   "parser/font_length_handler.cc",

--- a/core/renderer/css/computed_css_style.cc
+++ b/core/renderer/css/computed_css_style.cc
@@ -4,6 +4,7 @@
 
 #include "core/renderer/css/computed_css_style.h"
 
+#include <limits>
 #include <utility>
 #include <vector>
 
@@ -17,6 +18,7 @@
 #include "core/build/gen/lynx_sub_error_code.h"
 #include "core/renderer/css/css_debug_msg.h"
 #include "core/renderer/css/css_style_utils.h"
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
 #include "core/renderer/starlight/style/css_type.h"
 #include "core/style/color.h"
 
@@ -691,7 +693,12 @@ ComputedCSSStyle::ComputedCSSStyle(float layouts_unit_per_px,
                       layouts_unit_per_px * DEFAULT_FONT_SIZE_DP,
                       layouts_unit_per_px * DEFAULT_FONT_SIZE_DP, LayoutUnit(),
                       LayoutUnit()),
-      caret_gradient_(DefaultCaretGradient()) {}
+      caret_gradient_(DefaultCaretGradient()) {
+  auto* grid_data = layout_computed_style_.grid_data_.Access();
+  grid_data->flow_tolerance_ =
+      NLength::MakeUnitNLength(length_context_.cur_node_font_size_);
+  grid_data->flow_tolerance_is_normal_ = true;
+}
 
 ComputedCSSStyle::ComputedCSSStyle(const ComputedCSSStyle& o)
     : layout_computed_style_(o.layout_computed_style_),
@@ -835,6 +842,10 @@ void ComputedCSSStyle::Reset() {
   const float default_font_size =
       length_context_.layouts_unit_per_px_ * DEFAULT_FONT_SIZE_DP;
   SetFontSize(default_font_size, default_font_size);
+  auto* grid_data = layout_computed_style_.grid_data_.Access();
+  grid_data->flow_tolerance_ =
+      NLength::MakeUnitNLength(length_context_.cur_node_font_size_);
+  grid_data->flow_tolerance_is_normal_ = true;
 }
 
 bool ComputedCSSStyle::SetValue(tasm::CSSPropertyID id,
@@ -1423,6 +1434,45 @@ bool ComputedCSSStyle::SetDisplay(const tasm::CSSValue& value,
       value, reset, layout_computed_style_.display_,
       DefaultLayoutStyle::SL_DEFAULT_DISPLAY, "display must be a enum!",
       parser_configs_);
+}
+
+bool ComputedCSSStyle::SetFlowTolerance(const tasm::CSSValue& value,
+                                        const bool reset) {
+  auto* grid_data = layout_computed_style_.grid_data_.Access();
+  auto& flow_tolerance = grid_data->flow_tolerance_;
+  const auto old_value = flow_tolerance;
+  const auto old_is_normal = grid_data->flow_tolerance_is_normal_;
+  if (reset) {
+    flow_tolerance =
+        NLength::MakeUnitNLength(length_context_.cur_node_font_size_);
+    grid_data->flow_tolerance_is_normal_ = true;
+  } else if (value.IsEnum()) {
+    const auto keyword = value.GetEnum<tasm::FlowToleranceHandler::Keyword>();
+    if (keyword == tasm::FlowToleranceHandler::Keyword::kNormal) {
+      flow_tolerance =
+          NLength::MakeUnitNLength(length_context_.cur_node_font_size_);
+      grid_data->flow_tolerance_is_normal_ = true;
+    } else if (keyword == tasm::FlowToleranceHandler::Keyword::kInfinite) {
+      flow_tolerance =
+          NLength::MakeUnitNLength(std::numeric_limits<float>::infinity());
+      grid_data->flow_tolerance_is_normal_ = false;
+    } else {
+      return false;
+    }
+  } else {
+    const auto parsed =
+        CSSStyleUtils::ToLength(value, length_context_, parser_configs_);
+    if (!parsed.second ||
+        (parsed.first.IsPercent() && parsed.first.GetRawValue() < 0) ||
+        (!parsed.first.ContainsPercentage() &&
+         parsed.first.NumericLength().GetFixedPart() < 0)) {
+      return false;
+    }
+    flow_tolerance = parsed.first;
+    grid_data->flow_tolerance_is_normal_ = false;
+  }
+  return old_value != flow_tolerance ||
+         old_is_normal != grid_data->flow_tolerance_is_normal_;
 }
 
 bool ComputedCSSStyle::SetLinearOrientation(const tasm::CSSValue& value,

--- a/core/renderer/css/computed_css_style.h
+++ b/core/renderer/css/computed_css_style.h
@@ -227,6 +227,10 @@ class ComputedCSSStyle {
     }
     length_context_.cur_node_font_size_ = cur_node_font_size;
     length_context_.root_node_font_size_ = root_node_font_size;
+    if (layout_computed_style_.grid_data_->flow_tolerance_is_normal_) {
+      layout_computed_style_.grid_data_.Access()->flow_tolerance_ =
+          NLength::MakeUnitNLength(cur_node_font_size);
+    }
     return true;
   }
 

--- a/core/renderer/css/computed_css_style_unittest.cc
+++ b/core/renderer/css/computed_css_style_unittest.cc
@@ -7,11 +7,14 @@
 
 #include "core/renderer/css/computed_css_style.h"
 
+#include <cmath>
+#include <limits>
 #include <unordered_set>
 #include <utility>
 #include <variant>
 
 #include "core/renderer/css/parser/css_string_parser.h"
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace lynx {
@@ -94,6 +97,78 @@ TEST(ComputedCSSStyleTest, ResetClearsOptionalStateAndDirtyBits) {
   EXPECT_TRUE(style.BackgroundColorToLepus().IsEmpty());
   EXPECT_TRUE(style.GetResolvedValues().empty());
   EXPECT_TRUE(style.IsClean());
+}
+
+TEST(ComputedCSSStyleTest, StoresAndResetsFlowTolerance) {
+  starlight::ComputedCSSStyle style{1.f, 1.f};
+  style.SetFontSize(20.f, DEFAULT_FONT_SIZE_DP);
+
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(20.f));
+
+  EXPECT_TRUE(style.SetValue(CSSPropertyID::kPropertyIDFlowTolerance,
+                             CSSValue(12.0, CSSValuePattern::PX), false));
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(12.f));
+  style.SetFontSize(24.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(12.f));
+
+  EXPECT_TRUE(style.SetValue(CSSPropertyID::kPropertyIDFlowTolerance,
+                             CSSValue(10.0, CSSValuePattern::PERCENT), false));
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakePercentageNLength(10.f));
+
+  EXPECT_TRUE(style.SetValue(
+      CSSPropertyID::kPropertyIDFlowTolerance,
+      CSSValue(tasm::FlowToleranceHandler::Keyword::kInfinite), false));
+  EXPECT_TRUE(std::isinf(
+      style.GetLayoutComputedStyle()->GetFlowTolerance().GetRawValue()));
+
+  EXPECT_TRUE(style.ResetValue(CSSPropertyID::kPropertyIDFlowTolerance));
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(24.f));
+
+  EXPECT_FALSE(style.SetValue(
+      CSSPropertyID::kPropertyIDFlowTolerance,
+      CSSValue(tasm::FlowToleranceHandler::Keyword::kNormal), false));
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(24.f));
+  style.SetFontSize(28.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(28.f));
+}
+
+TEST(ComputedCSSStyleTest, DirectFlowToleranceSetterTracksNormalState) {
+  starlight::ComputedCSSStyle style{1.f, 1.f};
+  style.SetFontSize(20.f, DEFAULT_FONT_SIZE_DP);
+  auto* layout_style = style.GetLayoutComputedStyle();
+
+  EXPECT_TRUE(layout_style->SetFlowTolerance(
+      starlight::NLength::MakeUnitNLength(14.f)));
+  style.SetFontSize(24.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_EQ(layout_style->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(14.f));
+
+  EXPECT_TRUE(layout_style->SetFlowTolerance(
+      starlight::NLength::MakePercentageNLength(10.f)));
+  style.SetFontSize(26.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_EQ(layout_style->GetFlowTolerance(),
+            starlight::NLength::MakePercentageNLength(10.f));
+
+  EXPECT_TRUE(
+      layout_style->SetFlowTolerance(starlight::NLength::MakeUnitNLength(
+          std::numeric_limits<float>::infinity())));
+  style.SetFontSize(27.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_TRUE(std::isinf(layout_style->GetFlowTolerance().GetRawValue()));
+
+  EXPECT_TRUE(
+      layout_style->SetFlowTolerance(layout_style->GetFlowTolerance(), true));
+  EXPECT_EQ(layout_style->GetFlowTolerance(),
+            starlight::DefaultLayoutStyle::SL_DEFAULT_FLOW_TOLERANCE());
+  style.SetFontSize(28.f, DEFAULT_FONT_SIZE_DP);
+  EXPECT_EQ(layout_style->GetFlowTolerance(),
+            starlight::NLength::MakeUnitNLength(28.f));
 }
 
 TEST(ComputedCSSStyleTest, StoresTextDecorationExtensionValues) {

--- a/core/renderer/css/css_decoder.cc
+++ b/core/renderer/css/css_decoder.cc
@@ -14,6 +14,7 @@
 #include "base/include/value/table.h"
 #include "core/build/gen/lynx_sub_error_code.h"
 #include "core/renderer/css/css_color.h"
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
 #include "core/style/timing_function_data.h"
 #include "core/style/transform_raw_data.h"
 
@@ -122,6 +123,14 @@ std::string CSSDecoder::CSSValueToString(const CSSPropertyID id,
 std::string CSSDecoder::CSSValueEnumToString(
     const CSSPropertyID id, const lynx::tasm::CSSValue &value) {
   switch (id) {
+    case lynx::tasm::kPropertyIDFlowTolerance:
+      switch (value.GetEnum<FlowToleranceHandler::Keyword>()) {
+        case FlowToleranceHandler::Keyword::kNormal:
+          return "normal";
+        case FlowToleranceHandler::Keyword::kInfinite:
+          return "infinite";
+      }
+      return "";
     case lynx::tasm::kPropertyIDTop:
     case lynx::tasm::kPropertyIDLeft:
     case lynx::tasm::kPropertyIDRight:

--- a/core/renderer/css/css_property_unittest.cc
+++ b/core/renderer/css/css_property_unittest.cc
@@ -4,6 +4,7 @@
 #include "core/renderer/css/css_property.h"
 
 #include "core/renderer/css/css_property_id.h"
+#include "core/renderer/css/layout_property.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace lynx {
@@ -137,6 +138,11 @@ TEST(CSSProperty, IsCustomProperty) {
   EXPECT_TRUE(CSSProperty::IsCustomProperty("--x", 3));
   EXPECT_FALSE(CSSProperty::IsCustomProperty("custom-property", 15));
   EXPECT_TRUE(CSSProperty::IsCustomProperty("--custom-property", 17));
+}
+
+TEST(CSSProperty, GridLanesPropertiesAreLayoutOnly) {
+  EXPECT_TRUE(LayoutProperty::IsLayoutOnly(kPropertyIDDisplay));
+  EXPECT_TRUE(LayoutProperty::IsLayoutOnly(kPropertyIDFlowTolerance));
 }
 }  // namespace test
 }  // namespace tasm

--- a/core/renderer/css/dynamic_css_styles_manager.cc
+++ b/core/renderer/css/dynamic_css_styles_manager.cc
@@ -61,6 +61,7 @@ const std::unordered_set<CSSPropertyID>& GetComplexDynamicProps(
           kPropertyIDGridAutoColumns,
           kPropertyIDGridTemplateRows,
           kPropertyIDGridTemplateColumns,
+          kPropertyIDFlowTolerance,
       });
 
   const static base::NoDestructor<std::unordered_set<CSSPropertyID>>
@@ -84,6 +85,7 @@ const std::unordered_set<CSSPropertyID>& GetComplexDynamicProps(
           kPropertyIDGridAutoColumns,
           kPropertyIDGridTemplateRows,
           kPropertyIDGridTemplateColumns,
+          kPropertyIDFlowTolerance,
           kPropertyIDFilter,
       });
   if (fix_filter_dynamic_update_bug) {

--- a/core/renderer/css/parser/BUILD.gn
+++ b/core/renderer/css/parser/BUILD.gn
@@ -38,6 +38,7 @@ unittest_set("css_parser_testset") {
     "filter_handler_unittest.cc",
     "flex_flow_handler_unittest.cc",
     "flex_handler_unittest.cc",
+    "flow_tolerance_handler_unittest.cc",
     "font_length_handler_unittest.cc",
     "four_sides_shorthand_handler_unittest.cc",
     "grid_shorthand_handler_unittest.cc",

--- a/core/renderer/css/parser/css_parser_configs.h
+++ b/core/renderer/css/parser/css_parser_configs.h
@@ -43,6 +43,7 @@ struct CSSParserConfigs {
         compile_options.enable_flex_basis_zero_percent_;
     config.enable_grid_placement_shorthands =
         compile_options.enable_grid_placement_shorthands_;
+    config.enable_grid_lanes = compile_options.enable_grid_lanes_;
     return config;
   }
   // default is disable.
@@ -56,6 +57,7 @@ struct CSSParserConfigs {
   bool enable_flex_basis_zero_percent = false;
   bool enable_new_time_handler = false;
   bool enable_grid_placement_shorthands = false;
+  bool enable_grid_lanes = false;
 };
 
 }  // namespace tasm

--- a/core/renderer/css/parser/css_string_parser.cc
+++ b/core/renderer/css/parser/css_string_parser.cc
@@ -25,6 +25,7 @@
 #include "core/renderer/css/css_color.h"
 #include "core/renderer/css/css_value.h"
 #include "core/renderer/css/parser/css_string_scanner.h"
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
 #include "core/renderer/css/unit_handler.h"
 #include "core/renderer/starlight/style/css_type.h"
 
@@ -251,6 +252,34 @@ void CSSStringParser::ParseLengthTo(CSSValue &target) {
   if (!AtEnd()) {
     target = CSSValue();
   }
+}
+
+CSSValue CSSStringParser::ParseFlowTolerance() {
+  Advance();
+  if (Check(TokenType::NORMAL)) {
+    Consume(TokenType::NORMAL);
+    return AtEnd() ? CSSValue(FlowToleranceHandler::Keyword::kNormal)
+                   : CSSValue();
+  }
+  if (Check(TokenType::INFINITE)) {
+    Consume(TokenType::INFINITE);
+    return AtEnd() ? CSSValue(FlowToleranceHandler::Keyword::kInfinite)
+                   : CSSValue();
+  }
+
+  Token token;
+  if (!LengthOrPercentageValue(token) || !AtEnd() ||
+      token.type == TokenType::AUTO || token.type == TokenType::ENV ||
+      token.type == TokenType::FIT_CONTENT ||
+      token.type == TokenType::MAX_CONTENT) {
+    return CSSValue();
+  }
+
+  CSSValue result = TokenToLength(token);
+  if (result.IsEmpty() || (!result.IsCalc() && result.GetNumber() < 0)) {
+    return CSSValue();
+  }
+  return result;
 }
 
 CSSValue CSSStringParser::ParseSingleBorderRadius() {

--- a/core/renderer/css/parser/css_string_parser.h
+++ b/core/renderer/css/parser/css_string_parser.h
@@ -197,6 +197,7 @@ class CSSStringParser final {
 
   CSSValue ParseLength();
   void ParseLengthTo(CSSValue& target);
+  CSSValue ParseFlowTolerance();
 
   CSSValue ParseListGap();
 

--- a/core/renderer/css/parser/enum_handler.cc
+++ b/core/renderer/css/parser/enum_handler.cc
@@ -65,6 +65,8 @@ static bool ToDisplayType(std::string_view str, int& result) {
     type = DisplayType::kBlock;
   } else if (str == "auto") {
     type = DisplayType::kAuto;
+  } else if (str == "grid-lanes") {
+    type = DisplayType::kGridLanes;
   } else {
     return false;
   }
@@ -806,6 +808,12 @@ HANDLER_IMPL() {
       break;
     default:
       break;
+  }
+
+  if (key == kPropertyIDDisplay &&
+      result == static_cast<int>(DisplayType::kGridLanes) &&
+      !configs.enable_grid_lanes) {
+    success = false;
   }
 
   CSS_HANDLER_FAIL_IF_NOT(success, configs.enable_css_strict_mode,

--- a/core/renderer/css/parser/enum_handler_unittest.cc
+++ b/core/renderer/css/parser/enum_handler_unittest.cc
@@ -62,6 +62,23 @@ TEST(EnumHandler, Handler) {
 
   // other cases see before @link{process}.
 }
+
+TEST(EnumHandler, GridLanesRequiresFeatureFlag) {
+  const auto id = CSSPropertyID::kPropertyIDDisplay;
+  const auto input = lepus::Value("grid-lanes");
+  StyleMap output;
+  CSSParserConfigs configs;
+
+  EXPECT_FALSE(UnitHandler::Process(id, input, output, configs));
+  EXPECT_TRUE(output.empty());
+
+  configs.enable_grid_lanes = true;
+  EXPECT_TRUE(UnitHandler::Process(id, input, output, configs));
+  ASSERT_TRUE(output.contains(id));
+  EXPECT_EQ(output[id].GetEnum<starlight::DisplayType>(),
+            starlight::DisplayType::kGridLanes);
+  EXPECT_EQ(static_cast<int>(starlight::DisplayType::kGridLanes), 7);
+}
 }  // namespace test
 
 }  // namespace tasm

--- a/core/renderer/css/parser/flow_tolerance_handler.cc
+++ b/core/renderer/css/parser/flow_tolerance_handler.cc
@@ -1,0 +1,43 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
+
+#include <utility>
+
+#include "core/renderer/css/parser/css_string_parser.h"
+#include "core/renderer/css/parser/length_handler.h"
+#include "core/renderer/css/unit_handler.h"
+
+namespace lynx {
+namespace tasm {
+namespace FlowToleranceHandler {
+
+HANDLER_IMPL() {
+  CSS_HANDLER_FAIL_IF_NOT(
+      configs.enable_grid_lanes, configs.enable_css_strict_mode,
+      TYPE_UNSUPPORTED, CSSProperty::GetPropertyNameCStr(key), input.CString())
+
+  CSSValue parsed;
+  if (input.IsString()) {
+    CSSStringParser parser = CSSStringParser::FromLepusString(input, configs);
+    parsed = parser.ParseFlowTolerance();
+  } else if (input.IsNumber()) {
+    parsed.SetValueAndPattern(input, CSSValuePattern::NUMBER);
+  }
+  CSS_HANDLER_FAIL_IF_NOT(
+      !parsed.IsEmpty() &&
+          (parsed.IsCalc() || parsed.IsEnum() || parsed.GetNumber() >= 0),
+      configs.enable_css_strict_mode, TYPE_UNSUPPORTED,
+      CSSProperty::GetPropertyNameCStr(key), input.CString())
+  LengthHandler::CheckLengthUnitValid(key, input, parsed, configs);
+  output.insert_or_assign(key, std::move(parsed));
+  return true;
+}
+
+HANDLER_REGISTER_IMPL() { array[kPropertyIDFlowTolerance] = &Handle; }
+
+}  // namespace FlowToleranceHandler
+}  // namespace tasm
+}  // namespace lynx

--- a/core/renderer/css/parser/flow_tolerance_handler.h
+++ b/core/renderer/css/parser/flow_tolerance_handler.h
@@ -1,0 +1,25 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef CORE_RENDERER_CSS_PARSER_FLOW_TOLERANCE_HANDLER_H_
+#define CORE_RENDERER_CSS_PARSER_FLOW_TOLERANCE_HANDLER_H_
+
+#include "core/renderer/css/parser/handler_defines.h"
+
+namespace lynx {
+namespace tasm {
+namespace FlowToleranceHandler {
+
+enum class Keyword : int32_t {
+  kNormal,
+  kInfinite,
+};
+
+HANDLER_REGISTER_DECLARE();
+
+}  // namespace FlowToleranceHandler
+}  // namespace tasm
+}  // namespace lynx
+
+#endif  // CORE_RENDERER_CSS_PARSER_FLOW_TOLERANCE_HANDLER_H_

--- a/core/renderer/css/parser/flow_tolerance_handler_unittest.cc
+++ b/core/renderer/css/parser/flow_tolerance_handler_unittest.cc
@@ -1,0 +1,119 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
+
+#include "core/renderer/css/computed_css_style.h"
+#include "core/renderer/css/css_decoder.h"
+#include "core/renderer/css/unit_handler.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace lynx {
+namespace tasm {
+namespace test {
+
+TEST(FlowToleranceHandler, RequiresGridLanesFlag) {
+  StyleMap output;
+  CSSParserConfigs configs;
+
+  EXPECT_FALSE(UnitHandler::Process(kPropertyIDFlowTolerance,
+                                    lepus::Value("12px"), output, configs));
+  EXPECT_TRUE(output.empty());
+}
+
+TEST(FlowToleranceHandler, ParsesAndRoundTripsSupportedValues) {
+  struct TestCase {
+    const char* input;
+    CSSValuePattern pattern;
+  };
+  constexpr TestCase kCases[] = {
+      {"12px", CSSValuePattern::PX},
+      {"10%", CSSValuePattern::PERCENT},
+      {"1", CSSValuePattern::NUMBER},
+      {"calc(10% - 1px)", CSSValuePattern::CALC},
+      {"normal", CSSValuePattern::ENUM},
+      {"infinite", CSSValuePattern::ENUM},
+  };
+
+  CSSParserConfigs configs;
+  configs.enable_grid_lanes = true;
+  for (const auto& test_case : kCases) {
+    StyleMap output;
+    ASSERT_TRUE(UnitHandler::Process(kPropertyIDFlowTolerance,
+                                     lepus::Value(test_case.input), output,
+                                     configs));
+    ASSERT_TRUE(output.contains(kPropertyIDFlowTolerance));
+    EXPECT_EQ(output[kPropertyIDFlowTolerance].GetPattern(), test_case.pattern);
+    EXPECT_EQ(CSSDecoder::CSSValueToString(kPropertyIDFlowTolerance,
+                                           output[kPropertyIDFlowTolerance]),
+              test_case.input);
+  }
+
+  StyleMap zero_output;
+  ASSERT_TRUE(UnitHandler::Process(kPropertyIDFlowTolerance, lepus::Value(0),
+                                   zero_output, configs));
+  EXPECT_EQ(zero_output[kPropertyIDFlowTolerance].GetPattern(),
+            CSSValuePattern::NUMBER);
+}
+
+TEST(FlowToleranceHandler, RejectsNegativeAndUnrelatedKeywords) {
+  CSSParserConfigs configs;
+  configs.enable_grid_lanes = true;
+
+  for (const char* invalid :
+       {"-1px", "-5%", "auto", "max-content", "normal extra", "infinite 1px",
+        "calc(1px) extra"}) {
+    StyleMap output;
+    EXPECT_FALSE(UnitHandler::Process(kPropertyIDFlowTolerance,
+                                      lepus::Value(invalid), output, configs));
+    EXPECT_TRUE(output.empty());
+  }
+
+  StyleMap number_output;
+  EXPECT_TRUE(UnitHandler::Process(kPropertyIDFlowTolerance, lepus::Value(1),
+                                   number_output, configs));
+  EXPECT_EQ(number_output[kPropertyIDFlowTolerance].GetPattern(),
+            CSSValuePattern::NUMBER);
+}
+
+TEST(FlowToleranceHandler, RejectsNegativeResolvedCalc) {
+  starlight::ComputedCSSStyle style{1.f, 1.f};
+  ASSERT_TRUE(style.SetValue(kPropertyIDFlowTolerance,
+                             CSSValue(12.0, CSSValuePattern::PX), false));
+
+  CSSParserConfigs configs;
+  configs.enable_grid_lanes = true;
+  for (const char* input : {"calc(-1px)", "calc(1px - 2px)"}) {
+    StyleMap output;
+    ASSERT_TRUE(UnitHandler::Process(kPropertyIDFlowTolerance,
+                                     lepus::Value(input), output, configs));
+    ASSERT_TRUE(output.contains(kPropertyIDFlowTolerance));
+    EXPECT_FALSE(style.SetValue(kPropertyIDFlowTolerance,
+                                output.at(kPropertyIDFlowTolerance), false));
+    EXPECT_EQ(style.GetLayoutComputedStyle()->GetFlowTolerance(),
+              starlight::NLength::MakeUnitNLength(12.f));
+  }
+}
+
+TEST(FlowToleranceHandler, PreservesPercentageDependentCalc) {
+  CSSParserConfigs configs;
+  configs.enable_grid_lanes = true;
+  StyleMap output;
+  ASSERT_TRUE(UnitHandler::Process(kPropertyIDFlowTolerance,
+                                   lepus::Value("calc(100% - 1px)"), output,
+                                   configs));
+
+  starlight::ComputedCSSStyle style{1.f, 1.f};
+  ASSERT_TRUE(style.SetValue(kPropertyIDFlowTolerance,
+                             output.at(kPropertyIDFlowTolerance), false));
+  const auto& tolerance = style.GetLayoutComputedStyle()->GetFlowTolerance();
+  EXPECT_TRUE(tolerance.IsCalc());
+  EXPECT_TRUE(tolerance.ContainsPercentage());
+  EXPECT_FLOAT_EQ(tolerance.NumericLength().GetFixedPart(), -1.f);
+  EXPECT_FLOAT_EQ(tolerance.NumericLength().GetPercentagePart(), 100.f);
+}
+
+}  // namespace test
+}  // namespace tasm
+}  // namespace lynx

--- a/core/renderer/css/unit_handler.cc
+++ b/core/renderer/css/unit_handler.cc
@@ -42,6 +42,7 @@
 #include "core/renderer/css/parser/filter_handler.h"
 #include "core/renderer/css/parser/flex_flow_handler.h"
 #include "core/renderer/css/parser/flex_handler.h"
+#include "core/renderer/css/parser/flow_tolerance_handler.h"
 #include "core/renderer/css/parser/font_feature_settings_handler.h"
 #include "core/renderer/css/parser/font_length_handler.h"
 #include "core/renderer/css/parser/font_variation_settings_handler.h"
@@ -215,6 +216,7 @@ UnitHandler::UnitHandler() {
   EnumHandler::Register(interceptors_);
   FlexFlowHandler::Register(interceptors_);
   FlexHandler::Register(interceptors_);
+  FlowToleranceHandler::Register(interceptors_);
   FontLengthHandler::Register(interceptors_);
   FourSidesShorthandHandler::Register(interceptors_);
   GridPositionHandler::Register(interceptors_);

--- a/core/renderer/starlight/event/layout_event.h
+++ b/core/renderer/starlight/event/layout_event.h
@@ -20,6 +20,7 @@ enum class LayoutEventType {
   LayoutStyleError,
   FeatureCountOnGridDisplay,
   FeatureCountOnRelativeDisplay,
+  FeatureCountOnGridLanesDisplay,
 };
 
 }

--- a/core/renderer/starlight/layout/layout_object.cc
+++ b/core/renderer/starlight/layout/layout_object.cc
@@ -592,7 +592,8 @@ bool LayoutObject::CanReuseLayoutWithSameSizeAsGivenConstraint(
       if (is_horizontal != css_style_->IsRow(configs_, attr_map())) {
         return false;
       }
-    } else if (display == DisplayType::kRelative) {
+    } else if (display == DisplayType::kRelative ||
+               display == DisplayType::kGridLanes) {
       return false;
     }
   }
@@ -723,6 +724,9 @@ FloatSize LayoutObject::UpdateMeasure(const Constraints& given_constraints,
       algorithm_ = new RelativeLayoutAlgorithm(this);
     } else if (type == DisplayType::kGrid) {
       SendLayoutEvent(LayoutEventType::FeatureCountOnGridDisplay);
+      algorithm_ = new GridLayoutAlgorithm(this);
+    } else if (type == DisplayType::kGridLanes) {
+      SendLayoutEvent(LayoutEventType::FeatureCountOnGridLanesDisplay);
       algorithm_ = new GridLayoutAlgorithm(this);
     }
 

--- a/core/renderer/starlight/style/default_layout_style.h
+++ b/core/renderer/starlight/style/default_layout_style.h
@@ -10,6 +10,7 @@
 #include "base/include/no_destructor.h"
 #include "core/renderer/starlight/style/css_type.h"
 #include "core/renderer/starlight/types/nlength.h"
+#include "core/renderer/tasm/config.h"
 
 #define CSS_UNDEFINED 0x7FFFFFF
 static constexpr float UNDEFINED = 10E20;
@@ -136,6 +137,10 @@ struct DefaultLayoutStyle {
   static const NLength SL_DEFAULT_RADIUS() { return SL_DEFAULT_ZEROLENGTH(); }
 
   static const NLength SL_DEFAULT_GRID_GAP() { return SL_DEFAULT_ZEROLENGTH(); }
+
+  static const NLength SL_DEFAULT_FLOW_TOLERANCE() {
+    return NLength::MakeUnitNLength(DEFAULT_FONT_SIZE_DP);
+  }
 
   static std::vector<NLength> SL_DEFAULT_GRID_TRACK() {
     static base::NoDestructor<std::vector<NLength>> l{std::vector<NLength>()};

--- a/core/renderer/starlight/style/grid_data.cc
+++ b/core/renderer/starlight/style/grid_data.cc
@@ -27,6 +27,8 @@ GridData::GridData()
           DefaultLayoutStyle::SL_DEFAULT_GRID_TRACK()),
       grid_column_gap_(DefaultLayoutStyle::SL_DEFAULT_GRID_GAP()),
       grid_row_gap_(DefaultLayoutStyle::SL_DEFAULT_GRID_GAP()),
+      flow_tolerance_(DefaultLayoutStyle::SL_DEFAULT_FLOW_TOLERANCE()),
+      flow_tolerance_is_normal_(true),
       justify_self_(DefaultLayoutStyle::SL_DEFAULT_JUSTIFY_SELF),
       justify_items_(DefaultLayoutStyle::SL_DEFAULT_JUSTIFY_ITEMS),
       grid_auto_flow_(DefaultLayoutStyle::SL_DEFAULT_GRID_AUTO_FLOW),
@@ -56,6 +58,8 @@ GridData::GridData(const GridData& data)
           data.grid_auto_rows_max_track_sizing_function_),
       grid_column_gap_(data.grid_column_gap_),
       grid_row_gap_(data.grid_row_gap_),
+      flow_tolerance_(data.flow_tolerance_),
+      flow_tolerance_is_normal_(data.flow_tolerance_is_normal_),
       justify_self_(data.justify_self_),
       justify_items_(data.justify_items_),
       grid_auto_flow_(data.grid_auto_flow_),
@@ -85,6 +89,8 @@ void GridData::Reset() {
       DefaultLayoutStyle::SL_DEFAULT_GRID_TRACK();
   grid_column_gap_ = DefaultLayoutStyle::SL_DEFAULT_GRID_GAP();
   grid_row_gap_ = DefaultLayoutStyle::SL_DEFAULT_GRID_GAP();
+  flow_tolerance_ = DefaultLayoutStyle::SL_DEFAULT_FLOW_TOLERANCE();
+  flow_tolerance_is_normal_ = true;
   justify_items_ = DefaultLayoutStyle::SL_DEFAULT_JUSTIFY_ITEMS;
   grid_auto_flow_ = DefaultLayoutStyle::SL_DEFAULT_GRID_AUTO_FLOW;
   grid_row_span_ = DefaultLayoutStyle::SL_DEFAULT_GRID_SPAN;

--- a/core/renderer/starlight/style/grid_data.h
+++ b/core/renderer/starlight/style/grid_data.h
@@ -42,6 +42,8 @@ class GridData : public fml::RefCountedThreadSafeStorage {
 
   NLength grid_column_gap_;
   NLength grid_row_gap_;
+  NLength flow_tolerance_;
+  bool flow_tolerance_is_normal_;
 
   JustifyType justify_self_;
   JustifyType justify_items_;

--- a/core/renderer/starlight/style/layout_computed_style.cc
+++ b/core/renderer/starlight/style/layout_computed_style.cc
@@ -79,6 +79,8 @@ DisplayType LayoutComputedStyle::GetDisplay(
     const LayoutConfigs& configs, const AttributesMap& attributes) const {
   const auto scroll = attributes.getScroll();
 
+  // Scroll containers retain the existing linear-layout override, including
+  // when their specified display value is grid-lanes.
   if (scroll.has_value() && *scroll && display_ != DisplayType::kNone) {
     return DisplayType::kLinear;
   }

--- a/core/renderer/starlight/style/layout_computed_style.h
+++ b/core/renderer/starlight/style/layout_computed_style.h
@@ -163,6 +163,9 @@ class LayoutComputedStyle {
     return grid_data_->grid_column_gap_;
   }
   const NLength& GetGridRowGap() const { return grid_data_->grid_row_gap_; }
+  const NLength& GetFlowTolerance() const {
+    return grid_data_->flow_tolerance_;
+  }
   GridAutoFlowType GetGridAutoFlow() const {
     return grid_data_->grid_auto_flow_;
   }
@@ -354,6 +357,18 @@ class LayoutComputedStyle {
   }
   SUPPORTED_LAYOUT_PROPERTY(SET_LAYOUT_PROPERTY)
 #undef SET_LAYOUT_PROPERTY
+
+  LYNX_EXPORT bool SetFlowTolerance(const NLength& value,
+                                    const bool reset = false) {
+    auto* grid_data = grid_data_.Access();
+    const NLength old_value = grid_data->flow_tolerance_;
+    const bool old_is_normal = grid_data->flow_tolerance_is_normal_;
+    grid_data->flow_tolerance_ =
+        reset ? DefaultLayoutStyle::SL_DEFAULT_FLOW_TOLERANCE() : value;
+    grid_data->flow_tolerance_is_normal_ = reset;
+    return old_value != grid_data->flow_tolerance_ ||
+           old_is_normal != grid_data->flow_tolerance_is_normal_;
+  }
 
   float PhysicalPixelsPerLayoutUnit() const {
     return physical_pixels_per_layout_unit_;

--- a/core/renderer/ui_wrapper/layout/layout_context.cc
+++ b/core/renderer/ui_wrapper/layout/layout_context.cc
@@ -1204,6 +1204,10 @@ void LayoutContext::OnLayoutEvent(const starlight::LayoutObject* node,
       tasm::report::FeatureCounter::Instance()->Count(
           tasm::report::LynxFeature::CPP_USE_GRID_DISPLAY);
     } break;
+    case starlight::LayoutEventType::FeatureCountOnGridLanesDisplay: {
+      tasm::report::FeatureCounter::Instance()->Count(
+          tasm::report::LynxFeature::CPP_USE_GRID_LANES_DISPLAY);
+    } break;
     case starlight::LayoutEventType::FeatureCountOnRelativeDisplay: {
       tasm::report::FeatureCounter::Instance()->Count(
           tasm::report::LynxFeature::CPP_USE_RELATIVE_DISPLAY);

--- a/core/runtime/lepus/bindings/renderer_functions.cc
+++ b/core/runtime/lepus/bindings/renderer_functions.cc
@@ -969,6 +969,7 @@ RENDERER_FUNCTION_CC(LoadStyleSheet) {
         page_config->GetEnableFlexBasisZeroPercent();
     bundle_options.enable_grid_placement_shorthands_ =
         page_config->GetEnableGridPlacementShorthands();
+    bundle_options.enable_grid_lanes_ = page_config->GetEnableGridLanes();
     bundle_options.enable_css_rule_ = page_config->GetEnableCSSRule();
   }
 

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder.cc
@@ -220,6 +220,7 @@ void LynxBinaryConfigDecoder::UpdateCSSConfigs(
       page_config->GetEnableFlexBasisZeroPercent();
   compile_options_.enable_grid_placement_shorthands_ =
       page_config->GetEnableGridPlacementShorthands();
+  compile_options_.enable_grid_lanes_ = page_config->GetEnableGridLanes();
   compile_options_.enable_css_rule_ = page_config->GetEnableCSSRule();
   auto configs =
       CSSParserConfigs::GetCSSParserConfigsByComplierOptions(compile_options_);

--- a/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder_unittest.cc
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_binary_config_decoder_unittest.cc
@@ -211,6 +211,27 @@ TEST_F(LynxBinaryConfigDecoderTest,
   EXPECT_EQ(output[kPropertyIDGridColumnEnd].AsNumber(), 4);
 }
 
+TEST_F(LynxBinaryConfigDecoderTest, ReadEnableGridLanes) {
+  EXPECT_FALSE(page_config_->GetEnableGridLanes());
+  EXPECT_FALSE(page_config_->GetCSSParserConfigs().enable_grid_lanes);
+
+  StyleMap output;
+  EXPECT_FALSE(UnitHandler::Process(kPropertyIDDisplay,
+                                    lepus::Value("grid-lanes"), output,
+                                    page_config_->GetCSSParserConfigs()));
+  EXPECT_TRUE(output.empty());
+
+  config_decoder_->DecodePageConfig("{\n  \"enableGridLanes\" : true\n}",
+                                    page_config_);
+  EXPECT_TRUE(page_config_->GetEnableGridLanes());
+  EXPECT_TRUE(page_config_->GetCSSParserConfigs().enable_grid_lanes);
+
+  EXPECT_TRUE(UnitHandler::Process(kPropertyIDDisplay,
+                                   lepus::Value("grid-lanes"), output,
+                                   page_config_->GetCSSParserConfigs()));
+  EXPECT_TRUE(output.contains(kPropertyIDDisplay));
+}
+
 TEST_F(LynxBinaryConfigDecoderTest, EnableLayoutOnlyEventThrough) {
   EXPECT_FALSE(page_config_->GetEnableLayoutOnlyEventThrough());
 
@@ -285,6 +306,7 @@ TEST_F(LynxBinaryConfigDecoderTest, CompileOptionsPropagatesDerivedCSSFlags) {
   EXPECT_FALSE(options.enable_parse_int_flex_);
   EXPECT_FALSE(options.enable_flex_basis_zero_percent_);
   EXPECT_FALSE(options.enable_grid_placement_shorthands_);
+  EXPECT_FALSE(options.enable_grid_lanes_);
 
   auto decoder =
       std::make_unique<LynxBinaryConfigDecoder>(options, "3.2", true, false);
@@ -293,13 +315,15 @@ TEST_F(LynxBinaryConfigDecoderTest, CompileOptionsPropagatesDerivedCSSFlags) {
       "{\n"
       "  \"enableParseIntFlex\": true,\n"
       "  \"enableFlexBasisZeroPercent\": true,\n"
-      "  \"enableGridPlacementShorthands\": true\n"
+      "  \"enableGridPlacementShorthands\": true,\n"
+      "  \"enableGridLanes\": true\n"
       "}",
       page_config_);
 
   EXPECT_TRUE(options.enable_parse_int_flex_);
   EXPECT_TRUE(options.enable_flex_basis_zero_percent_);
   EXPECT_TRUE(options.enable_grid_placement_shorthands_);
+  EXPECT_TRUE(options.enable_grid_lanes_);
 }
 
 }  // namespace test

--- a/core/template_bundle/template_codec/binary_decoder/lynx_config.yml
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_config.yml
@@ -1695,6 +1695,17 @@ enableGridPlacementShorthands:
   author: renzhongyue
   since: '3.9'
   export: true
+enableGridLanes:
+  description: Controls whether the CSS parser accepts display grid-lanes and the flow-tolerance property.
+  defaultValue: 'false'
+  valueType: bool
+  author: Huxpro
+  since: '4.3'
+  supportPlatform:
+    - Android
+    - HarmonyOS
+    - iOS
+  export: true
 enableFlexBasisZeroPercent:
   description: When enabled, flex-basis defaults to 0% instead of 0 when omitted in flex shorthand, matching web browser behavior.
   defaultValue: 'false'

--- a/core/template_bundle/template_codec/binary_decoder/lynx_config_decoder.h
+++ b/core/template_bundle/template_codec/binary_decoder/lynx_config_decoder.h
@@ -798,6 +798,11 @@ class LynxConfigDecoder final {
       page_config->SetEnableGridPlacementShorthands(true);
     }
 
+    if (doc.HasMember(config::kEnableGridLanes) &&
+        doc[config::kEnableGridLanes].IsBool()) {
+      page_config->SetEnableGridLanes(doc[config::kEnableGridLanes].GetBool());
+    }
+
     if (doc.HasMember(config::kEnableFlexBasisZeroPercent) &&
         doc[config::kEnableFlexBasisZeroPercent].IsBool()) {
       page_config->SetEnableFlexBasisZeroPercent(

--- a/core/template_bundle/template_codec/binary_encoder/css_encoder/css_parser_token_unittest.cc
+++ b/core/template_bundle/template_codec/binary_encoder/css_encoder/css_parser_token_unittest.cc
@@ -12,6 +12,7 @@
 #include "core/base/thread/once_task.h"
 #include "core/base/threading/task_runner_manufactor.h"
 #include "core/renderer/starlight/style/css_type.h"
+#include "core/template_bundle/template_codec/generator/page_config_compile_options_helper.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "third_party/rapidjson/document.h"
 
@@ -310,6 +311,58 @@ TEST(CSSParseTokenEncoder, ImportantParsing) {
                 .find(tasm::kPropertyIDWidth)
                 ->second.GetPattern(),
             tasm::CSSValuePattern::PX);
+}
+
+TEST(CSSParseTokenEncoder, GridLanesPropertiesRequireFeatureFlag) {
+  rapidjson::Document doc;
+  doc.SetObject();
+  rapidjson::Value style(rapidjson::kArrayType);
+  for (const auto& [name, value] : {std::pair{"display", "grid-lanes"},
+                                    std::pair{"flow-tolerance", "12px"}}) {
+    rapidjson::Value entry(rapidjson::kObjectType);
+    entry.AddMember("name", rapidjson::Value(name, doc.GetAllocator()),
+                    doc.GetAllocator());
+    entry.AddMember("value", rapidjson::Value(value, doc.GetAllocator()),
+                    doc.GetAllocator());
+    style.PushBack(entry, doc.GetAllocator());
+  }
+
+  rapidjson::Value style_vars(rapidjson::kObjectType);
+  tasm::CompileOptions options;
+  options.enable_css_parser_ = true;
+  options.target_sdk_version_ = "4.3";
+  std::string rule = ".test";
+
+  encoder::CSSParseToken disabled(style, rule, "", style_vars, options);
+  EXPECT_FALSE(disabled.GetAttributes().contains(tasm::kPropertyIDDisplay));
+  EXPECT_FALSE(
+      disabled.GetAttributes().contains(tasm::kPropertyIDFlowTolerance));
+
+  options.enable_grid_lanes_ = true;
+  encoder::CSSParseToken enabled(style, rule, "", style_vars, options);
+  ASSERT_TRUE(enabled.GetAttributes().contains(tasm::kPropertyIDDisplay));
+  EXPECT_EQ(enabled.GetAttributes()
+                .find(tasm::kPropertyIDDisplay)
+                ->second.GetEnum<starlight::DisplayType>(),
+            starlight::DisplayType::kGridLanes);
+  ASSERT_TRUE(enabled.GetAttributes().contains(tasm::kPropertyIDFlowTolerance));
+  EXPECT_EQ(enabled.GetAttributes()
+                .find(tasm::kPropertyIDFlowTolerance)
+                ->second.GetPattern(),
+            tasm::CSSValuePattern::PX);
+}
+
+TEST(CSSParseTokenEncoder, GridLanesFlagComesFromPageConfig) {
+  tasm::CompileOptions options;
+  EXPECT_FALSE(options.enable_grid_lanes_);
+
+  tasm::ApplyPageConfigDerivedCompileOptions(options,
+                                             R"({"enableGridLanes":true})");
+
+  EXPECT_TRUE(options.enable_grid_lanes_);
+  EXPECT_TRUE(
+      tasm::CSSParserConfigs::GetCSSParserConfigsByComplierOptions(options)
+          .enable_grid_lanes);
 }
 
 }  // namespace encoder

--- a/core/template_bundle/template_codec/compile_options.h
+++ b/core/template_bundle/template_codec/compile_options.h
@@ -112,6 +112,7 @@ struct CompileOptions {
   bool enable_parse_int_flex_{false};
   bool enable_flex_basis_zero_percent_{false};
   bool enable_grid_placement_shorthands_{false};
+  bool enable_grid_lanes_{false};
   bool enable_css_rule_{false};
 };
 

--- a/core/template_bundle/template_codec/generator/page_config_compile_options_helper.h
+++ b/core/template_bundle/template_codec/generator/page_config_compile_options_helper.h
@@ -31,6 +31,12 @@ inline void ApplyPageConfigDerivedCompileOptions(
         doc[config::kEnableParseIntFlex].GetBool();
   }
 
+  if (doc.HasMember(config::kEnableGridLanes) &&
+      doc[config::kEnableGridLanes].IsBool()) {
+    compile_options.enable_grid_lanes_ =
+        doc[config::kEnableGridLanes].GetBool();
+  }
+
   if (doc.HasMember(config::kEnableCSSRule) &&
       doc[config::kEnableCSSRule].IsBool()) {
     bool v = doc[config::kEnableCSSRule].GetBool();

--- a/devtool/lynx_devtool/element/inspector_css_helper.cc
+++ b/devtool/lynx_devtool/element/inspector_css_helper.cc
@@ -404,6 +404,7 @@ bool InspectorCSSHelper::IsLegal(const std::string& name,
   }
 
   lynx::tasm::CSSParserConfigs configs;
+  configs.enable_grid_lanes = true;
   lynx::tasm::CSSStringParser variable_parser{
       value.c_str(), static_cast<uint32_t>(value.length()), configs};
   if (variable_parser.ParseVariable().IsVariable()) {

--- a/devtool/lynx_devtool/element/inspector_css_helper_unittest.cc
+++ b/devtool/lynx_devtool/element/inspector_css_helper_unittest.cc
@@ -194,6 +194,17 @@ TEST(InspectorCSSHelperTest, IsLegalTest) {
 
   std::string name4 = "outline-width", value4 = "blue";
   EXPECT_FALSE(lynx::devtool::InspectorCSSHelper::IsLegal(name4, value4));
+
+  EXPECT_TRUE(
+      lynx::devtool::InspectorCSSHelper::IsLegal("display", "grid-lanes"));
+  EXPECT_TRUE(
+      lynx::devtool::InspectorCSSHelper::IsLegal("flow-tolerance", "normal"));
+  EXPECT_TRUE(
+      lynx::devtool::InspectorCSSHelper::IsLegal("flow-tolerance", "infinite"));
+  EXPECT_TRUE(
+      lynx::devtool::InspectorCSSHelper::IsLegal("flow-tolerance", "10%"));
+  EXPECT_FALSE(
+      lynx::devtool::InspectorCSSHelper::IsLegal("flow-tolerance", "-1px"));
 }
 
 TEST(InspectorCSSHelperTest, IsAnimationLegalTest) {

--- a/js_libraries/type-config/config-keys.js
+++ b/js_libraries/type-config/config-keys.js
@@ -21,6 +21,7 @@ const configKeys = [
   'enableFetchAPIStandardStreaming',
   'enableFixedNew',
   'enableFlexBasisZeroPercent',
+  'enableGridLanes',
   'enableGridPlacementShorthands',
   'enableJsBindingApiThrowException',
   'enableLayoutOnlyEventThrough',

--- a/js_libraries/type-config/test/index.test-d.ts
+++ b/js_libraries/type-config/test/index.test-d.ts
@@ -25,6 +25,7 @@ describe('Test Config Types', () => {
     expectTypeOf<Config>().toHaveProperty('enableFetchAPIStandardStreaming').toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Config>().toHaveProperty('enableFixedNew').toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Config>().toHaveProperty('enableFlexBasisZeroPercent').toEqualTypeOf<boolean | undefined>();
+    expectTypeOf<Config>().toHaveProperty('enableGridLanes').toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Config>().toHaveProperty('enableGridPlacementShorthands').toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Config>().toHaveProperty('enableJsBindingApiThrowException').toEqualTypeOf<boolean | undefined>();
     expectTypeOf<Config>().toHaveProperty('enableLayoutOnlyEventThrough').toEqualTypeOf<boolean | undefined>();

--- a/js_libraries/type-config/test/index.test.js
+++ b/js_libraries/type-config/test/index.test.js
@@ -18,7 +18,7 @@ describe('type-config index', () => {
     expect(compilerOptionsKeys).toEqual([]);
   });
   it('should have correct configKeys', () => {
-    expect(configKeys.length).toBe(36);
+    expect(configKeys.length).toBe(37);
     expect(configKeys).toEqual([
       'alignMouseEventWithW3C',
       'disableLongpressAfterScroll',
@@ -34,6 +34,7 @@ describe('type-config index', () => {
       'enableFetchAPIStandardStreaming',
       'enableFixedNew',
       'enableFlexBasisZeroPercent',
+      'enableGridLanes',
       'enableGridPlacementShorthands',
       'enableJsBindingApiThrowException',
       'enableLayoutOnlyEventThrough',

--- a/js_libraries/type-config/types/config.d.ts
+++ b/js_libraries/type-config/types/config.d.ts
@@ -182,6 +182,19 @@ export interface Config {
   enableFlexBasisZeroPercent?: boolean;
 
   /**
+   * Controls whether the CSS parser accepts display grid-lanes and the flow-tolerance property.
+   *
+   * @Android
+   * @Harmony
+   * @iOS
+   *
+   * Since: LynxSDK 4.3
+   *
+   * @defaultValue false
+   */
+  enableGridLanes?: boolean;
+
+  /**
    * Controls whether the CSS parser accepts grid-column and grid-row shorthand syntax. When enabled, grid shorthand handlers parse placement shorthands into style values; when disabled, those shorthand declarations are rejected.
    *
    * @Android

--- a/js_libraries/types/CHANGELOG.md
+++ b/js_libraries/types/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 4.3.4
+- Add `display: grid-lanes` and `flow-tolerance` CSS typings.
+
 ## 4.3.3
 - Add `border-radius` and its four physical corner longhands to `transition-property` typings.
 

--- a/js_libraries/types/package.json
+++ b/js_libraries/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/types",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "",
   "keywords": [
     "lynx",

--- a/js_libraries/types/types/common/csstype.d.ts
+++ b/js_libraries/types/types/common/csstype.d.ts
@@ -11,7 +11,7 @@ export type CSSProperties = Modify<
   {
     position?: 'absolute' | 'relative' | 'fixed' | 'sticky';
     boxSizing?: 'border-box' | 'content-box' | 'auto';
-    display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto';
+    display?: 'none' | 'flex' | 'grid' | 'linear' | 'relative' | 'block' | 'auto' | 'grid-lanes';
     overflow?: 'hidden' | 'visible' | (string & {});
     whiteSpace?: 'normal' | 'nowrap';
     textAlign?: 'left' | 'center' | 'right' | 'start' | 'end';
@@ -112,6 +112,7 @@ export type CSSProperties = Modify<
     XCaretHeight?: number | (string & {});
     XCaretRadius?: number | (string & {});
     pointerEvents?: 'auto' | 'none';
+    flowTolerance?: 'normal' | 'infinite' | (string & {});
   }
 >;
 

--- a/oliver/lynx-tasm/CHANGELOG.md
+++ b/oliver/lynx-tasm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 0.0.53
+* Support encoding `display: grid-lanes` and the `flow-tolerance` CSS property.
+
 # 0.0.52
 * Support serializing decoded CSS descriptors into CSS text.
 

--- a/oliver/lynx-tasm/package.json
+++ b/oliver/lynx-tasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/tasm",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/tools/css_generator/CHANGELOG.md
+++ b/tools/css_generator/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.19
+- Add the experimental `display: grid-lanes` value and `flow-tolerance` CSS property.
+
 ## 0.0.18
 - Add compat data for `border-radius` animations and the four physical corner longhands in `transition-property`.
 

--- a/tools/css_generator/css_defines/237-flow-tolerance.json
+++ b/tools/css_generator/css_defines/237-flow-tolerance.json
@@ -1,0 +1,48 @@
+{
+  "name": "flow-tolerance",
+  "id": 237,
+  "type": "complex",
+  "default_value": "normal",
+  "version": "4.3",
+  "author": "lynx",
+  "consumption_status": "layout-only",
+  "desc": "The `flow-tolerance` property controls how far grid-lanes items may shift between lanes. It only applies when `display: grid-lanes` is enabled.",
+  "keywords": ["normal", "infinite"],
+  "formal_syntax": "normal | <length-percentage [0,\u221e]> | infinite",
+  "is_shorthand": false,
+  "compat_data": {
+    "flow-tolerance": {
+      "__compat": {
+        "lynx_path": "api/css/properties/flow-tolerance",
+        "spec_url": "https://drafts.csswg.org/css-grid-3/#propdef-flow-tolerance",
+        "status": {
+          "deprecated": false,
+          "experimental": true
+        },
+        "support": {
+          "android": {
+            "version_added": "4.3"
+          },
+          "ios": {
+            "version_added": "4.3"
+          },
+          "harmony": {
+            "version_added": "4.3"
+          },
+          "clay_android": {
+            "version_added": "4.3"
+          },
+          "clay_macos": {
+            "version_added": "4.3"
+          },
+          "clay_windows": {
+            "version_added": "4.3"
+          },
+          "web_lynx": {
+            "version_added": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/css_generator/css_defines/24-display.json
+++ b/tools/css_generator/css_defines/24-display.json
@@ -42,6 +42,11 @@
       "value": "auto",
       "version": "2.0",
       "desc": "lynx: flex, w3c block"
+    },
+    {
+      "value": "grid-lanes",
+      "version": "4.3",
+      "desc": "Creates a grid-lanes formatting context when enableGridLanes is enabled."
     }
   ],
   "compat_data": {
@@ -194,6 +199,38 @@
           }
         }
       },
+      "grid-lanes": {
+        "__compat": {
+          "description": "<code>grid-lanes</code>",
+          "status": {
+            "deprecated": false,
+            "experimental": true
+          },
+          "support": {
+            "android": {
+              "version_added": "4.3"
+            },
+            "ios": {
+              "version_added": "4.3"
+            },
+            "harmony": {
+              "version_added": "4.3"
+            },
+            "clay_android": {
+              "version_added": "4.3"
+            },
+            "clay_macos": {
+              "version_added": "4.3"
+            },
+            "clay_windows": {
+              "version_added": "4.3"
+            },
+            "web_lynx": {
+              "version_added": false
+            }
+          }
+        }
+      },
       "unsupported_value": {
         "__compat": {
           "description": "<code>inline</code> and <code>block</code>",
@@ -237,5 +274,5 @@
     }
   },
   "is_shorthand": false,
-  "formal_syntax": "flex | linear | none | grid | relative"
+  "formal_syntax": "flex | linear | none | grid | grid-lanes | relative"
 }

--- a/tools/css_generator/css_parser_generator.py
+++ b/tools/css_generator/css_parser_generator.py
@@ -104,6 +104,7 @@ def check_and_get_defines():
     # Overwrite property_index.json when all check passed
     with open(os.path.join("./", "property_index.json"), "w", encoding="utf-8") as f:
         json.dump(mid_json, f, ensure_ascii=False, indent=4)
+        f.write("\n")
 
     # Return combined_data
     combined_data = []

--- a/tools/css_generator/package.json
+++ b/tools/css_generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/css-defines",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Property definitions of Lynx Styling module",
   "scripts": {
     "gen:types": "ts-node scripts/generate-types.ts",

--- a/tools/css_generator/property_index.json
+++ b/tools/css_generator/property_index.json
@@ -1,6 +1,6 @@
 [
     {
-        "count": 236
+        "count": 237
     },
     {
         "id": 1,
@@ -945,5 +945,9 @@
     {
         "id": 236,
         "name": "-x-text-decoration-gap"
+    },
+    {
+        "id": 237,
+        "name": "flow-tolerance"
     }
 ]

--- a/tools/css_generator/utils.py
+++ b/tools/css_generator/utils.py
@@ -621,6 +621,9 @@ namespace LengthHandler {
 
 bool Handle(CSSPropertyID key, const lepus::Value &input, StyleMap &output,
             const CSSParserConfigs &configs);
+void CheckLengthUnitValid(CSSPropertyID key, const lepus::Value &input,
+                          const CSSValue &css_value,
+                          const CSSParserConfigs &configs);
 // help parse length css
 bool Process(const lepus::Value &input, CSSValue &css_value,
              const CSSParserConfigs &configs);

--- a/tools/feature_count/specification.yaml
+++ b/tools/feature_count/specification.yaml
@@ -46,6 +46,7 @@ cpp:
   - disable_standard_css_selector
   - enable_native_list_from_env
   - element_from_binary
+  - use_grid_lanes_display
 typescript:
   - bundle_support_load_script
 objc:


### PR DESCRIPTION
## Summary
- append `display: grid-lanes` and property ID 237 `flow-tolerance`
- propagate `enableGridLanes` through parser, runtime, encoder, and generated config paths
- add computed-style storage, dynamic re-resolution, feature counting, types, and release metadata

Closes #8617

## Stack
- follows M0: #8625
- next layer remains isolated in the contributor fork until this PR lands

## Validation
- CSS parser: 227/227
- encoder: 86/86
- binary config decoder: 19/19
- Starlight: 28/28
- feasible CSS suite: 785/785
- DevTool: 52/52
- type-config: 7/7; types: 85/85
