### PR TITLE
[BugFix][Autolink] Regenerate registry when manifests change

### DIFF
--- a/platform/android/lynx_library_plugin/src/main/groovy/org/lynxsdk/library/LynxLibraryBuildPlugin.groovy
+++ b/platform/android/lynx_library_plugin/src/main/groovy/org/lynxsdk/library/LynxLibraryBuildPlugin.groovy
@@ -7,6 +7,7 @@ package org.lynxsdk.library
 import org.gradle.api.Plugin
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.compile.JavaCompile
 
 class LynxLibraryBuildPlugin implements Plugin<Project> {
@@ -73,6 +74,9 @@ class LynxLibraryBuildPlugin implements Plugin<Project> {
         File generatedDir = new File(
             project.buildDir, "generated/source/lynxLibraryRegistry/${variantName}")
         def taskProvider = project.tasks.register(taskName) { task ->
+            task.inputs.files(libraries.collect { it.manifestFile })
+                .withPropertyName('lynxLibraryManifests')
+                .withPathSensitivity(PathSensitivity.RELATIVE)
             task.outputs.dir(generatedDir)
             task.doLast {
                 File packageDir = new File(generatedDir,

--- a/platform/android/lynx_library_plugin/src/test/groovy/org/lynxsdk/library/LynxLibraryBuildPluginTest.groovy
+++ b/platform/android/lynx_library_plugin/src/test/groovy/org/lynxsdk/library/LynxLibraryBuildPluginTest.groovy
@@ -1,0 +1,138 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+package org.lynxsdk.library
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+class LynxLibraryBuildPluginTest {
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void regeneratesRegistryWhenManifestChanges() {
+        File projectDir = temporaryFolder.newFolder('app')
+        writeFakeAndroidPlugin(projectDir)
+        new File(projectDir, 'settings.gradle').text = "rootProject.name = 'test-app'\n"
+        new File(projectDir, 'build.gradle').text = '''
+          plugins {
+            id 'com.android.application'
+            id 'org.lynxsdk.lynx.library-build'
+          }
+        '''.stripIndent()
+
+        File packageDir = new File(projectDir, 'node_modules/demo-library')
+        new File(packageDir, 'android').mkdirs()
+        new File(packageDir, 'android/build.gradle').text = ''
+        File manifest = new File(packageDir, 'lynx.lib.json')
+        manifest.text = manifestFor('com.example.initial')
+
+        BuildResult firstBuild = runRegistryTask(projectDir)
+
+        assertEquals(TaskOutcome.SUCCESS,
+            firstBuild.task(':generateDebugLynxLibraryRegistry').outcome)
+        File generatedRegistry = new File(projectDir,
+            'build/generated/source/lynxLibraryRegistry/debug/' +
+                'com/lynx/tasm/library/LynxAutolinkGenerated.java')
+        assertTrue(generatedRegistry.text.contains(
+            'com.example.initial.LynxLibraryProviderImpl'))
+
+        manifest.text = manifestFor('com.example.renamed')
+        BuildResult secondBuild = runRegistryTask(projectDir)
+
+        assertEquals(TaskOutcome.SUCCESS,
+            secondBuild.task(':generateDebugLynxLibraryRegistry').outcome)
+        assertFalse(generatedRegistry.text.contains(
+            'com.example.initial.LynxLibraryProviderImpl'))
+        assertTrue(generatedRegistry.text.contains(
+            'com.example.renamed.LynxLibraryProviderImpl'))
+    }
+
+    private static BuildResult runRegistryTask(File projectDir) {
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withPluginClasspath()
+            .withArguments('generateDebugLynxLibraryRegistry', '--stacktrace')
+            .build()
+    }
+
+    private static String manifestFor(String packageName) {
+        """{
+          "platforms": {
+            "android": {
+              "packageName": "${packageName}",
+              "sourceDir": "android"
+            }
+          }
+        }"""
+    }
+
+    private static void writeFakeAndroidPlugin(File projectDir) {
+        File buildSrc = new File(projectDir, 'buildSrc')
+        new File(buildSrc, 'src/main/groovy').mkdirs()
+        new File(buildSrc, 'build.gradle').text = '''
+          plugins {
+            id 'groovy'
+            id 'java-gradle-plugin'
+          }
+
+          dependencies {
+            implementation gradleApi()
+            implementation localGroovy()
+          }
+
+          gradlePlugin {
+            plugins {
+              fakeAndroidApplication {
+                id = 'com.android.application'
+                implementationClass = 'FakeAndroidApplicationPlugin'
+              }
+            }
+          }
+        '''.stripIndent()
+        new File(buildSrc,
+            'src/main/groovy/FakeAndroidApplicationPlugin.groovy').text = '''
+          import org.gradle.api.Plugin
+          import org.gradle.api.Project
+          import org.gradle.api.Task
+
+          class FakeAndroidApplicationPlugin implements Plugin<Project> {
+            @Override
+            void apply(Project project) {
+              project.extensions.add('android', new FakeAndroidExtension())
+            }
+          }
+
+          class FakeAndroidExtension {
+            final FakeApplicationVariants applicationVariants =
+                new FakeApplicationVariants()
+          }
+
+          class FakeApplicationVariants {
+            private final List<FakeAndroidVariant> variants = [
+              new FakeAndroidVariant(name: 'debug')
+            ]
+
+            void all(Closure action) {
+              variants.each(action)
+            }
+          }
+
+          class FakeAndroidVariant {
+            String name
+
+            void registerJavaGeneratingTask(Task task, File generatedDir) {}
+          }
+        '''.stripIndent()
+    }
+}


### PR DESCRIPTION
## Summary

- Declare every discovered `lynx.lib.json` manifest as an input of the generated registry task.
- Use relative path sensitivity so manifest content changes invalidate the task without depending on absolute checkout paths.
- Add a Gradle TestKit regression test for renaming a provider package between incremental builds.

## Root Cause

The registry generation task only declared its generated source directory as an output. Gradle therefore considered the task up-to-date after a library manifest changed, leaving `LynxAutolinkGenerated.java` with the previous provider list until a clean build removed the output.

## Validation

- All `lynx_library_plugin` unit tests passed.
- A Gradle 8.7 consumer project regenerated the registry without `clean` after changing the manifest package name.
- Gradle reported `lynxLibraryManifests` as the changed input, and the generated provider changed from the old package to the renamed package.
