### PR TITLE
[BugFix][Android] Support 16KB page size in image service via Fresco 3.7

### DIFF
--- a/explorer/android/lynx_explorer/build.gradle
+++ b/explorer/android/lynx_explorer/build.gradle
@@ -139,11 +139,11 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.core:core:1.6.0'
-    implementation 'com.facebook.fresco:fresco:2.3.0'
-    implementation 'com.facebook.fresco:animated-gif:2.3.0'
-    implementation 'com.facebook.fresco:animated-webp:2.3.0'
-    implementation 'com.facebook.fresco:webpsupport:2.3.0'
-    implementation 'com.facebook.fresco:animated-base:2.3.0'
+    implementation 'com.facebook.fresco:fresco:3.7.0'
+    implementation 'com.facebook.fresco:animated-gif:3.7.0'
+    implementation 'com.facebook.fresco:animated-webp:3.7.0'
+    implementation 'com.facebook.fresco:webpsupport:3.7.0'
+    implementation 'com.facebook.fresco:animated-base:3.7.0'
 
     implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
     implementation "com.squareup.okhttp3:okhttp:4.9.0"

--- a/platform/android/lynx_service/lynx_service_image/build.gradle
+++ b/platform/android/lynx_service/lynx_service_image/build.gradle
@@ -43,8 +43,8 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    compileOnly 'com.facebook.fresco:fresco:2.3.0'
-    compileOnly 'com.facebook.fresco:animated-base:2.3.0'
+    compileOnly 'com.facebook.fresco:fresco:3.7.0'
+    compileOnly 'com.facebook.fresco:animated-base:3.7.0'
     compileOnly "androidx.annotation:annotation:1.0.0"
     compileOnly project(':LynxAndroid')
     implementation project(':ServiceAPI')

--- a/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/LynxImageService.java
+++ b/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/LynxImageService.java
@@ -199,21 +199,21 @@ public class LynxImageService implements ILynxImageService, ILynxImageServiceExt
       if (animationListener != null) {
         animatedDrawable.setAnimationListener(new BaseAnimationListener() {
           @Override
-          public void onAnimationStart(AnimatedDrawable2 drawable) {
+          public void onAnimationStart(Drawable drawable) {
             animationListener.onAnimationStart(drawable);
           }
 
           @Override
-          public void onAnimationStop(AnimatedDrawable2 drawable) {
-            if (drawable.isRunning()) {
+          public void onAnimationStop(Drawable drawable) {
+            if (animatedDrawable.isRunning()) {
               animationListener.onAnimationCurrentLoop(drawable);
               animationListener.onAnimationFinalLoop(drawable);
             }
           }
 
           @Override
-          public void onAnimationRepeat(AnimatedDrawable2 drawable) {
-            if (drawable.isRunning()) {
+          public void onAnimationRepeat(Drawable drawable) {
+            if (animatedDrawable.isRunning()) {
               animationListener.onAnimationCurrentLoop(drawable);
             }
           }

--- a/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/decoder/MultiPostProcessor.java
+++ b/platform/android/lynx_service/lynx_service_image/src/main/java/com/lynx/service/image/decoder/MultiPostProcessor.java
@@ -11,7 +11,6 @@ import com.facebook.cache.common.MultiCacheKey;
 import com.facebook.cache.common.SimpleCacheKey;
 import com.facebook.common.references.CloseableReference;
 import com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory;
-import com.facebook.imagepipeline.nativecode.Bitmaps;
 import com.facebook.imagepipeline.request.BasePostprocessor;
 import com.facebook.imagepipeline.request.Postprocessor;
 import com.lynx.tasm.image.model.BitmapPostProcessor;
@@ -40,12 +39,9 @@ public class MultiPostProcessor implements Postprocessor {
             bitmapFactory.createBitmapInternal(sourceBitmap.getWidth(), sourceBitmap.getHeight(),
                 sourceBitmapConfig != null ? sourceBitmapConfig
                                            : BasePostprocessor.FALLBACK_BITMAP_CONFIGURATION);
-        if (nextBitmap.get().getConfig() == sourceBitmap.getConfig()) {
-          Bitmaps.copyBitmap(nextBitmap.get(), sourceBitmap);
-        } else {
-          Canvas canvas = new Canvas(nextBitmap.get());
-          canvas.drawBitmap(sourceBitmap, 0, 0, null);
-        }
+        // Canvas copy keeps this class free of the native imagepipeline module
+        Canvas canvas = new Canvas(nextBitmap.get());
+        canvas.drawBitmap(sourceBitmap, 0, 0, null);
         p.process(prevBitmap != null ? prevBitmap.get() : sourceBitmap, nextBitmap.get());
         CloseableReference.closeSafely(prevBitmap);
         prevBitmap = CloseableReference.cloneOrNull(nextBitmap);


### PR DESCRIPTION
Summary of change:
lynx-service-image compiles against Fresco 2.3.0, whose native libraries (libimagepipeline.so, libgifimage.so, libstatic-webp.so, libnative-filters.so, libnative-imagetranscoder.so) are not 16KB page aligned.  
so apps integrating Lynx fail Google Play's 16KB requirement when targeting Android 15+.   

Compiling against 2.x also emits an invokevirtual call to CloseableBitmap,  
which became an interface in Fresco 3.0, so pairing the service with Fresco 3.x crashes with IncompatibleClassChangeError as soon as an image decodes.  

Upgrade lynx-service-image and lynx_explorer to Fresco 3.7.0, which ships 16KB aligned native binaries since 3.4.0. Replace Bitmaps.copyBitmap with a Canvas copy so the service no longer references the native imagepipeline module, and adapt the animation listener overrides to the Drawable based callbacks introduced in Fresco 3.x. Apps pairing the image service with Fresco 2.x need to move to Fresco 3.x alongside this change.  
  
issue: #1542  
  

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).  
- [x] Documentation updated (or not required).  
