### PR TITLE
[Feature][Runtime] Materialize ContextProxy data in LepusNG

### DIFF
--- a/core/runtime/lepus/bindings/event/lepus_event_listener.cc
+++ b/core/runtime/lepus/bindings/event/lepus_event_listener.cc
@@ -11,10 +11,27 @@
 #include "core/runtime/common/bindings/event/message_event.h"
 #include "core/runtime/common/bindings/event/runtime_constants.h"
 #include "core/runtime/lepusng/jsvalue_helper.h"
+#include "core/runtime/lepusng/quick_context.h"
 #include "core/value_wrapper/value_wrapper_utils.h"
 
 namespace lynx {
 namespace tasm {
+
+namespace {
+
+lepus::Value ConvertMessageDataToReceivingContext(runtime::MTSRuntime* context,
+                                                  const pub::Value& message) {
+  auto data = pub::ValueUtils::ConvertValueToLepusValue(message);
+  if (!context->IsLepusNGContext() ||
+      (!message.IsArray() && !message.IsMap())) {
+    return data;
+  }
+
+  auto* quick_context = runtime::MTSRuntime::ToQuickContext(context);
+  return lepus::LepusValueFactory(quick_context->context()).Create(data, true);
+}
+
+}  // namespace
 
 LepusClosureEventListener::LepusClosureEventListener(
     runtime::MTSRuntime* context, lepus::Value closure,
@@ -55,9 +72,9 @@ lepus::Value LepusClosureEventListener::ConvertEventToLepusValue(
     auto message_event = fml::static_ref_ptr_cast<runtime::MessageEvent>(event);
     value.SetProperty(BASE_STATIC_STRING(runtime::kType),
                       lepus::Value(message_event->type()));
-    value.SetProperty(
-        BASE_STATIC_STRING(runtime::kData),
-        pub::ValueUtils::ConvertValueToLepusValue(*message_event->message()));
+    value.SetProperty(BASE_STATIC_STRING(runtime::kData),
+                      ConvertMessageDataToReceivingContext(
+                          context_, *message_event->message()));
     value.SetProperty(BASE_STATIC_STRING(runtime::kOrigin),
                       lepus::Value(message_event->GetOriginString()));
   }

--- a/core/runtime/lepus/bindings/event/lepus_event_listener_test.cc
+++ b/core/runtime/lepus/bindings/event/lepus_event_listener_test.cc
@@ -4,12 +4,64 @@
 
 #include "core/runtime/lepus/bindings/event/lepus_event_listener_test.h"
 
+#include <cstring>
+#include <memory>
+#include <utility>
+
+#include "base/include/value/array.h"
+#include "base/include/value/table.h"
+#include "core/runtime/common/bindings/event/message_event.h"
+#include "core/runtime/lepus/bindings/event/lepus_event_listener.h"
+#include "core/value_wrapper/value_impl_lepus.h"
+
 namespace lynx {
 namespace tasm {
 namespace test {
 
-TEST_F(LepusClosureEventListenerTest, LepusClosureEventListenerTest0) {
-  // TODO(songshourui.null): impl this later.
+TEST_F(LepusClosureEventListenerTest, MaterializesMessageDataInLepusNG) {
+  auto context = runtime::MTSRuntime::CreateContext(
+      runtime::ContextType::LepusNGContextType);
+  ASSERT_NE(context, nullptr);
+  context->Initialize();
+
+  constexpr char kListenerSource[] = R"(
+    var messageDataResult = "not called";
+    function listener(event) {
+      messageDataResult = [
+        Reflect.ownKeys(event.data).sort().join(","),
+        Object(event.data) === event.data,
+        event.data instanceof Object,
+        Object.getPrototypeOf(event.data) === Object.prototype,
+        Reflect.ownKeys(event.data.nested).join(","),
+        Object(event.data.nested) === event.data.nested,
+        event.data.nested instanceof Array
+      ].join("|");
+    }
+    listener;
+  )";
+  lepus::Value closure;
+  ASSERT_TRUE(context->EvalBuf(kListenerSource, std::strlen(kListenerSource),
+                               closure, "context-proxy-test.js"));
+  ASSERT_TRUE(closure.IsCallable());
+
+  auto nested = lepus::CArray::Create();
+  nested->emplace_back("value");
+  auto message = lepus::Dictionary::Create();
+  message->SetValue("answer", 42);
+  message->SetValue("nested", lepus::Value(std::move(nested)));
+  auto event = fml::MakeRefCounted<runtime::MessageEvent>(
+      runtime::ContextProxy::Type::kJSContext,
+      runtime::ContextProxy::Type::kCoreContext,
+      std::make_unique<pub::ValueImplLepus>(lepus::Value(std::move(message))));
+
+  LepusClosureEventListener listener(context.get(), std::move(closure));
+  listener.Invoke(std::move(event));
+
+  lepus::Value result;
+  ASSERT_TRUE(context->GetTopLevelVariableByName(
+      base::String("messageDataResult"), &result));
+  EXPECT_EQ("answer,nested|true|true|true|0,length|true|true",
+            result.StdString());
 }
 
 }  // namespace test


### PR DESCRIPTION
## Summary

- Materialize composite `ContextProxy` message data as ordinary objects and arrays in the receiving LepusNG realm.
- Preserve the existing path for primitives and the legacy Lepus runtime.
- Add a conformance test covering `Reflect.ownKeys`, identity, prototypes, and nested arrays.

RFC: https://github.com/Huxpro/octane/issues/158

AI-assisted contribution: Codex was used to help implement and test this change. The commit includes the corresponding `Assisted-by` trailer.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required). No public API or documentation change.