### PR TITLE
[BugFix][Harmony] Flush expired tasks in promise microtask

### DIFF
--- a/base/include/fml/platform/harmony/message_loop_harmony.h
+++ b/base/include/fml/platform/harmony/message_loop_harmony.h
@@ -5,10 +5,12 @@
 #ifndef BASE_INCLUDE_FML_PLATFORM_HARMONY_MESSAGE_LOOP_HARMONY_H_
 #define BASE_INCLUDE_FML_PLATFORM_HARMONY_MESSAGE_LOOP_HARMONY_H_
 
+#include <node_api.h>
 #include <uv.h>
 
 #include <atomic>
 
+#include "base/include/base_export.h"
 #include "base/include/fml/macros.h"
 #include "base/include/fml/message_loop_impl.h"
 #include "base/include/fml/unique_fd.h"
@@ -21,6 +23,7 @@ namespace fml {
 class MessageLoopHarmony : public MessageLoopImpl {
  public:
   void* GetPlatformLoop() const { return static_cast<void*>(looper_); }
+  BASE_EXPORT void SetupNapiCallback(napi_env env);
 
  private:
   uv_loop_t* looper_;
@@ -28,12 +31,20 @@ class MessageLoopHarmony : public MessageLoopImpl {
   uv_poll_t poll_;
   fml::UniqueFD timer_fd_;
   bool running_;
+  napi_env env_ = nullptr;
+  napi_ref run_expired_tasks_callback_ = nullptr;
+  bool did_run_expired_tasks_in_microtask_ = false;
 
   void Run() override;
 
   void Terminate() override;
 
   void OnEventFired();
+
+  bool RunExpiredTasksByPromiseMicrotask();
+
+  static napi_value RunExpiredTasksInMicrotask(napi_env env,
+                                               napi_callback_info info);
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopHarmony);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopHarmony);

--- a/base/src/fml/platform/harmony/message_loop_harmony.cc
+++ b/base/src/fml/platform/harmony/message_loop_harmony.cc
@@ -8,6 +8,7 @@
 #include <uv.h>
 
 #include "base/include/fml/platform/linux/timerfd.h"
+#include "base/include/platform/harmony/napi_util.h"
 
 // temporarily workaround to compile without logging
 #undef LOGE
@@ -24,6 +25,24 @@ fml::RefPtr<MessageLoopImpl> MessageLoopImpl::Create(void* platform_loop) {
 }
 
 static constexpr int kClockType = CLOCK_MONOTONIC;
+static constexpr const char* kThen = "then";
+
+napi_value MessageLoopHarmony::RunExpiredTasksInMicrotask(
+    napi_env env, napi_callback_info info) {
+  void* data = nullptr;
+  napi_get_cb_info(env, info, nullptr, nullptr, nullptr, &data);
+  auto* self = static_cast<MessageLoopHarmony*>(data);
+  self->did_run_expired_tasks_in_microtask_ = true;
+  self->RunExpiredTasksNow();
+  return nullptr;
+}
+
+void MessageLoopHarmony::SetupNapiCallback(napi_env env) {
+  env_ = env;
+  napi_value fn{};
+  napi_create_function(env_, nullptr, 0, RunExpiredTasksInMicrotask, this, &fn);
+  napi_create_reference(env_, fn, 1, &run_expired_tasks_callback_);
+}
 
 MessageLoopHarmony::MessageLoopHarmony(void* platform_loop)
     : timer_fd_(timerfd_create(kClockType, TFD_NONBLOCK | TFD_CLOEXEC)),
@@ -86,8 +105,58 @@ void MessageLoopHarmony::WakeUp(fml::TimePoint time_point) {
   // DCHECK(result);
 }
 
+bool MessageLoopHarmony::RunExpiredTasksByPromiseMicrotask() {
+  if (env_ == nullptr || run_expired_tasks_callback_ == nullptr) {
+    return false;
+  }
+
+  base::NapiHandleScope scope(env_);
+
+  napi_value promise{};
+  napi_deferred deferred{};
+  napi_status status = napi_create_promise(env_, &deferred, &promise);
+  if (status != napi_ok) {
+    return false;
+  }
+
+  napi_value then{};
+  status = napi_get_named_property(env_, promise, kThen, &then);
+  if (status != napi_ok) {
+    return false;
+  }
+
+  napi_value callback{};
+  status =
+      napi_get_reference_value(env_, run_expired_tasks_callback_, &callback);
+  if (status != napi_ok || callback == nullptr) {
+    return false;
+  }
+
+  status = napi_call_function(env_, promise, then, 1, &callback, nullptr);
+  if (status != napi_ok) {
+    return false;
+  }
+
+  napi_value undefined{};
+  status = napi_get_undefined(env_, &undefined);
+  if (status != napi_ok) {
+    return false;
+  }
+
+  did_run_expired_tasks_in_microtask_ = false;
+  // Ark's napi_resolve_deferred executes pending promise jobs, so the resolved
+  // promise drives the task flush without wrapping it in napi_call_function.
+  status = napi_resolve_deferred(env_, deferred, undefined);
+  return status == napi_ok || did_run_expired_tasks_in_microtask_;
+}
+
 void MessageLoopHarmony::OnEventFired() {
   if (TimerDrain(timer_fd_.get())) {
+    const bool should_use_napi_microtask =
+        run_expired_tasks_callback_ != nullptr;
+    if (should_use_napi_microtask && RunExpiredTasksByPromiseMicrotask()) {
+      return;
+    }
     RunExpiredTasksNow();
   }
 }

--- a/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.cc
+++ b/platform/harmony/lynx_harmony/src/main/cpp/lynx_template_renderer.cc
@@ -10,6 +10,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/include/fml/platform/harmony/message_loop_harmony.h"
 #include "base/include/log/logging.h"
 #include "base/include/memory/memory_pressure_level.h"
 #include "base/include/notification_center.h"
@@ -888,6 +889,9 @@ napi_value LynxTemplateRenderer::InitGlobalEnv(napi_env env,
     uv_loop_t* loop;
     napi_get_uv_event_loop(env, &loop);
     lynx::base::UIThread::Init(loop);
+    auto* ui_loop = static_cast<fml::MessageLoopHarmony*>(
+        base::UIThread::GetRunner()->GetLoop().get());
+    ui_loop->SetupNapiCallback(env);
 
     size_t argc = 1;
     napi_value args[1] = {nullptr};


### PR DESCRIPTION
## Summary
- run Harmony main-thread expired task flushing from a per-event local Promise reaction instead of wrapping the whole flush in napi_call_function
- create and resolve one Promise per timer event; no cross-event prepared Promise/deferred is stored
- rely on Ark napi_resolve_deferred to execute pending promise jobs; no explicit empty checkpoint callback is used

## Test
- git diff --check
- /Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/native/llvm/bin/aarch64-unknown-linux-ohos-clang++ -std=c++17 -DOS_HARMONY=1 -DOS_POSIX=1 -I. -I/Applications/DevEco-Studio.app/Contents/sdk/default/openharmony/native/sysroot/usr/include -fsyntax-only base/src/fml/platform/harmony/message_loop_harmony.cc

## Notes
- GN generation was attempted with HARMONY_HOME=/Applications/DevEco-Studio.app/Contents/sdk, but dependency sync was incomplete: tools/hab sync failed because local Python is missing yaml and boringssl/perfetto Git fetches timed out.