### PR TITLE
[Testing] Give builder_for_starlight_geometry its own output directory

### DIFF
--- a/.rtf/native-ut-lynx.template
+++ b/.rtf/native-ut-lynx.template
@@ -2,6 +2,11 @@
 # Licensed under the Apache License Version 2.0 that can be found in the
 # LICENSE file in the root directory of this source tree.
 
+# NOTE: every builder below must own a distinct output directory. `gn gen`
+# rewrites a directory wholesale and RTF generates all builders up front, so two
+# builders sharing one directory means the last one silently wins: the other
+# builder's args are dropped and its targets are built with the wrong
+# configuration.
 builder({
     "default" :{
         "args": [
@@ -39,7 +44,7 @@ builder({
             "use_flutter_cxx=false",
             "is_debug=false",
         ],
-        "output": "out/Default",
+        "output": "out/Default_starlight_geometry",
         "type": "gn",
     },
 })


### PR DESCRIPTION
## Summary

In `.rtf/native-ut-lynx.template` both the `default` builder and `builder_for_starlight_geometry` declare `out/Default` as their output directory. RTF generates every builder of a template up front, and `builder_for_starlight_geometry` is declared last, so its `gn gen` overwrites the one the `default` builder just ran. Since `gn gen` rewrites a directory wholesale, the `default` builder's args are silently dropped and never take effect.

This is what `out/Default/args.gn` actually contained after `tools/rtf/rtf native-ut run --names lynx`:

```
enable_lepusng_worklet = true
enable_unittests = true
enable_inspector = true
enable_napi_binding = true
enable_coverage = true
use_flutter_cxx = false
is_debug = false          <- from builder_for_starlight_geometry
                          <- is_asan from the default builder is gone
```

Two consequences, neither of them visible from the test output:

1. **The lynx unit test suite was never built in the configuration its builder declares.** 37 of its 38 targets were built with `is_debug=false`. The `default` builder does not declare `is_debug` at all, and `build/config/BUILDCONFIG.gn` defaults it to `true`.
2. **`enable_asan` never had any effect.** The `default` builder's `is_asan={options.get_str('enable_asan', 'false')}` was discarded together with the rest of its args, so `--args="enable_asan=true"` silently produced a non-ASan build.

### Change

Give `builder_for_starlight_geometry` its own `out/Default_starlight_geometry` directory so both builders keep the args they declare. This follows the convention the other builders in this template and in `native-ut-devtool.template` already use (`out/Default_test_enable_trace`, `out/Default_element_test`, `out/Default_agent_test`).

### Verification

After the change `out/Default` carries the `default` builder's args, `is_asan` included:

```
enable_lepusng_worklet = true
enable_unittests = true
enable_inspector = true
enable_napi_binding = true
enable_coverage = true
use_flutter_cxx = false
is_asan = false
```

Rerunning the full suite in the now-correct configuration gives **identical results per target** — 38 targets, 14713 cases executed, 14544 passed, 0 failures — so building in the declared configuration does not uncover failures that the accidental release build had been hiding. `builder_for_starlight_geometry` builds its own directory and `starlight_geometry_unittest_exec` passes.

`git lynx check` passes.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
