### PR TITLE
[BugFix][CI] Support tag input for CSS defines publish

### DIFF
--- a/.github/workflows/css-defines-publish.yml
+++ b/.github/workflows/css-defines-publish.yml
@@ -1,6 +1,12 @@
 name: css_defines_publish
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The npm tag to publish with.'
+        required: false
+        default: 'latest'
 
 jobs:
   css-defines-publish:
@@ -54,7 +60,7 @@ jobs:
         if: steps.check-published.outputs.already-published != 'true'
         run: |-
           cd $GITHUB_WORKSPACE/lynx/tools/css_generator
-          npm publish --access public --provenance
+          npm publish --access public --provenance --tag "${{ github.event.inputs.tag }}"
 
   notify-website:
     needs: css-defines-publish


### PR DESCRIPTION
## Summary

- Declare the optional tag input for manual CSS defines publishing, defaulting to latest, so workflow dispatch API requests can provide the tag.
- Pass the selected tag to npm publish.

## Validation

- actionlint -ignore SC2086 .github/workflows/css-defines-publish.yml
- git diff --check

## Checklist

- [x] Tests updated (not required for this workflow-only change).
- [x] Documentation updated (not required).