### PR TITLE
[Infra] Pin WebDriverAgent version in E2E CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -908,8 +908,11 @@ jobs:
           retry_wait_seconds: 5
           timeout_minutes: 5
           command: |
+            set -e
             pushd $GITHUB_WORKSPACE
-            git clone https://github.com/appium/WebDriverAgent.git
+            rm -rf WebDriverAgent
+            git clone --depth 1 --branch v16.9.3 https://github.com/appium/WebDriverAgent.git
+            test "$(git -C WebDriverAgent rev-parse HEAD)" = "54fc1a254632911fdc48e2b6fbcca2481d27d223"
             xcodebuild build-for-testing \
               -project ./WebDriverAgent/WebDriverAgent.xcodeproj \
               -scheme WebDriverAgentRunner \


### PR DESCRIPTION
- Pin WebDriverAgent to the verified v16.9.3 commit

- Preserve xcodebuild failures and support clean retries

issue: #5312999715

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx/blob/develop/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
