### PR TITLE
[Feature][DevTool] Support emulated touch on iOS

### DIFF
--- a/platform/darwin/ios/lynx_devtool/BUILD.gn
+++ b/platform/darwin/ios/lynx_devtool/BUILD.gn
@@ -371,6 +371,7 @@ subspec_target("UnitTests") {
     "ConsoleDelegateManagerUnitTest.mm",
     "DevToolPlatformDarwinDelegateUnitTest.mm",
     "Helper/LepusDebugInfoHelperUnitTest.mm",
+    "Helper/LynxEmulateTouchHelperUnitTest.m",
     "Helper/LynxUITreeHelperUnitTest.m",
     "LynxDevToolErrorUtilsUnitTest.m",
     "Memory/LynxMemoryControllerUnitTest.m",

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelper.h
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelper.h
@@ -9,13 +9,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface LynxEmulateTouchHelper : NSObject
 
-@property(nonatomic, weak) LynxView *lynxView;
-@property(nonatomic, assign) Boolean mouseWheelFlag;
-@property(nonatomic, assign) CGPoint last;
-@property(nonatomic, copy) dispatch_block_t task;
+@property(nonatomic, weak, readonly, nullable) LynxView *lynxView;
+@property(nonatomic, assign, readonly) Boolean mouseWheelFlag;
+@property(nonatomic, assign, readonly) CGPoint last;
+@property(nonatomic, copy, readonly, nullable) dispatch_block_t task;
 @property(nonatomic, assign) int deltaScale;
-@property(nonatomic, strong) UITouch *touch;
-@property(nonatomic, strong) UIEvent *event;
+@property(nonatomic, strong, readonly, nullable) UITouch *touch;
+@property(nonatomic, strong, readonly, nullable) UIEvent *event;
 
 - (nonnull instancetype)initWithLynxView:(LynxView *)view;
 

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelper.mm
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelper.mm
@@ -3,16 +3,212 @@
 // LICENSE file in the root directory of this source tree.
 
 #import <LynxDevtool/LynxEmulateTouchHelper.h>
-#include <string>
+
+#import <Lynx/LynxLog.h>
+#import <Lynx/LynxUIKitAPIAdapter.h>
+
+#include <dlfcn.h>
+#include <mach/mach_time.h>
+
+// Event types defined by the CDP method `Input.emulateTouchFromMouseEvent`.
+static NSString* const kMouseEventPressed = @"mousePressed";
+static NSString* const kMouseEventMoved = @"mouseMoved";
+static NSString* const kMouseEventReleased = @"mouseReleased";
+static NSString* const kMouseEventWheel = @"mouseWheel";
+
+static NSString* const kScreenshotModeLynxView = @"lynxview";
+
+// A mouse wheel sequence is emulated as a drag which is released when no wheel event arrives
+// within this interval, consistent with the Android implementation.
+static int64_t const kMouseWheelReleaseDelayMs = 100;
+
+#pragma mark - IOHIDEvent
+
+// UIKit does not deliver touches without an IOHIDEvent to gesture recognizers, so a digitizer
+// event is attached to every emulated touch. The IOKit symbols are resolved at runtime and touch
+// emulation is disabled when they are unavailable.
+typedef struct __IOHIDEvent* IOHIDEventRef;
+// IOHIDFloat follows the same LP64 rule as CGFloat: double on 64-bit and float on 32-bit.
+typedef CGFloat IOHIDFloat;
+
+static uint32_t const kIOHIDEventTypeDigitizer = 11;
+static uint32_t const kIOHIDDigitizerTransducerTypeHand = 3;
+static uint32_t const kIOHIDDigitizerEventRange = 1 << 0;
+static uint32_t const kIOHIDDigitizerEventTouch = 1 << 1;
+static uint32_t const kIOHIDDigitizerEventPosition = 1 << 2;
+// IOHIDEventFieldBase(kIOHIDEventTypeDigitizer) plus the offset of
+// kIOHIDEventFieldDigitizerIsDisplayIntegrated in IOHIDEventTypes.h.
+static uint32_t const kIOHIDEventFieldDigitizerIsDisplayIntegrated =
+    (kIOHIDEventTypeDigitizer << 16) | 25;
+
+typedef IOHIDEventRef (*LynxIOHIDEventCreateDigitizerEventFunc)(
+    CFAllocatorRef allocator, AbsoluteTime timeStamp, uint32_t type, uint32_t index,
+    uint32_t identity, uint32_t eventMask, uint32_t buttonMask, IOHIDFloat x, IOHIDFloat y,
+    IOHIDFloat z, IOHIDFloat tipPressure, IOHIDFloat barrelPressure, Boolean range, Boolean touch,
+    uint32_t options);
+typedef IOHIDEventRef (*LynxIOHIDEventCreateDigitizerFingerEventFunc)(
+    CFAllocatorRef allocator, AbsoluteTime timeStamp, uint32_t index, uint32_t identity,
+    uint32_t eventMask, IOHIDFloat x, IOHIDFloat y, IOHIDFloat z, IOHIDFloat tipPressure,
+    IOHIDFloat twist, Boolean range, Boolean touch, uint32_t options);
+typedef void (*LynxIOHIDEventAppendEventFunc)(IOHIDEventRef event, IOHIDEventRef childEvent,
+                                              uint32_t options);
+typedef void (*LynxIOHIDEventSetIntegerValueFunc)(IOHIDEventRef event, uint32_t field,
+                                                  CFIndex value);
+
+typedef struct {
+  LynxIOHIDEventCreateDigitizerEventFunc createDigitizerEvent;
+  LynxIOHIDEventCreateDigitizerFingerEventFunc createDigitizerFingerEvent;
+  LynxIOHIDEventAppendEventFunc appendEvent;
+  LynxIOHIDEventSetIntegerValueFunc setIntegerValue;
+} LynxIOHIDEventApi;
+
+static const LynxIOHIDEventApi* LynxGetIOHIDEventApi(void) {
+  static LynxIOHIDEventApi api;
+  static BOOL available = NO;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    void* handle = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_LAZY);
+    if (handle == NULL) {
+      handle = RTLD_DEFAULT;
+    }
+    api.createDigitizerEvent =
+        (LynxIOHIDEventCreateDigitizerEventFunc)dlsym(handle, "IOHIDEventCreateDigitizerEvent");
+    api.createDigitizerFingerEvent = (LynxIOHIDEventCreateDigitizerFingerEventFunc)dlsym(
+        handle, "IOHIDEventCreateDigitizerFingerEvent");
+    api.appendEvent = (LynxIOHIDEventAppendEventFunc)dlsym(handle, "IOHIDEventAppendEvent");
+    api.setIntegerValue =
+        (LynxIOHIDEventSetIntegerValueFunc)dlsym(handle, "IOHIDEventSetIntegerValue");
+    available = api.createDigitizerEvent != NULL && api.createDigitizerFingerEvent != NULL &&
+                api.appendEvent != NULL && api.setIntegerValue != NULL;
+    if (!available) {
+      LLogError(@"LynxEmulateTouchHelper: IOHIDEvent symbols are unavailable");
+    }
+  });
+  return available ? &api : NULL;
+}
+
+// Returns a retained digitizer event describing the current state of the touch.
+static IOHIDEventRef LynxCreateIOHIDEventForTouch(UITouch* touch) {
+  const LynxIOHIDEventApi* api = LynxGetIOHIDEventApi();
+  if (api == NULL) {
+    return NULL;
+  }
+  uint64_t machTime = mach_absolute_time();
+  AbsoluteTime timestamp;
+  timestamp.hi = (UInt32)(machTime >> 32);
+  timestamp.lo = (UInt32)(machTime & 0xFFFFFFFF);
+
+  IOHIDEventRef handEvent =
+      api->createDigitizerEvent(kCFAllocatorDefault, timestamp, kIOHIDDigitizerTransducerTypeHand,
+                                0, 0, kIOHIDDigitizerEventTouch, 0, 0, 0, 0, 0, 0, false, true, 0);
+  if (handEvent == NULL) {
+    return NULL;
+  }
+  api->setIntegerValue(handEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, 1);
+
+  Boolean touching = touch.phase != UITouchPhaseEnded && touch.phase != UITouchPhaseCancelled;
+  uint32_t eventMask = touch.phase == UITouchPhaseMoved
+                           ? kIOHIDDigitizerEventPosition
+                           : (kIOHIDDigitizerEventRange | kIOHIDDigitizerEventTouch);
+  CGPoint location = [touch locationInView:touch.window];
+  IOHIDEventRef fingerEvent =
+      api->createDigitizerFingerEvent(kCFAllocatorDefault, timestamp, 1, 2, eventMask, location.x,
+                                      location.y, 0, 0, 0, touching, touching, 0);
+  if (fingerEvent != NULL) {
+    api->setIntegerValue(fingerEvent, kIOHIDEventFieldDigitizerIsDisplayIntegrated, 1);
+    api->appendEvent(handEvent, fingerEvent, 0);
+    CFRelease(fingerEvent);
+  }
+  return handEvent;
+}
+
+#pragma mark - UIKit SPI
+
+// UIKit has no public API for injecting touches. The selectors below are the ones used by iOS
+// testing frameworks such as KIF and EarlGrey; their availability is verified at runtime.
+@interface UITouch (LynxEmulateTouch)
+- (void)setWindow:(UIWindow*)window;
+- (void)setView:(UIView*)view;
+- (void)setTapCount:(NSUInteger)tapCount;
+- (void)setIsTap:(BOOL)isTap;
+- (void)setPhase:(UITouchPhase)phase;
+- (void)setTimestamp:(NSTimeInterval)timestamp;
+- (void)_setLocationInWindow:(CGPoint)location resetPrevious:(BOOL)resetPrevious;
+- (void)_setIsFirstTouchForView:(BOOL)isFirstTouchForView;
+- (void)_setHidEvent:(IOHIDEventRef)event;
+@end
+
+@interface UIEvent (LynxEmulateTouch)
+- (void)_clearTouches;
+- (void)_addTouch:(UITouch*)touch forDelayedDelivery:(BOOL)delayed;
+- (void)_setHIDEvent:(IOHIDEventRef)event;
+@end
+
+@interface UIApplication (LynxEmulateTouch)
+- (UIEvent*)_touchesEvent;
+@end
+
+static BOOL LynxIsTouchEmulationSupported(void) {
+  static BOOL supported = NO;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSMutableArray<NSString*>* missing = [NSMutableArray array];
+    NSArray<NSString*>* touchSelectors = @[
+      @"setWindow:", @"setView:", @"setTapCount:", @"setPhase:", @"setTimestamp:",
+      @"_setLocationInWindow:resetPrevious:", @"_setIsFirstTouchForView:", @"_setHidEvent:"
+    ];
+    for (NSString* name in touchSelectors) {
+      if (![UITouch instancesRespondToSelector:NSSelectorFromString(name)]) {
+        [missing addObject:[@"-[UITouch " stringByAppendingFormat:@"%@]", name]];
+      }
+    }
+    Class touchesEventClass = NSClassFromString(@"UITouchesEvent") ?: [UIEvent class];
+    NSArray<NSString*>* eventSelectors =
+        @[ @"_clearTouches", @"_addTouch:forDelayedDelivery:", @"_setHIDEvent:" ];
+    for (NSString* name in eventSelectors) {
+      if (![touchesEventClass instancesRespondToSelector:NSSelectorFromString(name)]) {
+        [missing addObject:[@"-[UIEvent " stringByAppendingFormat:@"%@]", name]];
+      }
+    }
+    if (![UIApplication instancesRespondToSelector:@selector(_touchesEvent)]) {
+      [missing addObject:@"-[UIApplication _touchesEvent]"];
+    }
+    if (missing.count > 0) {
+      LLogError(@"LynxEmulateTouchHelper: touch emulation is unavailable, missing %@",
+                [missing componentsJoinedByString:@", "]);
+      return;
+    }
+    supported = LynxGetIOHIDEventApi() != NULL;
+  });
+  return supported;
+}
 
 #pragma mark - LynxEmulateTouchHelper
+
+@interface LynxEmulateTouchHelper ()
+
+@property(nonatomic, weak, nullable) LynxView* lynxView;
+@property(nonatomic, assign) Boolean mouseWheelFlag;
+@property(nonatomic, assign) CGPoint last;
+@property(nonatomic, copy, nullable) dispatch_block_t task;
+@property(nonatomic, strong, nullable) UITouch* touch;
+@property(nonatomic, strong, nullable) UIEvent* event;
+
+@end
+
 @implementation LynxEmulateTouchHelper
 
 - (nonnull instancetype)initWithLynxView:(LynxView*)view {
-  _lynxView = view;
-  _mouseWheelFlag = NO;
-  _deltaScale = 5;
+  if (self = [super init]) {
+    _lynxView = view;
+    _mouseWheelFlag = NO;
+    _deltaScale = 5;
+  }
   return self;
+}
+
+- (void)dealloc {
+  [self cancelMouseWheelTask];
 }
 
 - (void)emulateTouch:(nonnull NSString*)type
@@ -24,11 +220,213 @@
            modifiers:(int)modifiers
           clickCount:(int)click_count
       screenshotMode:(NSString*)screenshotMode {
-  // TODO(zhengyuwei): Support simulating clicks based on coordinate on iOS
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf emulateTouch:type
+                 coordinateX:x
+                 coordinateY:y
+                      button:button
+                      deltaX:dx
+                      deltaY:dy
+                   modifiers:modifiers
+                  clickCount:click_count
+              screenshotMode:screenshotMode];
+    });
+    return;
+  }
+
+  LynxView* lynxView = _lynxView;
+  if (lynxView == nil) {
+    LLogError(@"LynxEmulateTouchHelper: lynxView is nil");
+    return;
+  }
+  UIWindow* window = lynxView.window ?: [LynxUIKitAPIAdapter getKeyWindow];
+  if (window == nil) {
+    LLogError(@"LynxEmulateTouchHelper: no window is available to deliver %@", type);
+    return;
+  }
+  CGPoint location = [self locationInWindow:window
+                                   forPoint:CGPointMake(x, y)
+                             screenshotMode:screenshotMode
+                                   lynxView:lynxView];
+
+  if ([type isEqualToString:kMouseEventPressed]) {
+    [self handleMousePressedAtLocation:location inWindow:window clickCount:click_count];
+  } else if ([type isEqualToString:kMouseEventMoved]) {
+    [self handleMouseMovedToLocation:location];
+  } else if ([type isEqualToString:kMouseEventReleased]) {
+    [self handleMouseReleasedAtLocation:location];
+  } else if ([type isEqualToString:kMouseEventWheel]) {
+    [self handleMouseWheelAtLocation:location inWindow:window deltaX:dx deltaY:dy];
+  } else {
+    LLogWarn(@"LynxEmulateTouchHelper: unsupported event type %@", type);
+  }
 }
 
 - (void)attachLynxView:(nonnull LynxView*)lynxView {
+  [self cancelActiveTouch];
   _lynxView = lynxView;
+}
+
+#pragma mark - Mouse events
+
+// CDP coordinates are in points relative to the screencast image, which is the LynxView in
+// `lynxview` mode and the key window (i.e. the screen) in `fullscreen` mode.
+- (CGPoint)locationInWindow:(UIWindow*)window
+                   forPoint:(CGPoint)point
+             screenshotMode:(NSString*)screenshotMode
+                   lynxView:(LynxView*)lynxView {
+  if ([screenshotMode isEqualToString:kScreenshotModeLynxView]) {
+    return [lynxView convertPoint:point toView:window];
+  }
+  return [window convertPoint:point fromWindow:nil];
+}
+
+- (void)handleMousePressedAtLocation:(CGPoint)location
+                            inWindow:(UIWindow*)window
+                          clickCount:(int)clickCount {
+  // A new press always starts a fresh touch sequence.
+  [self cancelActiveTouch];
+  [self beginTouchAtLocation:location inWindow:window tapCount:clickCount];
+}
+
+- (void)handleMouseMovedToLocation:(CGPoint)location {
+  // Hovering without an active press has no touch counterpart.
+  if (_touch == nil || _mouseWheelFlag) {
+    return;
+  }
+  [self sendTouchWithPhase:UITouchPhaseMoved location:location];
+}
+
+- (void)handleMouseReleasedAtLocation:(CGPoint)location {
+  if (_touch == nil || _mouseWheelFlag) {
+    return;
+  }
+  [self sendTouchWithPhase:UITouchPhaseEnded location:location];
+}
+
+- (void)handleMouseWheelAtLocation:(CGPoint)location
+                          inWindow:(UIWindow*)window
+                            deltaX:(CGFloat)dx
+                            deltaY:(CGFloat)dy {
+  if (_touch != nil && !_mouseWheelFlag) {
+    // Do not interfere with a drag driven by the mouse button.
+    return;
+  }
+  [self cancelMouseWheelTask];
+  if (_touch == nil) {
+    [self beginTouchAtLocation:location inWindow:window tapCount:1];
+    if (_touch == nil) {
+      return;
+    }
+    _mouseWheelFlag = YES;
+  }
+  CGFloat scale = _deltaScale > 0 ? _deltaScale : 1;
+  [self sendTouchWithPhase:UITouchPhaseMoved
+                  location:CGPointMake(_last.x + dx / scale, _last.y + dy / scale)];
+
+  __weak typeof(self) weakSelf = self;
+  _task = dispatch_block_create(DISPATCH_BLOCK_INHERIT_QOS_CLASS, ^{
+    [weakSelf stopMouseWheel];
+  });
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, kMouseWheelReleaseDelayMs * NSEC_PER_MSEC),
+                 dispatch_get_main_queue(), _task);
+}
+
+- (void)stopMouseWheel {
+  _task = nil;
+  if (_touch == nil || !_mouseWheelFlag) {
+    return;
+  }
+  [self sendTouchWithPhase:UITouchPhaseEnded location:_last];
+}
+
+- (void)cancelMouseWheelTask {
+  if (_task != nil) {
+    dispatch_block_cancel(_task);
+    _task = nil;
+  }
+}
+
+// Ends an in-flight touch with a cancel so that gesture recognizers and scroll views that
+// already received it do not stay in a began or changed state.
+- (void)cancelActiveTouch {
+  if (![NSThread isMainThread]) {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [weakSelf cancelActiveTouch];
+    });
+    return;
+  }
+  [self cancelMouseWheelTask];
+  [self sendTouchWithPhase:UITouchPhaseCancelled location:_last];
+}
+
+#pragma mark - Touch synthesis
+
+- (void)beginTouchAtLocation:(CGPoint)location inWindow:(UIWindow*)window tapCount:(int)tapCount {
+  if (!LynxIsTouchEmulationSupported()) {
+    return;
+  }
+  UITouch* touch = [[UITouch alloc] init];
+  // The window has to be set first since it resets other state of the touch.
+  [touch setWindow:window];
+  [touch setTapCount:(NSUInteger)MAX(tapCount, 1)];
+  if ([touch respondsToSelector:@selector(setIsTap:)]) {
+    [touch setIsTap:YES];
+  }
+  [touch _setLocationInWindow:location resetPrevious:YES];
+  [touch setView:[window hitTest:location withEvent:nil] ?: window];
+  [touch setPhase:UITouchPhaseBegan];
+  [touch _setIsFirstTouchForView:YES];
+  [touch setTimestamp:[[NSProcessInfo processInfo] systemUptime]];
+
+  _touch = touch;
+  _last = location;
+  [self sendCurrentTouch];
+}
+
+- (void)sendTouchWithPhase:(UITouchPhase)phase location:(CGPoint)location {
+  if (_touch == nil) {
+    return;
+  }
+  [_touch setTimestamp:[[NSProcessInfo processInfo] systemUptime]];
+  [_touch _setLocationInWindow:location resetPrevious:NO];
+  [_touch setPhase:phase];
+  _last = location;
+  [self sendCurrentTouch];
+  if (phase == UITouchPhaseEnded || phase == UITouchPhaseCancelled) {
+    _touch = nil;
+    _event = nil;
+    _mouseWheelFlag = NO;
+  }
+}
+
+- (void)sendCurrentTouch {
+  UIApplication* application = [UIApplication sharedApplication];
+  UIEvent* event = [application _touchesEvent];
+  if (event == nil) {
+    // There is no running application to deliver through, e.g. in a standalone test runner.
+    static BOOL logged = NO;
+    if (!logged) {
+      logged = YES;
+      LLogError(@"LynxEmulateTouchHelper: failed to obtain the touches event");
+    }
+    return;
+  }
+  [event _clearTouches];
+  IOHIDEventRef hidEvent = LynxCreateIOHIDEventForTouch(_touch);
+  if (hidEvent != NULL) {
+    [event _setHIDEvent:hidEvent];
+    [_touch _setHidEvent:hidEvent];
+  }
+  [event _addTouch:_touch forDelayedDelivery:NO];
+  _event = event;
+  [application sendEvent:event];
+  if (hidEvent != NULL) {
+    CFRelease(hidEvent);
+  }
 }
 
 @end

--- a/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelperUnitTest.m
+++ b/platform/darwin/ios/lynx_devtool/Helper/LynxEmulateTouchHelperUnitTest.m
@@ -1,0 +1,262 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <LynxDevtool/LynxEmulateTouchHelper.h>
+#import <UIKit/UIKit.h>
+#import <XCTest/XCTest.h>
+
+static NSString* const kScreenshotModeLynxView = @"lynxview";
+static NSString* const kScreenshotModeFullScreen = @"fullscreen";
+
+@interface LynxEmulateTouchGestureRecorder : NSObject
+
+@property(nonatomic, assign) NSInteger tapCount;
+@property(nonatomic, strong) NSMutableArray<NSNumber*>* panStates;
+
+@end
+
+@implementation LynxEmulateTouchGestureRecorder
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _panStates = [NSMutableArray array];
+  }
+  return self;
+}
+
+- (void)onTap:(UITapGestureRecognizer*)recognizer {
+  self.tapCount++;
+}
+
+- (void)onPan:(UIPanGestureRecognizer*)recognizer {
+  [self.panStates addObject:@(recognizer.state)];
+}
+
+@end
+
+@interface LynxEmulateTouchHelperUnitTest : XCTestCase
+@end
+
+@implementation LynxEmulateTouchHelperUnitTest {
+  UIWindow* _window;
+  UIView* _lynxView;
+  UIView* _target;
+  LynxEmulateTouchGestureRecorder* _recorder;
+  LynxEmulateTouchHelper* _helper;
+}
+
+- (void)setUp {
+  [super setUp];
+  _window = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, 320, 640)];
+  // The view standing in for the LynxView is offset so that coordinates in the two screenshot
+  // modes differ.
+  _lynxView = [[UIView alloc] initWithFrame:CGRectMake(0, 100, 320, 400)];
+  _target = [[UIView alloc] initWithFrame:CGRectMake(20, 20, 100, 100)];
+  _recorder = [[LynxEmulateTouchGestureRecorder alloc] init];
+  [_target addGestureRecognizer:[[UITapGestureRecognizer alloc] initWithTarget:_recorder
+                                                                        action:@selector(onTap:)]];
+  [_target addGestureRecognizer:[[UIPanGestureRecognizer alloc] initWithTarget:_recorder
+                                                                        action:@selector(onPan:)]];
+  [_lynxView addSubview:_target];
+  [_window addSubview:_lynxView];
+  [_window makeKeyAndVisible];
+  // The helper only relies on the view hierarchy of the LynxView.
+  _helper = [[LynxEmulateTouchHelper alloc] initWithLynxView:(LynxView*)_lynxView];
+}
+
+- (void)tearDown {
+  _window.hidden = YES;
+  _helper = nil;
+  _recorder = nil;
+  _target = nil;
+  _lynxView = nil;
+  _window = nil;
+  [super tearDown];
+}
+
+// Synthesized touches only reach gesture recognizers when UIKit delivers them through a running
+// UIApplication, which the standalone test runner does not provide. The touch state kept by the
+// helper is verified everywhere and recognizer callbacks only when an application exists.
+- (BOOL)deliversTouches {
+  return [UIApplication sharedApplication] != nil;
+}
+
+- (void)emulate:(NSString*)type x:(int)x y:(int)y mode:(NSString*)mode {
+  [self emulate:type x:x y:y deltaX:0 deltaY:0 mode:mode];
+}
+
+- (void)emulate:(NSString*)type
+              x:(int)x
+              y:(int)y
+         deltaX:(CGFloat)deltaX
+         deltaY:(CGFloat)deltaY
+           mode:(NSString*)mode {
+  [_helper emulateTouch:type
+            coordinateX:x
+            coordinateY:y
+                 button:@"left"
+                 deltaX:deltaX
+                 deltaY:deltaY
+              modifiers:0
+             clickCount:1
+         screenshotMode:mode];
+}
+
+- (void)runLoopForSeconds:(NSTimeInterval)seconds {
+  [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:seconds]];
+}
+
+- (BOOL)waitUntil:(BOOL (^)(void))condition timeout:(NSTimeInterval)timeout {
+  NSDate* deadline = [NSDate dateWithTimeIntervalSinceNow:timeout];
+  while (!condition() && [deadline timeIntervalSinceNow] > 0) {
+    [self runLoopForSeconds:0.02];
+  }
+  return condition();
+}
+
+- (BOOL)waitForTapCount:(NSInteger)count timeout:(NSTimeInterval)timeout {
+  return [self
+      waitUntil:^BOOL {
+        return self->_recorder.tapCount >= count;
+      }
+        timeout:timeout];
+}
+
+- (BOOL)waitForPanState:(UIGestureRecognizerState)state timeout:(NSTimeInterval)timeout {
+  return [self
+      waitUntil:^BOOL {
+        return [self->_recorder.panStates containsObject:@(state)];
+      }
+        timeout:timeout];
+}
+
+- (void)assertLastLocation:(CGPoint)expected {
+  XCTAssertEqualWithAccuracy(_helper.last.x, expected.x, 0.001);
+  XCTAssertEqualWithAccuracy(_helper.last.y, expected.y, 0.001);
+}
+
+- (void)testPressAndReleaseTriggersTapInLynxViewCoordinates {
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNotNil(_helper.touch);
+  XCTAssertEqual(_helper.touch.phase, UITouchPhaseBegan);
+  XCTAssertEqual(_helper.touch.view, _target);
+  [self assertLastLocation:CGPointMake(50, 150)];
+
+  [self emulate:@"mouseReleased" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+  if ([self deliversTouches]) {
+    XCTAssertTrue([self waitForTapCount:1 timeout:1]);
+  }
+}
+
+- (void)testFullScreenModeUsesWindowCoordinates {
+  // (50, 50) in window coordinates lies above the LynxView.
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeFullScreen];
+  XCTAssertNotNil(_helper.touch);
+  XCTAssertNotEqual(_helper.touch.view, _target);
+  [self assertLastLocation:CGPointMake(50, 50)];
+  [self emulate:@"mouseReleased" x:50 y:50 mode:kScreenshotModeFullScreen];
+  [self runLoopForSeconds:0.1];
+  XCTAssertEqual(_recorder.tapCount, 0);
+
+  [self emulate:@"mousePressed" x:50 y:150 mode:kScreenshotModeFullScreen];
+  XCTAssertEqual(_helper.touch.view, _target);
+  [self assertLastLocation:CGPointMake(50, 150)];
+  [self emulate:@"mouseReleased" x:50 y:150 mode:kScreenshotModeFullScreen];
+  if ([self deliversTouches]) {
+    XCTAssertTrue([self waitForTapCount:1 timeout:1]);
+  }
+}
+
+- (void)testMoveAndReleaseWithoutPressAreIgnored {
+  [self emulate:@"mouseMoved" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+  [self emulate:@"mouseReleased" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+  [self runLoopForSeconds:0.1];
+
+  XCTAssertEqual(_recorder.tapCount, 0);
+  XCTAssertEqual(_recorder.panStates.count, 0u);
+}
+
+- (void)testDragTriggersPanInsteadOfTap {
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeLynxView];
+  UITouch* touch = _helper.touch;
+  [self emulate:@"mouseMoved" x:50 y:80 mode:kScreenshotModeLynxView];
+  XCTAssertEqual(_helper.touch, touch);
+  XCTAssertEqual(touch.phase, UITouchPhaseMoved);
+  [self assertLastLocation:CGPointMake(50, 180)];
+  [self emulate:@"mouseMoved" x:50 y:110 mode:kScreenshotModeLynxView];
+  [self assertLastLocation:CGPointMake(50, 210)];
+  [self emulate:@"mouseReleased" x:50 y:110 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+
+  if ([self deliversTouches]) {
+    XCTAssertTrue([self waitForPanState:UIGestureRecognizerStateEnded timeout:1]);
+    XCTAssertTrue([_recorder.panStates containsObject:@(UIGestureRecognizerStateBegan)]);
+  }
+  XCTAssertEqual(_recorder.tapCount, 0);
+}
+
+- (void)testMouseWheelEmulatesDragAndReleasesWhenIdle {
+  [self emulate:@"mouseWheel" x:50 y:50 deltaX:0 deltaY:-100 mode:kScreenshotModeLynxView];
+  XCTAssertNotNil(_helper.touch);
+  XCTAssertTrue(_helper.mouseWheelFlag);
+  [self assertLastLocation:CGPointMake(50, 150 - 100.0 / _helper.deltaScale)];
+  [self emulate:@"mouseWheel" x:50 y:50 deltaX:0 deltaY:-100 mode:kScreenshotModeLynxView];
+  [self assertLastLocation:CGPointMake(50, 150 - 200.0 / _helper.deltaScale)];
+
+  // Mouse moves do not disturb a drag driven by the wheel.
+  [self emulate:@"mouseMoved" x:200 y:200 mode:kScreenshotModeLynxView];
+  [self assertLastLocation:CGPointMake(50, 150 - 200.0 / _helper.deltaScale)];
+
+  // The drag is released once no wheel event arrives for a while.
+  XCTAssertTrue([self
+      waitUntil:^BOOL {
+        return self->_helper.touch == nil;
+      }
+        timeout:2]);
+  XCTAssertFalse(_helper.mouseWheelFlag);
+
+  if ([self deliversTouches]) {
+    XCTAssertTrue([self waitForPanState:UIGestureRecognizerStateBegan timeout:1]);
+    XCTAssertTrue([self waitForPanState:UIGestureRecognizerStateEnded timeout:1]);
+  }
+  XCTAssertEqual(_recorder.tapCount, 0);
+}
+
+- (void)testMouseWheelIsIgnoredWhilePressed {
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeLynxView];
+  [self emulate:@"mouseWheel" x:50 y:50 deltaX:0 deltaY:-100 mode:kScreenshotModeLynxView];
+  XCTAssertFalse(_helper.mouseWheelFlag);
+  [self assertLastLocation:CGPointMake(50, 150)];
+  [self emulate:@"mouseReleased" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+}
+
+- (void)testNewPressReplacesActiveTouch {
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeLynxView];
+  UITouch* first = _helper.touch;
+  [self emulate:@"mousePressed" x:60 y:60 mode:kScreenshotModeLynxView];
+  XCTAssertNotNil(_helper.touch);
+  XCTAssertNotEqual(_helper.touch, first);
+  XCTAssertEqual(first.phase, UITouchPhaseCancelled);
+  [self assertLastLocation:CGPointMake(60, 160)];
+}
+
+- (void)testAttachLynxViewCancelsPendingTouch {
+  [self emulate:@"mousePressed" x:50 y:50 mode:kScreenshotModeLynxView];
+  UITouch* touch = _helper.touch;
+  [_helper attachLynxView:(LynxView*)_lynxView];
+  XCTAssertEqual(touch.phase, UITouchPhaseCancelled);
+  XCTAssertNil(_helper.touch);
+  XCTAssertFalse(_helper.mouseWheelFlag);
+  [self emulate:@"mouseReleased" x:50 y:50 mode:kScreenshotModeLynxView];
+  XCTAssertNil(_helper.touch);
+  [self runLoopForSeconds:0.1];
+
+  XCTAssertEqual(_recorder.tapCount, 0);
+}
+
+@end


### PR DESCRIPTION
## Summary

Fixes #9167.

`Input.emulateTouchFromMouseEvent` was a no-op on iOS: `DevToolPlatformDarwinDelegate` forwards it to `LynxEmulateTouchHelper`, but `-[LynxEmulateTouchHelper emulateTouch:...]` was an empty stub, so clicking, dragging or scrolling on the DevTool screencast did nothing for a LynxView on iOS. Android (`EmulateTouchHelper.java`) and Harmony (#7508) already support this.

This PR implements the helper by synthesizing a `UITouch` sequence and delivering it through UIKit (`-[UIApplication sendEvent:]`), so that `LynxTouchHandler`, the tap / long-press recognizers and native scroll views react exactly as they do to a real finger:

- `mousePressed` / `mouseMoved` / `mouseReleased` map to the began / moved / ended phases of a single touch. A new press cancels any touch still in flight, and moves / releases without a press are ignored.
- `mouseWheel` is emulated as a drag that moves by `delta / deltaScale` and is released after 100 ms without further wheel events, mirroring the Android implementation (the DevTool frontend already flips the sign of `deltaY`, so the mapping is identical on both platforms).
- Coordinates honor the screenshot mode reported by `DevToolStatus`: LynxView-relative in `lynxview` mode and screen-relative in `fullscreen` mode. Since UIKit works in points and the screencast metadata reports `deviceWidth` in points, no density scaling is needed on iOS.
- Everything runs on the main thread; calls from other threads are re-dispatched.

### About the UIKit / IOKit SPI

UIKit has no public API for injecting touch events. The implementation uses the same SPI as KIF and EarlGrey (`-[UIApplication _touchesEvent]`, `-[UITouch _setLocationInWindow:resetPrevious:]`, `IOHIDEventCreateDigitizerEvent`, ...). All selectors are checked with `respondsToSelector:` and the IOKit functions are resolved with `dlsym` at runtime; if anything is missing the helper logs an error once and does nothing, so there is no crash path. The code is confined to the `LynxDevtool` pod, which already links `IOKit`. The Harmony implementation likewise runtime-loads its injection APIs.

`initWithLynxView:` also gained the missing `[super init]` call.

## Test

- New `LynxEmulateTouchHelperUnitTest` (8 cases) drives the helper against a real `UIWindow` and checks the touch state kept by the helper (phase, hit-tested view, window location for both screenshot modes, wheel drag distance and auto release, ignored moves / releases / wheels, press replacing an active touch, `attachLynxView:` reset). Recognizer callbacks (tap, pan) are asserted additionally when a `UIApplication` exists, because the standalone pod test runner has none and UIKit only delivers touches through a running application.
- Verified on the iOS 26.4 simulator (iPhone 17 Pro, Xcode 26.4.1):
  - `LynxDevtool-Unit-UnitTests` (standalone runner): 8/8 pass.
  - The same test file hosted in the `LynxExplorer` app: 8/8 pass including tap / pan recognition, and a `UIScrollView` scrolls in response to `mouseWheel` events.
  - Real `LynxView` hosted in `LynxExplorer` with `homepage.lynx.bundle` loaded: an emulated press / release produces `touchstart`, `touchend`, `tap` and an emulated drag produces `touchstart`, `touchmove`, `touchmove`, `touchend` through `LynxTouchHandler` (observed via `LynxViewLifecycle onLynxEvent:`, with `:active` pseudo state toggling in `touch_event_handler.cc`).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
