### PR TITLE
[BugFix] File custom section debug info under the section name

### DIFF
--- a/core/template_bundle/template_codec/binary_encoder/template_binary_writer.cc
+++ b/core/template_bundle/template_codec/binary_encoder/template_binary_writer.cc
@@ -257,15 +257,19 @@ void TemplateBinaryWriter::EncodeCustomSection() {
             EncodeValue(&content, false);
             break;
           case CustomSectionEncodingType::JS_BYTECODE: {
+            // The section name is the file name its debug info is filed under,
+            // so pass it along: a stack frame carries the file name, and
+            // without one every function is attributed to "".
+            const std::string section_name = it.name.GetString();
             auto error = lepus::BytecodeGenerator::GenerateBytecode(
                 mts_context(), content.StdString(),
-                compile_options_.target_sdk_version_);
+                compile_options_.target_sdk_version_, section_name);
             if (!error.empty()) {
               throw lepus::CompileException(error.c_str());
             }
             if (IsLepusNGContext()) {
               auto debug_info = GetDebugInfo();
-              lepus_debug_info_.AddDebugInfo(it.name.GetString(), debug_info,
+              lepus_debug_info_.AddDebugInfo(section_name, debug_info,
                                              quick_context());
             }
             ContextBinaryWriter::encode();
@@ -443,7 +447,11 @@ void TemplateBinaryWriter::EncodeLepusSection() {
         mts_context(), lepus_code_, compile_options_.target_sdk_version_,
         lepus_code_filename_);
 
-    if (IsLepusNGContext()) {
+    // A bundle whose main thread code lives in custom sections carries no root
+    // lepus code. Compiling the empty root still yields one `<eval>` function,
+    // and filing it drowns out the sections: consumers fall back to
+    // "lepusNG_debug_info" and remap against a stub that describes nothing.
+    if (IsLepusNGContext() && !lepus_code_.empty()) {
       auto debug_info = GetDebugInfo();
       // "lepusNG_debug_info" is hardcoded in various places in lynx sdk, tasm &
       // oliver. Use this name for now.

--- a/oliver/lynx-tasm/CHANGELOG.md
+++ b/oliver/lynx-tasm/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# 0.0.53
+* File custom section debug info under the section name, and skip the empty root entry when a bundle has no root lepus code.
+
 # 0.0.52
 * Support serializing decoded CSS descriptors into CSS text.
 

--- a/oliver/lynx-tasm/package.json
+++ b/oliver/lynx-tasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lynx-js/tasm",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
## Summary

The encoder files one debug info entry per compilation unit, and a `JsBytecode` custom section is filed wrong in two ways.

**The section's functions carry no file name.** The root lepus code and every lepus chunk are compiled with a file name (`lepus_code_filename_` / the chunk path); a custom section was compiled without one, so every function it holds gets `file_name: ""`. Consumers match a stack frame against that name, so frames from a section cannot be attributed. Pass the section name, which is also the key its entry is filed under.

**An empty root drowns out the sections.** A bundle that keeps its main thread code in custom sections has no root lepus code. Compiling the empty root still yields one `<eval>` function, and filing it as `lepusNG_debug_info` hands consumers a stub that describes nothing. Both the devtool error parser and the logbox parser fall back to `lepusNG_debug_info` when a frame's file name matches no entry, so they remap against that stub instead of the section holding the real code. Skip the entry when there is no root lepus code.

## Verification

Built this encoder into `@lynx-js/tasm` and encoded the same three inputs with it and with the published 0.0.52, feeding each the `tasm.json` a real build produces:

| input | 0.0.52 | this change |
| --- | --- | --- |
| card | `lepusNG_debug_info`: 264 functions, `file_name: "main-thread.js"` | identical |
| bundle, one main thread entry | `lepusNG_debug_info`: 1 function, `file_name: ""`<br>`ReactLynx__main-thread`: 651 functions, `file_name: ""` | `ReactLynx__main-thread`: 651 functions, `file_name: "ReactLynx__main-thread"` |
| bundle, two main thread entries | the same stub, plus both sections with `file_name: ""` | each section with its own name, 651 functions each |

A card is byte-identical (100875 B). A bundle grows about 0.4% (184596 → 185270 B for one entry), which is the section name now carried as the file name in the debug info the bundle holds.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).