### PR TITLE
[BugFix][iOS] Stabilize Autolink Pod paths

### DIFF
--- a/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/lib/lynx/library/autolink.rb
@@ -4,6 +4,7 @@
 
 require 'fileutils'
 require 'json'
+require 'pathname'
 
 module Lynx
   module Library
@@ -26,13 +27,15 @@ module Lynx
           added_pods = []
           libraries.each do |library|
             pod_name = pod_name_from_podspec(library.podspec_path)
-            add_pod_once(podfile, added_pods, pod_name, File.dirname(library.podspec_path))
+            pod_path = pod_path_for_podspec(library.package_dir, library.podspec_path)
+            add_pod_once(podfile, added_pods, pod_name, pod_path)
             library.node_api_addons.each do |addon|
-              add_pod_once(podfile, added_pods, addon.pod_name, File.dirname(addon.podspec_path))
+              addon_path = pod_path_for_podspec(library.package_dir, addon.podspec_path)
+              add_pod_once(podfile, added_pods, addon.pod_name, addon_path)
             end
           end
           generate_registry(output_dir, libraries)
-          podfile.pod 'LynxLibraryRegistry', :path => output_dir
+          podfile.pod 'LynxLibraryRegistry', :path => relative_pod_path(podfile, output_dir)
           libraries
         end
 
@@ -131,11 +134,23 @@ module Lynx
         end
 
         def add_pod_once(podfile, added_pods, pod_name, pod_path)
-          key = [pod_name, pod_path]
+          key = [pod_name, File.realpath(pod_path)]
           return if added_pods.include?(key)
 
-          podfile.pod pod_name, :path => pod_path
+          podfile.pod pod_name, :path => relative_pod_path(podfile, pod_path)
           added_pods << key
+        end
+
+        def relative_pod_path(podfile, pod_path)
+          podfile_dir = File.expand_path(File.dirname(podfile.defined_in_file.to_s))
+          expanded_pod_path = Pathname.new(File.expand_path(pod_path))
+          expanded_pod_path.relative_path_from(Pathname.new(podfile_dir)).to_s
+        end
+
+        def pod_path_for_podspec(package_dir, podspec_path)
+          package_realpath = Pathname.new(File.realpath(package_dir))
+          relative_podspec = Pathname.new(podspec_path).relative_path_from(package_realpath)
+          File.dirname(File.join(package_dir, relative_podspec.to_s))
         end
 
         def parse_node_api_addons(addons, package_realpath, default_podspec_path, manifest_file)

--- a/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
+++ b/tools/ios_tools/cocoapods-lynx-library/test/autolink_test.rb
@@ -170,33 +170,59 @@ class LynxLibraryAutolinkTest < Minitest::Test
     end
   end
 
-  def test_install_adds_node_api_addons_by_pod_path
+  def test_install_adds_pods_with_paths_relative_to_podfile
     Dir.mktmpdir do |dir|
-      package_dir = write_library(dir, 'demo-addon', 'DemoAddon')
+      package_dir = write_library(File.join(dir, 'workspace'), 'demo-lib', 'DemoLib')
+      addon_dir = File.join(package_dir, 'ios/addons')
+      FileUtils.mkdir_p(addon_dir)
+      File.write(File.join(addon_dir, 'DemoAddon.podspec'), <<~PODSPEC)
+        Pod::Spec.new do |s|
+          s.name = 'DemoAddon'
+        end
+      PODSPEC
       File.write(File.join(package_dir, 'lynx.lib.json'), <<~JSON)
         {
           "platforms": {
             "ios": {
-              "nodeApiAddons": [{
-                "name": "demo_addon",
-                "podName": "DemoAddon",
-                "podspecPath": "ios/DemoAddon.podspec",
-                "addonUseHeader": "addon_use.h"
-              }]
+              "nodeApiAddons": [
+                {
+                  "name": "demo_lib",
+                  "podName": "DemoLib",
+                  "podspecPath": "ios/DemoLib.podspec",
+                  "addonUseHeader": "addon_use.h"
+                },
+                {
+                  "name": "demo_addon",
+                  "podName": "DemoAddon",
+                  "podspecPath": "ios/addons/DemoAddon.podspec",
+                  "addonUseHeader": "addons/addon_use.h"
+                }
+              ]
             }
           }
         }
       JSON
-      podfile = FakePodfile.new
+      FileUtils.mkdir_p(File.join(dir, 'node_modules'))
+      File.symlink(package_dir, File.join(dir, 'node_modules/demo-lib'))
+      podfile_dir = File.join(dir, 'ios')
+      FileUtils.mkdir_p(podfile_dir)
+      podfile = FakePodfile.new(File.join(podfile_dir, 'Podfile'))
 
       Lynx::Library::Autolink.install!(podfile, root: dir,
-                                                output_dir: File.join(dir, 'generated/lynx-library'))
+                                                output_dir: File.join(podfile_dir,
+                                                                      'generated/lynx-library'))
 
       assert_includes podfile.pods,
-                      ['DemoAddon', { path: File.realpath(File.join(package_dir, 'ios')) }]
-      assert_equal 1, podfile.pods.count { |name, _options| name == 'DemoAddon' }
+                      ['DemoLib', { path: '../node_modules/demo-lib/ios' }]
+      assert_equal 1, podfile.pods.count { |name, _options| name == 'DemoLib' }
       assert_includes podfile.pods,
-                      ['LynxLibraryRegistry', { path: File.join(dir, 'generated/lynx-library') }]
+                      ['DemoAddon', { path: '../node_modules/demo-lib/ios/addons' }]
+      assert_includes podfile.pods,
+                      ['LynxLibraryRegistry', { path: 'generated/lynx-library' }]
+      podfile.pods.each do |_name, options|
+        refute Pathname.new(options[:path]).absolute?
+        refute_includes options[:path], dir
+      end
     end
   end
 
@@ -391,9 +417,10 @@ class LynxLibraryAutolinkTest < Minitest::Test
   private
 
   class FakePodfile
-    attr_reader :pods
+    attr_reader :defined_in_file, :pods
 
-    def initialize
+    def initialize(defined_in_file)
+      @defined_in_file = Pathname.new(defined_in_file)
       @pods = []
     end
 


### PR DESCRIPTION
## Summary

- declare discovered Library and Node-API addon Pods relative to the Podfile
- declare the generated `LynxLibraryRegistry` Pod with a relative path
- preserve realpath validation and canonical deduplication for symlinked packages
- prevent machine-specific absolute paths from entering `Podfile.lock`

## Testing

- `ruby -Itest test/autolink_test.rb`
- Ruby 3.2.8: `ruby -Itest test/autolink_test.rb`
- `gem build cocoapods-lynx-library.gemspec`
- verified generated external sources with CocoaPods 1.16.2