### PR TITLE
[BugFix][CSS] Fix stale compatibility documentation paths

### DIFF
--- a/tools/css_generator/CHANGELOG.md
+++ b/tools/css_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.18
+- Add `-x-box-propagate-min-constraints` and `-x-box-match-parent-size` CSS properties.
+- Repoint stale CSS compatibility documentation paths and remove the obsolete `linear-orientation` link.
+
 ## 0.0.17
 - Add compat_data for `box-shadow` animations and the `transition-property: box-shadow` keyword.
 

--- a/tools/css_generator/css_defines/1-top.json
+++ b/tools/css_generator/css_defines/1-top.json
@@ -11,7 +11,7 @@
     "top": {
       "__compat": {
         "description": "participates in setting the vertical position of a positioned element. It has no effect on non-positioned elements.",
-        "lynx_path": "docs/zh/api/css/properties/top",
+        "lynx_path": "api/css/properties/top",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/top",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/131-relative-id.json
+++ b/tools/css_generator/css_defines/131-relative-id.json
@@ -11,7 +11,7 @@
     "relative-id": {
       "__compat": {
         "description": "Used to set the number of sibling elements in the relative layout.",
-        "lynx_path": "docs/zh/api/css/properties/relative-id",
+        "lynx_path": "api/css/properties/relative-id",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/132-relative-align-top.json
+++ b/tools/css_generator/css_defines/132-relative-align-top.json
@@ -11,7 +11,7 @@
     "relative-align-top": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the top edge of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-top",
+        "lynx_path": "api/css/properties/relative-align-top",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/133-relative-align-right.json
+++ b/tools/css_generator/css_defines/133-relative-align-right.json
@@ -11,7 +11,7 @@
     "relative-align-right": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the right edge of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-right",
+        "lynx_path": "api/css/properties/relative-align-right",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/134-relative-align-bottom.json
+++ b/tools/css_generator/css_defines/134-relative-align-bottom.json
@@ -11,7 +11,7 @@
     "relative-align-bottom": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-bottom",
+        "lynx_path": "api/css/properties/relative-align-bottom",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/135-relative-align-left.json
+++ b/tools/css_generator/css_defines/135-relative-align-left.json
@@ -11,7 +11,7 @@
     "relative-align-left": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the left edge of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-left",
+        "lynx_path": "api/css/properties/relative-align-left",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/136-relative-top-of.json
+++ b/tools/css_generator/css_defines/136-relative-top-of.json
@@ -11,7 +11,7 @@
     "relative-top-of": {
       "__compat": {
         "description": "The current element is to the top of the sibling element specified corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-top-of",
+        "lynx_path": "api/css/properties/relative-top-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/137-relative-right-of.json
+++ b/tools/css_generator/css_defines/137-relative-right-of.json
@@ -11,7 +11,7 @@
     "relative-right-of": {
       "__compat": {
         "description": "The current element is to the right of the sibling element specified corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-right-of",
+        "lynx_path": "api/css/properties/relative-right-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/138-relative-bottom-of.json
+++ b/tools/css_generator/css_defines/138-relative-bottom-of.json
@@ -11,7 +11,7 @@
     "relative-bottom-of": {
       "__compat": {
         "description": "The current element is to the bottom of the sibling element specified corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-bottom-of",
+        "lynx_path": "api/css/properties/relative-bottom-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/139-relative-left-of.json
+++ b/tools/css_generator/css_defines/139-relative-left-of.json
@@ -11,7 +11,7 @@
     "relative-left-of": {
       "__compat": {
         "description": "The current element is to the left of the sibling element specified corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-left-of",
+        "lynx_path": "api/css/properties/relative-left-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/140-relative-layout-once.json
+++ b/tools/css_generator/css_defines/140-relative-layout-once.json
@@ -11,7 +11,7 @@
     "relative-layout-once": {
       "__compat": {
         "description": "Used to set typesetting acceleration. When using positioning between elements at the same level, it is recommended to enable this property, and elements at the same level will only depend upwards.",
-        "lynx_path": "docs/zh/api/css/properties/relative-layout-once",
+        "lynx_path": "api/css/properties/relative-layout-once",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/141-relative-center.json
+++ b/tools/css_generator/css_defines/141-relative-center.json
@@ -33,7 +33,7 @@
     "relative-center": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the bottom edge of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-center",
+        "lynx_path": "api/css/properties/relative-center",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/152-padding-inline-start.json
+++ b/tools/css_generator/css_defines/152-padding-inline-start.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-inline-start": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-inline-start",
+        "lynx_path": "api/css/properties/padding-inline-start",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-inline-start",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/153-padding-inline-end.json
+++ b/tools/css_generator/css_defines/153-padding-inline-end.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-inline-end": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-inline-end",
+        "lynx_path": "api/css/properties/padding-inline-end",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-inline-end",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/164-relative-align-inline-start.json
+++ b/tools/css_generator/css_defines/164-relative-align-inline-start.json
@@ -11,7 +11,7 @@
     "relative-align-inline-start": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-inline-start",
+        "lynx_path": "api/css/properties/relative-align-inline-start",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/165-relative-align-inline-end.json
+++ b/tools/css_generator/css_defines/165-relative-align-inline-end.json
@@ -11,7 +11,7 @@
     "relative-align-inline-end": {
       "__compat": {
         "description": "Specifies that the current element is aligned with the left/right edges of the parent or sibling element corresponding to id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-align-inline-end",
+        "lynx_path": "api/css/properties/relative-align-inline-end",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/166-relative-inline-start-of.json
+++ b/tools/css_generator/css_defines/166-relative-inline-start-of.json
@@ -11,7 +11,7 @@
     "relative-inline-start-of": {
       "__compat": {
         "description": "The current element is to the left/right of the sibling element corresponding to the specified id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-inline-start-of",
+        "lynx_path": "api/css/properties/relative-inline-start-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/167-relative-inline-end-of.json
+++ b/tools/css_generator/css_defines/167-relative-inline-end-of.json
@@ -11,7 +11,7 @@
     "relative-inline-end-of": {
       "__compat": {
         "description": "The current element is to the left/right of the sibling element corresponding to the specified id.",
-        "lynx_path": "docs/zh/api/css/properties/relative-inline-end-of",
+        "lynx_path": "api/css/properties/relative-inline-end-of",
         "spec_url": [],
         "status": {
           "deprecated": false,

--- a/tools/css_generator/css_defines/2-left.json
+++ b/tools/css_generator/css_defines/2-left.json
@@ -11,7 +11,7 @@
     "left": {
       "__compat": {
         "description": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
-        "lynx_path": "docs/zh/api/css/properties/left",
+        "lynx_path": "api/css/properties/left",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/left",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/28-max-width.json
+++ b/tools/css_generator/css_defines/28-max-width.json
@@ -11,7 +11,7 @@
     "max-width": {
       "__compat": {
         "description": "sets the maximum width of an element.",
-        "lynx_path": "docs/zh/api/css/properties/max-width",
+        "lynx_path": "api/css/properties/max-width",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/max-width",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/29-min-width.json
+++ b/tools/css_generator/css_defines/29-min-width.json
@@ -11,7 +11,7 @@
     "min-width": {
       "__compat": {
         "description": "sets the minimum width of an element.",
-        "lynx_path": "docs/zh/api/css/properties/min-width",
+        "lynx_path": "api/css/properties/min-width",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/min-width",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/3-right.json
+++ b/tools/css_generator/css_defines/3-right.json
@@ -11,7 +11,7 @@
     "right": {
       "__compat": {
         "description": "participates in setting the horizontal position of a positioned element. It has no effect on non-positioned elements.",
-        "lynx_path": "docs/zh/api/css/properties/right",
+        "lynx_path": "api/css/properties/right",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/right",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/30-max-height.json
+++ b/tools/css_generator/css_defines/30-max-height.json
@@ -11,7 +11,7 @@
     "max-height": {
       "__compat": {
         "description": "sets the maximum height of an element.",
-        "lynx_path": "docs/zh/api/css/properties/max-height",
+        "lynx_path": "api/css/properties/max-height",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/max-height",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/31-min-height.json
+++ b/tools/css_generator/css_defines/31-min-height.json
@@ -11,7 +11,7 @@
     "min-height": {
       "__compat": {
         "description": "sets the minimum height of an element.",
-        "lynx_path": "docs/zh/api/css/properties/min-height",
+        "lynx_path": "api/css/properties/min-height",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/min-height",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/32-padding.json
+++ b/tools/css_generator/css_defines/32-padding.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding",
+        "lynx_path": "api/css/properties/padding",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/33-padding-left.json
+++ b/tools/css_generator/css_defines/33-padding-left.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-left": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-left",
+        "lynx_path": "api/css/properties/padding-left",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-left",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/34-padding-right.json
+++ b/tools/css_generator/css_defines/34-padding-right.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-right": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-right",
+        "lynx_path": "api/css/properties/padding-right",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-right",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/35-padding-top.json
+++ b/tools/css_generator/css_defines/35-padding-top.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-top": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-top",
+        "lynx_path": "api/css/properties/padding-top",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-top",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/36-padding-bottom.json
+++ b/tools/css_generator/css_defines/36-padding-bottom.json
@@ -10,7 +10,7 @@
   "compat_data": {
     "padding-bottom": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/properties/padding-bottom",
+        "lynx_path": "api/css/properties/padding-bottom",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/padding-bottom",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/5-position.json
+++ b/tools/css_generator/css_defines/5-position.json
@@ -33,7 +33,7 @@
   "compat_data": {
     "position": {
       "__compat": {
-        "lynx_path": "docs/zh/api/css/css-style/position",
+        "lynx_path": "api/css/properties/position",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/position",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/75-order.json
+++ b/tools/css_generator/css_defines/75-order.json
@@ -11,7 +11,7 @@
     "order": {
       "__compat": {
         "description": "The order CSS property sets the order to lay out an item.",
-        "lynx_path": "docs/zh/api/css/properties/order",
+        "lynx_path": "api/css/properties/order",
         "mdn_url": "https://developer.mozilla.org/zh-CN/docs/Web/CSS/order",
         "spec_url": [],
         "status": {

--- a/tools/css_generator/css_defines/78-linear-orientation.json
+++ b/tools/css_generator/css_defines/78-linear-orientation.json
@@ -53,7 +53,6 @@
     "linear-orientation": {
       "__compat": {
         "description": "sets how linear items are placed in the linear container defining the main axis and the direction.",
-        "lynx_path": "api/css/properties/linear-orientation",
         "spec_url": [],
         "status": {
           "deprecated": true,


### PR DESCRIPTION
## Problem

`@lynx-js/css-defines` is the source of CSS compatibility metadata consumed by `lynx-website`. Each `lynx_path` is resolved against the English documentation tree when compatibility data is generated.

After the documentation routes were reorganized, 31 entries still pointed to obsolete locale-prefixed or legacy routes. This produced unresolved-path warnings and prevented those entries from linking to their documentation pages.

Among the properties without an existing page, `linear-orientation` is deprecated and should no longer expose a documentation link. The other six paths are intentionally retained because dedicated pages will be added separately: four were identified in #9015, and two `-x-box-*` properties were added later for `0.0.18`.

## Changes

- Repoint 31 `lynx_path` values to their canonical English documentation routes.
- Remove `lynx_path` from the deprecated `linear-orientation` property.
- Record the corrections in the `0.0.18` changelog.

## Validation

- `npm test`
- `npm run lint:compat-keys`
- `npm pack --dry-run`
- Verified all 31 repointed paths against the English documentation tree.
- Generated downstream CSS compatibility data and stats; the only unresolved CSS paths are the six intentionally retained for follow-up documentation.

`npm run validate` retains its existing schema failures because `harmony` and `clay_ios` are absent from the platform allowlist. The changed files produce identical schema diagnostics before and after this patch.

## Release and follow-up

The repository is prepared for `@lynx-js/css-defines@0.0.18`; npm currently publishes `0.0.17`, and `lynx-website` uses `0.0.16`.

- Add dedicated documentation pages for the six retained CSS paths.
- Publish `@lynx-js/css-defines@0.0.18`.
- Upgrade `lynx-website` and regenerate its compatibility data.

## Related

- Closes #9015
- lynx-family/lynx-website#1337
