### PR TITLE
[BugFix][CI] Remove unreachable CSS defines website dispatch

### DIFF
--- a/.github/workflows/css-defines-publish.yml
+++ b/.github/workflows/css-defines-publish.yml
@@ -15,8 +15,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    outputs:
-      version: ${{ steps.get-version.outputs.version }}
     steps:
       - name: Download Source
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -63,16 +61,3 @@ jobs:
         run: |-
           cd $GITHUB_WORKSPACE/lynx/tools/css_generator
           npm publish --access public --provenance --tag "${{ github.event.inputs.tag }}"
-
-  notify-website:
-    needs: css-defines-publish
-    if: needs.css-defines-publish.outputs.version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger lynx-website sync
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: lynx-family/lynx-website
-          event-type: bump-css-defines
-          client-payload: '{"version": "${{ needs.css-defines-publish.outputs.version }}"}'


### PR DESCRIPTION
## Summary

The `css_defines_publish` workflow attempts to dispatch a dependency bump to `lynx-family/lynx-website` with the source repository `GITHUB_TOKEN`. GitHub scopes that token to `lynx-family/lynx`, so the npm publish succeeds but the downstream `notify-website` job fails with `Resource not accessible by integration`.

This change:

- Removes the unreachable `notify-website` job.
- Removes the job-level `version` output that was used only by that dispatch.
- Keeps npm publication and the existing-version check unchanged.
- Does not introduce a long-lived cross-repository credential; any replacement automation should receive a separate security review.

Closes #9319

## Validation

- `actionlint -shellcheck= .github/workflows/css-defines-publish.yml`
- YAML syntax validation
- `git diff --check`
- Full `actionlint` diagnostics are unchanged from the base revision; the remaining findings are pre-existing ShellCheck warnings outside the removed job.

## Checklist

- [x] Tests updated (not required for this workflow-only removal).
- [x] Documentation updated (not required).

## AI Assistance

This pull request was prepared with assistance from TRAE and reviewed by the contributor.
