### PR TITLE
[Doc][Agents] Align commit message guidance with contributing guide

### DIFF
--- a/agents/code_review/commit_message_format.md
+++ b/agents/code_review/commit_message_format.md
@@ -13,9 +13,11 @@
 
   Footer (optional):
   `issue: #12345`
+  `doc: https://xxxxxxxx`
+  `TEST: Test cases`
 
 ### Type
-- `Feature`, `BugFix`, `Optimize`, `Refactor`, `Infra`, `Docs`, `Test`, etc., using capitalized English.
+- `Feature`, `BugFix`, `Optimize`, `Refactor`, `Infra`, `Doc`, `Testing`, etc., using capitalized English.
 
 ### Scope
 - Module or subsystem name (e.g., `Clay`, `Layout`, `Headers`, `Painting`, `Harmony`, `Android`, `iOS`, etc.), optional but recommended.


### PR DESCRIPTION
## Summary

- Align the agent commit-message guidance with the canonical conventions in `CONTRIBUTING.md`.
- Replace the unsupported `Docs` and `Test` types with `Doc` and `Testing`.
- Add the omitted `doc:` and `TEST:` footer examples.

The previous guidance could lead AI agents to create commit messages with unsupported type labels or omit footer metadata expected by the project conventions.

## Testing

- `git diff --check`

## AI Assistance

This PR was prepared with assistance from TRAE. I reviewed and verified the changes.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).