### PR TITLE
[BugFix][CSS] Recognize Harmony and Clay iOS platforms

### DIFF
--- a/tools/css_generator/css_define_json_schema/css_define_with_doc.schema.json
+++ b/tools/css_generator/css_define_json_schema/css_define_with_doc.schema.json
@@ -191,7 +191,9 @@
         "enum": [
           "ios",
           "android",
+          "harmony",
           "clay_android",
+          "clay_ios",
           "clay_macos",
           "clay_windows",
           "web_lynx"


### PR DESCRIPTION
## Summary

- Add `harmony` and `clay_ios` to the CSS support platform schema.
- Align the schema allowlist with platform keys already used by the CSS define data.

While updating stale `lynx_path` values in #9309, `npm run validate` reported 191 of 238 CSS define files as invalid. Those failures were unrelated to the path updates: the schema omitted `harmony` and `clay_ios`, although those keys are already widely present in the compatibility data. The platform errors obscured the smaller set of actionable schema diagnostics.

After this change, 233 of 238 files pass validation. The remaining five files contain separate, pre-existing data issues and are outside this patch.

## Validation

- `npm test`
- `npm run lint:compat-keys`
- `npm run validate` (invalid files reduced from 191 to 5)
- Parsed all CSS define files and confirmed the schema now covers every platform key in use.

## Related

- #9309

## AI Assistance

This PR was prepared with assistance from TRAE. I reviewed and verified the changes.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).