### PR TITLE
[BugFix][DevTool] Fix duplicate symbol in RTS inspector factory stub on iOS

### DIFF
--- a/devtool/lynx_devtool/js_debug/lepus/manager/rts_inspector_manager_factory_stub.cc
+++ b/devtool/lynx_devtool/js_debug/lepus/manager/rts_inspector_manager_factory_stub.cc
@@ -12,7 +12,13 @@ extern "C" __attribute__((visibility("default"))) void
 LynxRegisterRTSInspectorManagerFactoryImpl(
     lynx::devtool::JSDebugHelper* helper) {}
 
+// On iOS the registration entry point lives in
+// rts_inspector_manager_factory_stub_ios.cc, which is compiled alongside this
+// file; defining it here as well produces a duplicate symbol when the
+// framework is linked dynamically.
+#if !OS_IOS
 extern "C" void LynxRegisterRTSInspectorManagerFactory(void) {
   auto* anchor = &LynxRegisterRTSInspectorManagerFactoryImpl;
   (void)anchor;
 }
+#endif


### PR DESCRIPTION
## Summary

On iOS the `rts_inspector_manager_factory_stub` target compiles both `rts_inspector_manager_factory_stub.cc` and `rts_inspector_manager_factory_stub_ios.cc`, and each defines `LynxRegisterRTSInspectorManagerFactory`. Building `LynxDevtool` 4.1.0 as a **dynamic** framework fails with `ld: 1 duplicate symbols` (static frameworks hide it because the linker only pulls the first archive member).

This guards the registration entry point in the generic stub with `!defined(OS_IOS)`, so on iOS it is provided solely by the iOS stub. `LynxRegisterRTSInspectorManagerFactoryImpl` stays in the generic stub — it is the only definition and `LynxDevToolNGDarwinDelegate.mm` anchors it. Non-iOS platforms are unchanged (both symbols still come from the generic stub; Harmony's `entry.cc` keeps calling it).

Fixes #9349

## Alternative considered

Dropping the `if (is_ios)` block from the `rts_inspector_manager_factory_stub` GN target would also remove the duplicate for the OSS build, but I did not want to change which files are compiled in configurations that exclude the generic stub via `target_exclude_patterns`. The source-level guard keeps every configuration's object set the same minus the duplicate definition. Happy to switch to the GN change if that is preferred.

## Verification

Compiled both files for the iOS simulator with `OS_IOS=1` and linked them into a dylib:

- unpatched: `duplicate symbol '_LynxRegisterRTSInspectorManagerFactory'` — matches the CocoaPods dynamic-framework failure
- patched: links; `nm` shows `_LynxRegisterRTSInspectorManagerFactoryImpl` only in `rts_inspector_manager_factory_stub.o` and `_LynxRegisterRTSInspectorManagerFactory` only in `rts_inspector_manager_factory_stub_ios.o`; the dylib exports exactly one of each
- generic stub compiled **without** `OS_IOS`: still defines both symbols

## AI assistance

This change was prepared with Claude Code (analysis, patch, and verification steps); the commit carries an `Assisted-by: Claude Code` trailer per CONTRIBUTING.md.
